### PR TITLE
feat(orient): improve query behavior, caps, and output format

### DIFF
--- a/plugins/orient/skills/orient/SKILL.md
+++ b/plugins/orient/skills/orient/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orient
-description: Use when user invokes /orient with a topic keyword, entity type, project name, time qualifier, or combination. Searches the MCP Memory Server graph, knowledge files, journal entries, and research index to produce a focused orientation briefing. Gracefully degrades if MCP Memory Server is not connected.
+description: Use when user invokes /orient with a topic keyword, entity type, project name, time qualifier, or combination. Also triggers on "what do we know about X", "remind me about X", "where did we leave off on X". Provides targeted context loading — searches the MCP Memory Server graph, knowledge files, journal entries, and research index to produce a focused orientation briefing.
 ---
 
 # Topic-Focused Orientation
@@ -33,9 +33,9 @@ User types `/orient` followed by:
 /orient data engineering
 ```
 
-## Workflow Order (MANDATORY)
+## Workflow Order
 
-**You MUST follow this order. No skipping steps.**
+Follow in order. Skip a step only when its required component is absent (e.g., MCP not connected → skip Graph).
 
 ---
 
@@ -49,9 +49,24 @@ Classify the argument into one or more of:
 | Time qualifier | Contains: "recent", "latest", "last week", "today", date patterns (YYYY-MM-DD) | `recent evidence` |
 | Topic keyword | Everything else — natural language | `membrain`, `data engineering` |
 
+**Time qualifier definitions (applies to journal only — graph searches are always full-graph unless the query is explicitly temporal):**
+- "today" → today's journal entry only
+- "recent" / "latest" → journal entries from the last 1 month
+- "last week" → journal entries from the last 7 days
+- Specific date (YYYY-MM-DD) → that journal entry
+- User-specified timeframe → use that instead
+
+**Parsing rules:**
 - Strip filler words ("the", "and", "about") when extracting the core query
 - Handle compound inputs: "desires and tensions" → two entity types
 - Combinations are valid: "recent membrain" = time qualifier + topic keyword
+
+**Entity type vs keyword disambiguation:**
+When a word matches both a known entity type and a plausible keyword (e.g., "project", "research", "idea"), ask the user for clarity before searching:
+*"Does 'project' mean the entity type (graph nodes of type Project) or the topic keyword (anything related to projects)?"*
+Skip this check when context makes the intent obvious (e.g., "open tensions" → entity type).
+
+**Entity type reference:** Check `knowledge/reference.md` for the current schema if unsure which entity types exist.
 
 ---
 
@@ -61,12 +76,18 @@ Classify the argument into one or more of:
 
 If MCP Memory Server is not connected, skip this step entirely and note it in the output: *"Graph: MCP Memory Server not connected — skipped."*
 
+**Smart query construction:**
+1. Try the topic phrase as a single `search_nodes` query first (e.g., `search_nodes("streaming migration")`)
+2. If results are sparse (<3 entities), decompose into individual domain-specific keywords — drop generic words like "project", "system", "the" — and search each keyword separately
+3. Merge and deduplicate results across queries
+4. This uses signal from the first query to decide whether decomposition is needed
+
 **Search strategy:**
-- Call `search_nodes("topic")` with the parsed topic keyword
+- Call `search_nodes("topic")` with the parsed topic keyword (using smart query construction above)
 - If entity type detected, also call `search_nodes("EntityType")` for each type
 - If both topic and entity type detected, search for both
 
-**Hard caps (MANDATORY):**
+**Hard caps:**
 
 | Guard | Limit |
 |-------|-------|
@@ -76,7 +97,7 @@ If MCP Memory Server is not connected, skip this step entirely and note it in th
 | Entities shown | Max 10 |
 | Observations per entity | Max 3 |
 
-**Breadth guard:** If search returns >15 results, report the count and ask the user to narrow their query instead of dumping everything.
+**Breadth guard:** If search returns >15 results, show the top 10 most relevant and note: *(Showing top 10 of N results — narrow your query for more specific results.)*
 
 **Selection:** From results, select the top 10 most relevant entities. Show max 3 observations per entity.
 
@@ -85,11 +106,14 @@ If MCP Memory Server is not connected, skip this step entirely and note it in th
 ### Step 3: Scan Knowledge Files
 
 1. List the `knowledge/` directory to discover what files exist
-2. Grep discovered files for the topic keyword(s)
-3. For time qualifiers: list `knowledge/journal/` and read matching date entries (most recent first)
+2. Use the Grep tool to search discovered files for the topic keyword(s)
+3. For time qualifiers: list `knowledge/journal/` and read matching date entries (most recent first, per time qualifier definitions in Step 1)
 4. Extract only the enclosing section (H2/H3 level) around each match — NOT entire files
-5. **Cap:** Read from at most 3 files
+5. **Cap:** Aim for 3-5 files; extend beyond if the topic genuinely spans more
 6. **Cap:** Read at most 3 journal entries
+7. **Prioritization:** Prefer files whose filename directly relates to the topic, or that have the most substantive matches (not incidental keyword hits). For files tied on relevance, use these hints:
+   - Technical/project topics → prefer `projects.md`, `evidence.md`, `development_log.md`
+   - Conceptual/identity topics → prefer `core_principles.md`, `identity.md`, `procedures.md`
 
 If no `knowledge/` directory exists, skip this step and note it.
 
@@ -130,15 +154,23 @@ Use this output structure. **Omit empty sections** — do not include a section 
 - `research/agent-memory/hindsight.md` — biomimetic agent memory
 
 ### Suggested Queries
-- `search_nodes("membrain governance")` — governance layer details
-- `open_nodes(["Desire-Build-Something-Shippable"])` — full desire context
+- `/orient membrain governance` — governance layer details
+- `/orient membrain phase 5` — phase 5 planning context
+- `open_nodes(["Desire-Build-Something-Shippable"])` — full desire context (entity details)
 ```
+
+**Rough token budget per section (guidance, not hard caps):**
+- Graph: ~500 tokens
+- Knowledge: ~500 tokens
+- Journal: ~300 tokens
+- Research: ~100 tokens (file paths only)
+- Suggested Queries: ~100 tokens
 
 **Adaptive rules:**
 - If both Graph and Knowledge are empty, say so explicitly: *"No results found for '[topic]'. Try a different keyword or check available entity types."*
 - Always include at least one populated section or a clear "nothing found" message
 - If Graph was skipped due to MCP not being connected, note that in the Graph section position
-- Suggested Queries section: include 1-3 queries that would logically extend the orientation. Only suggest `search_nodes` or `open_nodes` — never `read_graph`.
+- Suggested Queries section: include 1-3 queries. Use `/orient [topic]` for follow-on topic searches. Use `open_nodes` only when suggesting specific entities the user might want full details on. Never suggest `read_graph`.
 
 ---
 
@@ -149,6 +181,7 @@ End with a contextual follow-up offer:
 - **For topic queries:** "Want me to read any of the research files, load more graph entities, or orient on a related topic?"
 - **For entity-type queries:** "Want me to open specific entities for full details?"
 - **For time queries:** "Want me to read more journal entries or search for a specific topic within this timeframe?"
+- **For compound queries:** "Want me to dig deeper into any of these threads, or orient on a sub-topic?"
 
 ---
 
@@ -161,11 +194,11 @@ End with a contextual follow-up offer:
 | `open_nodes` calls | Max 2 |
 | Graph entities shown | Max 10 |
 | Observations per entity | Max 3 |
-| Knowledge files read | Max 3 |
+| Knowledge files read | Aim 3-5 |
 | Journal entries read | Max 3 |
 | Research entries listed | Max 5 (listed, not read) |
 | Total output | ~800-2000 tokens |
-| Broad result threshold | >15 results → ask user to narrow |
+| Broad result threshold | >15 results → show top 10 with note |
 
 ## Common Mistakes
 
@@ -175,8 +208,10 @@ End with a contextual follow-up offer:
 | Reading entire knowledge files | Extract only the enclosing H2/H3 section around the match. |
 | Reading research synthesis files | List them. Offer to read specific ones. Don't read proactively. |
 | Exceeding search caps | Stop at 3 `search_nodes` calls, 2 `open_nodes` calls. If you need more, offer follow-up queries. |
-| Dumping >15 graph results | Report the count and ask the user to narrow their query. |
+| Dumping >15 graph results | Show top 10 most relevant, note the total count. |
 | Including empty sections | Omit sections that have no content. Don't show "### Research" with nothing under it. |
 | Ignoring MCP availability | Check if `search_nodes`/`open_nodes` tools exist before calling them. If not, skip Graph and note it. |
 | Wall of text | Keep output between ~800-2000 tokens. This is a briefing, not a report. Condense excerpts. |
-| Suggesting `read_graph` in follow-ups | Only suggest `search_nodes` or `open_nodes` as follow-up queries. |
+| Suggesting `read_graph` in follow-ups | Only suggest `/orient` calls or `open_nodes` as follow-up queries. |
+| Using grep bash command | Use the Grep tool instead for all file content searches. |
+| Applying time qualifiers to graph | Time qualifiers scope journal entries only. Graph searches are always full-graph. |


### PR DESCRIPTION
## Summary

10 targeted improvements to the `/orient` skill based on behavioral review:

- **Description** — add trigger phrases ("what do we know about X", "remind me about X", "where did we leave off on X"); replace "Gracefully degrades" with "targeted context loading"
- **Step 1** — time qualifier definitions (journal-scoped only, not graph); entity type vs keyword disambiguation rule; `reference.md` pointer for schema
- **Step 2** — smart query construction: try topic phrase first, decompose into keywords only if <3 results; breadth guard now shows top 10 with note instead of blocking the user
- **Step 3** — file cap raised from hard 3 → soft 3-5; file prioritization hints by topic type; explicit "Use the Grep tool" instead of vague "grep"
- **Step 5** — suggested queries use `/orient` calls instead of raw `search_nodes` tool calls; per-section token budget added (~500/500/300/100/100)
- **Step 6** — fourth follow-up variant added for compound queries
- **MANDATORY overuse removed** — kept only on `read_graph: NEVER`; workflow header softened to conditional skip guidance
- **Common Mistakes** — two new rows: Grep tool vs bash grep, time qualifiers scope

## Test plan

- [ ] Trace `/orient membrain` through steps — phrase search, knowledge grep, `/orient membrain governance` suggested
- [ ] Trace `/orient desires` — entity type detected, no disambiguation needed
- [ ] Trace `/orient recent` — time qualifier → journal last 1 month, graph still full-graph
- [ ] Trace `/orient project` — matches entity type AND keyword → disambiguation prompt fires
- [ ] Verify line count stays under 500 (currently 217)

🤖 Generated with [Claude Code](https://claude.com/claude-code)