### PR TITLE
feat: stage plugin — on-demand session information capture

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -39,6 +39,14 @@
       "version": "0.1.0",
       "author": { "name": "siracusa5" },
       "license": "MIT"
+    },
+    {
+      "name": "stage",
+      "source": "./stage",
+      "description": "Capture session information into a staging file for later reflection and knowledge graph processing",
+      "version": "0.1.0",
+      "author": { "name": "siracusa5" },
+      "license": "MIT"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Downloads skill files to `~/.claude/skills/` over HTTPS. This installs only the 
 | [`explain`](plugins/explain/skills/explain/README.md) | Layered explanations of files, functions, directories, or concepts | None |
 | [`data-lineage`](plugins/data-lineage/skills/data-lineage/README.md) | Trace column-level data lineage through SQL, Kafka, Spark, and JDBC codebases | None |
 | [`orient`](plugins/orient/skills/orient/README.md) | Topic-focused session orientation across graph, knowledge, journal, and research | None* |
+| [`stage`](plugins/stage/skills/stage/README.md) | Capture session information into a staging file for later reflection and knowledge graph processing | None |
 
 \* orient works without dependencies; optionally uses [MCP Memory Server](https://github.com/anthropics/claude-code-memory) for graph search.
 

--- a/install.sh
+++ b/install.sh
@@ -38,7 +38,7 @@ if [[ -n "$LOCAL_PLUGINS" ]]; then
 else
   echo "Remote install: downloading from ${REPO}"
 
-  for plugin in research explain data-lineage orient; do
+  for plugin in research explain data-lineage orient stage; do
     dest="${SKILLS_DEST}/${plugin}"
     mkdir -p "$dest"
     curl -fsSL "${RAW_BASE}/plugins/${plugin}/skills/${plugin}/SKILL.md"  -o "${dest}/SKILL.md"

--- a/plugins/stage/.claude-plugin/plugin.json
+++ b/plugins/stage/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "stage",
+  "description": "Capture session information into a staging file for later reflection and knowledge graph processing",
+  "version": "0.1.0"
+}

--- a/plugins/stage/scripts/session-stage.sh
+++ b/plugins/stage/scripts/session-stage.sh
@@ -22,7 +22,10 @@ fi
 
 STAGING_FILE=""
 
-# 1. Project-local: scripts/session-staging.md in current working directory
+# 1. Project-local: scripts/session-staging.md in current working directory.
+# Note: $PWD may not be the project root when a Stop hook fires — Claude Code
+# may set a different working directory. If the file doesn't exist here, we
+# fall through to the global fallback rather than creating a stray file.
 if [[ -f "$PWD/scripts/session-staging.md" ]]; then
   STAGING_FILE="$PWD/scripts/session-staging.md"
 elif [[ -d "$PWD/scripts" ]]; then
@@ -74,13 +77,14 @@ TODAY=$(date '+%Y-%m-%d')
 MANUAL_CONTEXT=""
 
 if grep -q "<!-- source: manual -->" "$STAGING_FILE" 2>/dev/null; then
-  # Extract today's manual entries if any exist
+  # Extract today's manual entries if any exist.
+  # `found` is intentionally not reset between sections — if the user ran
+  # /stage multiple times today, we accumulate all their bullets.
   MANUAL_TODAY=$(awk "
     /^## ${TODAY}/ { in_section=1; next }
     /^## [0-9]/ { in_section=0 }
     in_section && /<!-- source: manual -->/ { found=1 }
     in_section && found && /^- / { print }
-    in_section && /^## / { found=0 }
   " "$STAGING_FILE" 2>/dev/null || echo "")
 
   if [[ -n "$MANUAL_TODAY" ]]; then

--- a/plugins/stage/scripts/session-stage.sh
+++ b/plugins/stage/scripts/session-stage.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Session staging hook — fires at session end via ~/.claude/hooks.json (Stop event).
+# Generates a short summary of the session and appends it to the staging file
+# for the daily reflection to consume and write to the knowledge graph.
+#
+# Bundled with the harness-kit stage plugin.
+# https://github.com/siracusa5/harness-kit
+
+set -euo pipefail
+
+# ── Detect claude binary ─────────────────────────────────────────────────────
+
+if command -v claude &>/dev/null; then
+  CLAUDE_BIN="$(command -v claude)"
+elif [[ -x "$HOME/.local/bin/claude" ]]; then
+  CLAUDE_BIN="$HOME/.local/bin/claude"
+else
+  exit 0
+fi
+
+# ── Resolve staging file ─────────────────────────────────────────────────────
+
+STAGING_FILE=""
+
+# 1. Project-local: scripts/session-staging.md in current working directory
+if [[ -f "$PWD/scripts/session-staging.md" ]]; then
+  STAGING_FILE="$PWD/scripts/session-staging.md"
+elif [[ -d "$PWD/scripts" ]]; then
+  STAGING_FILE="$PWD/scripts/session-staging.md"
+fi
+
+# 2. Fallback: ~/.claude/session-staging.md
+if [[ -z "$STAGING_FILE" ]]; then
+  STAGING_FILE="$HOME/.claude/session-staging.md"
+fi
+
+# Create if missing
+if [[ ! -f "$STAGING_FILE" ]]; then
+  mkdir -p "$(dirname "$STAGING_FILE")"
+  cat > "$STAGING_FILE" <<'EOF'
+# Session Staging
+
+Facts staged here are consumed by the daily reflection and written to the knowledge graph.
+EOF
+fi
+
+# ── Find transcript ──────────────────────────────────────────────────────────
+
+PAYLOAD=$(cat)
+TRANSCRIPT_PATH=$(echo "$PAYLOAD" | python3 -c \
+  "import sys,json; d=json.load(sys.stdin); print(d.get('transcript_path',''))" \
+  2>/dev/null || echo "")
+
+# Fall back: most recently modified JSONL in ~/.claude/projects/
+if [[ -z "$TRANSCRIPT_PATH" || ! -f "$TRANSCRIPT_PATH" ]]; then
+  TRANSCRIPT_PATH=$(find "$HOME/.claude/projects" -name "*.jsonl" -type f \
+    2>/dev/null | xargs ls -t 2>/dev/null | head -1 || echo "")
+fi
+
+if [[ -z "$TRANSCRIPT_PATH" || ! -f "$TRANSCRIPT_PATH" ]]; then
+  exit 0
+fi
+
+# ── Guard: skip tiny transcripts (< 5KB = nothing meaningful happened) ───────
+
+TRANSCRIPT_SIZE=$(wc -c < "$TRANSCRIPT_PATH" 2>/dev/null || echo "0")
+if [[ "$TRANSCRIPT_SIZE" -lt 5120 ]]; then
+  exit 0
+fi
+
+# ── Check for manual entries from today ──────────────────────────────────────
+
+TODAY=$(date '+%Y-%m-%d')
+MANUAL_CONTEXT=""
+
+if grep -q "<!-- source: manual -->" "$STAGING_FILE" 2>/dev/null; then
+  # Extract today's manual entries if any exist
+  MANUAL_TODAY=$(awk "
+    /^## ${TODAY}/ { in_section=1; next }
+    /^## [0-9]/ { in_section=0 }
+    in_section && /<!-- source: manual -->/ { found=1 }
+    in_section && found && /^- / { print }
+    in_section && /^## / { found=0 }
+  " "$STAGING_FILE" 2>/dev/null || echo "")
+
+  if [[ -n "$MANUAL_TODAY" ]]; then
+    MANUAL_CONTEXT="The following facts were already manually staged today — do NOT repeat these facts:
+${MANUAL_TODAY}
+
+"
+  fi
+fi
+
+# ── Summarize ────────────────────────────────────────────────────────────────
+
+RECENT=$(tail -c 30000 "$TRANSCRIPT_PATH" 2>/dev/null)
+DATE=$(date '+%Y-%m-%d %H:%M')
+
+PROMPT="${MANUAL_CONTEXT}Summarize this Claude Code session in 3-6 bullet points for a knowledge graph update. Focus only on: new projects or decisions made, technical facts learned, status changes, new entities or tools introduced. Max 20 words per bullet. If nothing notable happened, output exactly: NOTHING_NOTABLE"
+
+SUMMARY=$(echo "$RECENT" | "$CLAUDE_BIN" -p "$PROMPT" \
+  --max-turns 1 \
+  2>/dev/null || echo "NOTHING_NOTABLE")
+
+if [[ -z "$SUMMARY" || "$SUMMARY" == *"NOTHING_NOTABLE"* ]]; then
+  exit 0
+fi
+
+# ── Append to staging file ───────────────────────────────────────────────────
+
+{
+  echo ""
+  echo "## $DATE"
+  echo "<!-- source: hook -->"
+  echo "$SUMMARY"
+} >> "$STAGING_FILE"

--- a/plugins/stage/skills/stage/README.md
+++ b/plugins/stage/skills/stage/README.md
@@ -77,7 +77,7 @@ Add to `~/.claude/hooks.json`:
 }
 ```
 
-Replace `/path/to/plugins/stage/scripts/session-stage.sh` with the actual path after installing.
+After `plugin install stage@harness-kit`, the script will be at `~/.claude/plugins/stage/scripts/session-stage.sh`. For a local clone, use the absolute path to `plugins/stage/scripts/session-stage.sh` within the repo.
 
 The hook reads from stdin (the Stop event payload), finds the session transcript, summarizes it, and appends to the staging file. It checks for `<!-- source: manual -->` entries from today and skips facts already captured manually.
 

--- a/plugins/stage/skills/stage/README.md
+++ b/plugins/stage/skills/stage/README.md
@@ -1,0 +1,126 @@
+# Stage Plugin
+
+A Claude Code plugin for capturing session information into a staging file mid-conversation. Feeds the same pipeline as the automated Stop hook — manual control over what gets remembered.
+
+## What It Does
+
+When you invoke `/stage`, the skill:
+
+1. Parses your argument to determine what to capture
+2. Resolves the staging file (`scripts/session-staging.md` → `~/.claude/session-staging.md`)
+3. Appends a timestamped entry with a `<!-- source: manual -->` marker
+4. Confirms exactly what was staged
+
+## Usage
+
+### Auto-extract (no argument)
+
+```
+/stage
+```
+
+Scans the conversation and extracts 3-8 most important facts — decisions, technical details, status changes, new entities.
+
+### Stage specific facts
+
+```
+/stage SQLite chosen over Postgres for local-first storage
+/stage harness-kit domain purchased at harnesskit.ai, 3-year registration
+```
+
+Stages the facts you provide, formatted as clean bullets.
+
+### Filter to decisions only
+
+```
+/stage decisions
+```
+
+Extracts only explicit decisions made this session — architectural choices, plans confirmed, approaches selected.
+
+### Filter to technical facts only
+
+```
+/stage technical
+```
+
+Extracts only technical facts — implementation details, file paths, APIs, schemas, commands.
+
+## Components
+
+| Component | Purpose |
+|-----------|---------|
+| `/stage` skill | Manual, on-demand staging from within a conversation |
+| `session-stage.sh` | Automated Stop hook that summarizes sessions at exit |
+
+## Setup
+
+### Wire the Stop hook
+
+Add to `~/.claude/hooks.json`:
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/path/to/plugins/stage/scripts/session-stage.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Replace `/path/to/plugins/stage/scripts/session-stage.sh` with the actual path after installing.
+
+The hook reads from stdin (the Stop event payload), finds the session transcript, summarizes it, and appends to the staging file. It checks for `<!-- source: manual -->` entries from today and skips facts already captured manually.
+
+## Staging File Format
+
+Both the skill and the hook write to the same file in this format:
+
+```markdown
+# Session Staging
+
+Facts staged here are consumed by the daily reflection and written to the knowledge graph.
+
+## 2026-03-08 14:32
+<!-- source: manual -->
+- SQLite chosen over Postgres for local-first storage
+- harness-kit domain purchased at harnesskit.ai
+
+## 2026-03-08 23:59
+<!-- source: hook -->
+- Implemented stage plugin with 4 argument types
+- Updated marketplace.json and install.sh
+```
+
+## Pipeline
+
+```
+Manual /stage  ──┐
+                  ├──▶  session-staging.md  ──▶  daily reflection  ──▶  knowledge graph
+Auto Stop hook ──┘
+```
+
+The Stop hook deduplicates against manual entries: if `<!-- source: manual -->` entries exist for today, it includes them in the summary prompt with "do NOT repeat these facts."
+
+## Design Notes
+
+### Why manual staging?
+
+The Stop hook auto-summarizes at session end — useful, but it misses nuance. You might know mid-session that a particular decision is worth capturing precisely. `/stage decisions` or `/stage specific text` lets you control what gets remembered while the context is fresh.
+
+### Why the same pipeline?
+
+Both sources feed the same staging file, which the daily reflection processes uniformly. You get the benefits of automation (nothing falls through) plus the precision of manual capture (important things get captured right).
+
+### Why append-only?
+
+The staging file is a write-ahead log — entries accumulate until the reflection runs. Modifying existing entries would corrupt the audit trail and break deduplication logic.

--- a/plugins/stage/skills/stage/SKILL.md
+++ b/plugins/stage/skills/stage/SKILL.md
@@ -30,8 +30,8 @@ Capture information from the current conversation into a staging file for the da
 
 Classify the argument:
 - **No argument** → auto-extract mode
-- **`decisions`** → filter to decisions only
-- **`technical`** → filter to technical facts only
+- **Exactly the word `decisions`** → filter to decisions only
+- **Exactly the word `technical`** → filter to technical facts only
 - **Anything else** → treat as specific facts provided by the user
 
 ### Step 2: Resolve Staging File
@@ -67,15 +67,16 @@ date '+%Y-%m-%d %H:%M'
 
 ### Step 4: Append to Staging File
 
-Use the **Edit tool** (NOT Write — Write would overwrite the file) to append the following to the end of the staging file:
+Use **Bash** with `>>` to append — do NOT use Write (overwrites the whole file) or Edit (find-replace, not true append):
 
-```markdown
-
-## YYYY-MM-DD HH:MM
-<!-- source: manual -->
-- bullet 1
-- bullet 2
-- bullet 3
+```bash
+{
+  echo ""
+  echo "## YYYY-MM-DD HH:MM"
+  echo "<!-- source: manual -->"
+  echo "- bullet 1"
+  echo "- bullet 2"
+} >> /path/to/staging-file.md
 ```
 
 The `<!-- source: manual -->` marker tells the Stop hook that manual staging already happened today, enabling deduplication.
@@ -95,7 +96,7 @@ Display what was staged to the user. Show the exact bullets that were written. K
 
 | Mistake | Fix |
 |---------|-----|
-| Using Write instead of Edit to append | Write overwrites the file. Always use Edit to append. |
+| Using Write or Edit to append | Write overwrites. Edit is find-replace, not append. Use Bash `>>`. |
 | Exceeding 8 bullets | Pick the most important facts. Cut the rest. |
 | Omitting `<!-- source: manual -->` | The Stop hook uses this marker for deduplication. Always include it. |
 | Writing summaries instead of bullet facts | "Decided to use SQLite for storage" not "We had a productive discussion about databases." |

--- a/plugins/stage/skills/stage/SKILL.md
+++ b/plugins/stage/skills/stage/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: stage
+description: Use when user invokes /stage to capture information from the current conversation into a staging file for later reflection and knowledge graph processing. Accepts no arguments (auto-extract), specific facts as text, or filter keywords like "decisions" or "technical".
+---
+
+# Session Staging
+
+## Overview
+
+Capture information from the current conversation into a staging file for the daily reflection pipeline to consume and write to the knowledge graph.
+
+**Core principles:**
+1. **Token-conscious** — 3-8 bullets, max 20 words each
+2. **Complementary to Stop hook** — captures nuance and specificity the auto-summary misses
+3. **Append-only** — never modify existing entries in the staging file
+4. **Confirm what was staged** — always show the user exactly what was written
+
+## Argument Types
+
+| Argument | Behavior |
+|----------|----------|
+| (none) | Auto-extract 3-8 most important facts from the conversation |
+| Specific text | Stage the provided facts as bullets |
+| `decisions` | Extract only decisions made this session |
+| `technical` | Extract only technical facts and implementation details |
+
+## Workflow (MANDATORY — follow in order)
+
+### Step 1: Parse Input
+
+Classify the argument:
+- **No argument** → auto-extract mode
+- **`decisions`** → filter to decisions only
+- **`technical`** → filter to technical facts only
+- **Anything else** → treat as specific facts provided by the user
+
+### Step 2: Resolve Staging File
+
+Check in order:
+1. `scripts/session-staging.md` in the project root (current working directory)
+2. `~/.claude/session-staging.md` as fallback
+
+If the resolved file does not exist, create it with this header:
+
+```markdown
+# Session Staging
+
+Facts staged here are consumed by the daily reflection and written to the knowledge graph.
+```
+
+### Step 3: Extract or Formulate Bullets
+
+Based on argument type, produce 3-8 bullets. Each bullet: max 20 words, factual, specific.
+
+**Auto-extract (no argument):** Scan the conversation for the most important facts — decisions made, technical details learned, status changes, new entities or tools introduced. Prefer concrete facts over vague summaries.
+
+**Specific facts (user-provided text):** Convert the user's text into clean bullet points. If they already gave you bullets, clean and tighten them. If they gave you prose, extract the key facts.
+
+**`decisions` filter:** Extract only explicit decisions made in this session — architectural choices, plans confirmed, approaches selected. Skip observations, status updates, and technical details.
+
+**`technical` filter:** Extract only technical facts — implementation details, APIs used, data structures, file paths, commands, schemas, and configuration. Skip process, decisions, and context.
+
+Get the current timestamp via Bash:
+```bash
+date '+%Y-%m-%d %H:%M'
+```
+
+### Step 4: Append to Staging File
+
+Use the **Edit tool** (NOT Write — Write would overwrite the file) to append the following to the end of the staging file:
+
+```markdown
+
+## YYYY-MM-DD HH:MM
+<!-- source: manual -->
+- bullet 1
+- bullet 2
+- bullet 3
+```
+
+The `<!-- source: manual -->` marker tells the Stop hook that manual staging already happened today, enabling deduplication.
+
+### Step 5: Confirm
+
+Display what was staged to the user. Show the exact bullets that were written. Keep it brief — no need to re-explain what staging does.
+
+## Scope Controls
+
+- Max 8 bullets per entry
+- Max 20 words per bullet
+- Append-only — never modify existing entries
+- Current conversation only — do not pull from memory, graph, or files
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Using Write instead of Edit to append | Write overwrites the file. Always use Edit to append. |
+| Exceeding 8 bullets | Pick the most important facts. Cut the rest. |
+| Omitting `<!-- source: manual -->` | The Stop hook uses this marker for deduplication. Always include it. |
+| Writing summaries instead of bullet facts | "Decided to use SQLite for storage" not "We had a productive discussion about databases." |
+| Staging vague observations | "SQLite chosen over Postgres for local-first storage" not "database discussion happened." |


### PR DESCRIPTION
## Summary

- Adds the `stage` plugin: manual, mid-conversation capture into the same staging pipeline as the automated Stop hook
- `/stage` skill supports 4 modes: auto-extract, specific facts, `decisions` filter, `technical` filter
- Bundled `session-stage.sh` is a generalized Stop hook with portable binary detection, portable staging file resolution, and deduplication via `<!-- source: manual -->` marker

## What ships

| File | Purpose |
|------|---------|
| `plugins/stage/.claude-plugin/plugin.json` | Plugin manifest |
| `plugins/stage/skills/stage/SKILL.md` | Behavioral spec — 5-step workflow, scope controls, common mistakes |
| `plugins/stage/skills/stage/README.md` | Human-facing docs with pipeline diagram and setup instructions |
| `plugins/stage/scripts/session-stage.sh` | Generalized Stop hook (portable, deduplicated) |

## CI

- JSON manifests valid ✓
- Version `0.1.0` aligned between `plugin.json` and `marketplace.json` ✓

## Test plan

- [ ] `/stage` with no args — auto-extracts from conversation, appends to staging file
- [ ] `/stage specific fact` — stages provided text as bullets
- [ ] `/stage decisions` — filters to decisions only
- [ ] `/stage technical` — filters to technical facts only
- [ ] Verify staging file appended (not overwritten)
- [ ] Verify `<!-- source: manual -->` marker present in entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)