### PR TITLE
feat: skill eval framework for cross-model quality measurement

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -57,6 +57,29 @@ jobs:
               print('All versions aligned.')
           "
 
+      - name: Validate developed_with field
+        run: |
+          python3 -c "
+          import json, sys, glob
+
+          errors = []
+
+          for manifest_path in glob.glob('plugins/*/.claude-plugin/plugin.json'):
+              manifest = json.load(open(manifest_path))
+              dw = manifest.get('developed_with')
+              if dw is not None:
+                  if not isinstance(dw, str) or not dw.strip():
+                      errors.append(f'{manifest_path}: developed_with must be non-empty string if present, got {dw!r}')
+
+          if errors:
+              print('developed_with validation errors:')
+              for e in errors:
+                  print(f'  {e}')
+              sys.exit(1)
+          else:
+              print('developed_with field valid (optional).')
+          "
+
       - name: Validate requires.env schema
         run: |
           python3 -c "

--- a/website/docs/guides/writing-evals.md
+++ b/website/docs/guides/writing-evals.md
@@ -127,7 +127,7 @@ python evals/runner.py --dry-run
 
 ## Tips
 
-- Keep fixtures small (1–5 files, <500 lines total) — they're loaded verbatim into the prompt
+- Keep fixtures small (1–5 files, &lt;500 lines total) — they're loaded verbatim into the prompt
 - Write `must_not_contain` checks for known failure modes (e.g., "I don't have access")
 - Use `--structure-only` during task authoring to iterate without API grading cost
 - Quality criteria should be binary and unambiguous — avoid "good" or "clear" without defining what that means


### PR DESCRIPTION
## Summary

- Adds a CI-driven eval suite that measures skill output quality across models (Sonnet, Haiku, Opus) and publishes a compatibility matrix to the docs site
- Adds `developed_with` transparency field to plugin manifests so users know what model a skill was built for
- Introduces plugin-author eval authoring guide (beta) so community plugins can ship their own evals

## What's included

### Eval framework (`evals/`)

**Runner** (`runner.py`) — CLI with `--skill`, `--model`, `--structure-only`, `--include-plugin-evals`, and `--dry-run` flags. Discovers tasks, loads the skill's SKILL.md as system prompt, injects fixture files as pre-context, and calls the Anthropic Messages API.

**Graders** (`grader.py`) — Two tiers:
- Code-based: `SectionGrader` (required H2 headings), `WordCountGrader` (min/max bounds), `ContainsGrader` (must/must-not phrases) — fast, free, deterministic
- Model-based: `ModelGrader` uses Haiku as grader model — one API call per quality criterion, returns `{"pass": bool, "reason": "..."}` with configurable weights

**Metrics** (`results.py`) — pass@1 (reliability), pass@N (capability ceiling), pass^N (reliability floor), weighted quality score

**Results → Docs** (`render_results.py`) — reads `evals/results/latest.json`, generates `website/docs/evals/compatibility.md` as a Docusaurus-compatible markdown page

### Task definitions (`evals/tasks/`)

7 tasks across 3 skills, chosen for structured output and static fixture input:

| Skill | Task | What it tests |
|-------|------|--------------|
| explain | fibonacci | 6-section structure, no inventing gotchas, correct fib description |
| explain | express-router | middleware chain understanding, error handling gotcha detection |
| explain | auth-concept-flow | cross-file concept tracing, JWT flow, security gotcha awareness |
| review | missing-error-handling | BLOCKER identification, Go `Scan`/`Exec` error ignoring |
| review | clean-rename | no BLOCKER inflation, correct Approve verdict |
| docgen | readme-go-project | accurate Go project description, confirms before writing |
| docgen | changelog | commit grouping, confirms before writing |

### Fixtures (`evals/fixtures/`)

5 synthetic codebases (committed in-tree, no external deps):
- `fibonacci/` — iterative Python fib with edge case handling
- `express-app/` — JWT auth middleware + users router with intentional gaps
- `go-project/` — in-memory HTTP item store + simulated git log
- `messy-diff/` — Go payment processor with two ignored error returns
- `clean-rename-diff/` — clean Go struct field rename across two files

### CI (`evals.yml`)

Triggers on `release: [published]` and `workflow_dispatch`. Runs evals → renders compatibility page → commits `latest.json` + `compatibility.md` back to the branch → triggers docs deploy.

**Cost estimate:** ~$2–5 per run at 7 tasks × 3 models × 3 trials + Haiku grading.

### Transparency: `developed_with` in plugin.json

```json
{ "developed_with": "claude-sonnet-4" }
```

Optional field on `explain`, `review`, and `docgen` manifests. Validated in this PR's `validate.yml` step (must be non-empty string if present). Surfaced on the compatibility docs page alongside eval scores.

### Docs

- `website/docs/evals/compatibility.md` — results page (placeholder until first CI run)
- `website/docs/guides/writing-evals.md` — plugin author guide for eval authoring (beta)
- `website/sidebars.js` — Evals category added

## Test plan

- [ ] `python evals/runner.py --dry-run` — lists all 21 task/model combos, no API calls
- [ ] `python evals/runner.py --structure-only --skill explain --model sonnet` — runs code graders only, writes `evals/results/latest.json`
- [ ] `python evals/render_results.py` — generates `website/docs/evals/compatibility.md` from results
- [ ] `cd website && npm run build` — docs site builds with new Evals sidebar category
- [ ] `validate.yml` CI passes — `developed_with` field validates correctly (present and absent)
- [ ] `evals.yml` — `workflow_dispatch` trigger runs full pipeline end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)