### PR TITLE
feat: align harness-share with Harness Protocol v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Produces a structured explanation: summary, key components, how it connects, pat
 | [`research`](plugins/research/skills/research/README.md) | Process any source into a structured, compounding knowledge base | `/research https://...` |
 | [`data-lineage`](plugins/data-lineage/skills/data-lineage/README.md) | Trace column-level data lineage through SQL, Kafka, Spark, and JDBC codebases | `/data-lineage orders.amount` |
 | [`orient`](plugins/orient/skills/orient/README.md) ¹ | Topic-focused session orientation across graph, knowledge, journal, and research | `/orient auth` |
-| [`capture-session`](plugins/capture-session/skills/capture-session/README.md) ¹ | Capture session information into a staging file for later reflection | `/capture-session` |
-| [`harness-share`](plugins/harness-share/skills/harness-export/README.md) | Export your plugin setup to `harness.yaml` and import it anywhere | `/harness-export` |
+| [`stage`](plugins/stage/skills/stage/README.md) ¹ | Capture session information into a staging file for later reflection | `/stage` |
+| [`harness-share`](plugins/harness-share/skills/harness-export/README.md) | Export your plugin setup to `harness.yaml`, import it anywhere, and validate against the Harness Protocol v1 spec | `/harness-export` · `/harness-import` · `/harness-validate` |
 
 ¹ Personal-workflow plugins designed for projects using the [knowledge graph + journal pattern](docs/claude-md-conventions.md).
 
@@ -87,9 +87,12 @@ Capture your installed plugins into a `harness.yaml` file, commit it to your dot
 ```
 /harness-export               # write harness.yaml from your current setup
 /harness-import harness.yaml  # interactive wizard to pick what to install
+/harness-validate             # validate harness.yaml against the Harness Protocol v1 schema
 ```
 
 The import wizard shows each plugin with its description and lets you pick a subset — your config is a starting point, not a mandate.
+
+`harness.yaml` follows the [Harness Protocol v1](https://harnessprotocol.ai) open spec — a vendor-neutral format for portable AI coding harnesses that can declare plugins, MCP servers, environment variables, and instructions in one shareable file.
 
 **Shell fallback (no Claude Code required):**
 

--- a/harness.yaml.example
+++ b/harness.yaml.example
@@ -1,52 +1,87 @@
 # harness.yaml — your personal harness configuration
 #
-# Commit this to your dotfiles and restore it on any new machine.
+# This file follows the Harness Protocol v1 format (harnessprotocol.ai).
+# Commit it to your dotfiles and restore it on any new machine.
 #
 # Restore with Claude Code:
 #   /harness-import harness.yaml
 #
 # Restore without Claude Code (skills only):
 #   curl -fsSL https://raw.githubusercontent.com/siracusa5/harness-kit/main/harness-restore.sh | bash -s -- harness.yaml
+#
+# ── Format note ────────────────────────────────────────────────────────────────
+# Protocol v1:  version: "1"  (string) — uses source: owner/repo per plugin
+# Legacy v1:    version: 1    (integer) — uses marketplace: key + marketplaces: section
+# harness-import handles both. New exports use protocol v1 format.
+# ───────────────────────────────────────────────────────────────────────────────
 
-version: 1
+$schema: https://harnessprotocol.ai/schema/v1/harness.schema.json
+version: "1"
 
-# marketplaces: mapping of short name → owner/repo
-# The short name is what you use after @ in /plugin install commands.
-marketplaces:
-  harness-kit: siracusa5/harness-kit
-  # obra: obra/superpowers-marketplace
+# Profile identity (optional — helps teammates understand what this harness is for)
+metadata:
+  name: my-harness
+  description: My personal harness configuration.
 
+# Plugins — add skills from any harness-kit compatible source.
+# source: owner/repo (resolved via GitHub by default)
 plugins:
   - name: explain
-    marketplace: harness-kit
+    source: siracusa5/harness-kit
     description: Layered explanations of files, functions, directories, or concepts
 
   - name: research
-    marketplace: harness-kit
+    source: siracusa5/harness-kit
     description: Process any source into a structured, compounding knowledge base
 
   - name: review
-    marketplace: harness-kit
+    source: siracusa5/harness-kit
     description: Code review for a branch, PR, or path — severity labels and cross-file analysis
 
   # Uncomment to include additional harness-kit plugins:
   # - name: docgen
-  #   marketplace: harness-kit
+  #   source: siracusa5/harness-kit
   #   description: Generate or update README, API docs, architecture overview, or changelog
 
   # - name: data-lineage
-  #   marketplace: harness-kit
+  #   source: siracusa5/harness-kit
   #   description: Column-level lineage tracing through SQL, Kafka, Spark, and JDBC
 
   # - name: orient
-  #   marketplace: harness-kit
+  #   source: siracusa5/harness-kit
   #   description: Topic-focused session orientation across graph, knowledge, and research
 
-  # - name: capture-session
-  #   marketplace: harness-kit
+  # - name: stage
+  #   source: siracusa5/harness-kit
   #   description: Capture session information into a staging file for later reflection
 
-  # Example third-party plugin (uncomment the marketplace entry above too):
+  # Example third-party plugin:
   # - name: superpowers
-  #   marketplace: obra
+  #   source: obra/superpowers-marketplace
   #   description: Structured dev workflows — TDD, systematic debugging, subagent delegation
+
+# MCP servers (optional) — local or remote tool servers.
+# Uncomment and fill in if you want to bundle MCP server config with your harness.
+# mcp-servers:
+#   postgres:
+#     transport: stdio
+#     command: uvx
+#     args:
+#       - mcp-server-postgres
+#       - ${DB_CONNECTION_STRING}
+
+# Environment variable declarations (optional).
+# List vars that plugins or MCP servers depend on.
+# sensitive: true (default) — harness prompts the user; default values are forbidden.
+# env:
+#   - name: DB_CONNECTION_STRING
+#     description: PostgreSQL connection string.
+#     required: true
+#     sensitive: true
+
+# Harness instructions (optional) — injected into CLAUDE.md/AGENT.md at import time.
+# import-mode: merge (default) appends to existing instructions.
+# instructions:
+#   operational: |
+#     Your operational guidance here.
+#   import-mode: merge

--- a/plugins/harness-share/skills/harness-export/SKILL.md
+++ b/plugins/harness-share/skills/harness-export/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: harness-export
-description: Use when user invokes /harness-export or wants to save their current harness-kit plugin setup to a shareable harness.yaml file. Detects installed skills, collects marketplace info, and writes the config. Do NOT use for importing or restoring a harness — use /harness-import instead.
+description: Use when user invokes /harness-export or wants to save their current harness-kit plugin setup to a shareable harness.yaml file. Detects installed skills, collects source info, and writes the config in Harness Protocol v1 format. Do NOT use for importing or restoring a harness — use /harness-import instead.
 disable-model-invocation: true
 ---
 
 # Export Your Harness Configuration
 
 You are helping the user capture their current harness-kit setup into a `harness.yaml` file they can share with teammates or commit to their dotfiles repo.
+
+This file follows the **Harness Protocol v1 format** — the open spec at harnessprotocol.ai. It is backward-compatible with harness-import (which handles both old and new formats).
 
 ## Workflow Order (MANDATORY)
 
@@ -26,15 +28,17 @@ Collect the directory names as your list of installed plugin names.
 
 ---
 
-### Step 2: Ask about marketplaces
+### Step 2: Ask about sources and metadata
 
 Tell the user what skills you found, then ask:
 
-> "I found these installed skills: [list]. Which marketplaces have you added? For each, provide the short name and the owner/repo path — for example:
-> - `harness-kit` → `siracusa5/harness-kit`
-> - `obra` → `obra/superpowers-marketplace`
+> "I found these installed skills: [list]. A couple of quick questions:
 >
-> If you've only added harness-kit, just say so."
+> 1. For each plugin, which repo is it from? Format: `owner/repo` — for example `siracusa5/harness-kit`. If a plugin is from harness-kit, just say so and I'll fill it in.
+> 2. What name and description should I give this harness profile? (optional — press enter to skip)
+> 3. Do you have any MCP servers, env variables, or CLAUDE.md instructions you'd like to include? (optional)
+>
+> If you've only added harness-kit plugins, just say so."
 
 Wait for the user's response before proceeding.
 
@@ -42,9 +46,9 @@ Wait for the user's response before proceeding.
 
 ### Step 3: Build the plugin entries
 
-For each installed skill, determine its marketplace and description:
+For each installed skill, determine its source repo:
 
-**Known harness-kit plugins** (marketplace: `harness-kit`):
+**Known harness-kit plugins** (source: `siracusa5/harness-kit`):
 | Plugin | Description |
 |--------|-------------|
 | explain | Layered explanations of files, functions, directories, or concepts |
@@ -56,34 +60,67 @@ For each installed skill, determine its marketplace and description:
 | docgen | Generate or update README, API docs, architecture overview, or changelog |
 | harness-export | Export your installed plugins to a shareable harness.yaml |
 | harness-import | Import a harness.yaml and interactively select plugins to install |
+| harness-validate | Validate a harness.yaml file against the Harness Protocol v1 JSON Schema |
 
 For any installed skill **not in this table**, ask the user:
-> "I see `[name]` installed but don't recognize it. What marketplace is it from, and what does it do in one sentence?"
+> "I see `[name]` installed but don't recognize it. What `owner/repo` is it from, and what does it do in one sentence?"
 
 ---
 
 ### Step 4: Write harness.yaml
 
-Write `harness.yaml` to the current directory (or a path the user specifies). Use this format exactly:
+Write `harness.yaml` to the current directory (or a path the user specifies). Use the **Harness Protocol v1 format**:
 
 ```yaml
-version: 1
+$schema: https://harnessprotocol.ai/schema/v1/harness.schema.json
+version: "1"
 
-marketplaces:
-  harness-kit: siracusa5/harness-kit
-  # add other marketplaces as: short-name: owner/repo
+# Profile identity (optional but recommended)
+metadata:
+  name: my-harness
+  description: My personal harness configuration.
 
 plugins:
   - name: explain
-    marketplace: harness-kit
+    source: siracusa5/harness-kit
     description: Layered explanations of files, functions, directories, or concepts
   # additional plugins follow the same structure
 ```
 
+**With MCP servers** (include only if user provided them):
+```yaml
+mcp-servers:
+  postgres:
+    transport: stdio
+    command: uvx
+    args:
+      - mcp-server-postgres
+      - ${DB_CONNECTION_STRING}
+```
+
+**With env declarations** (include only if user has env vars):
+```yaml
+env:
+  - name: DB_CONNECTION_STRING
+    description: PostgreSQL connection string.
+    required: true
+    sensitive: true
+```
+
+**With instructions** (include only if user wants to bundle CLAUDE.md/AGENT.md content):
+```yaml
+instructions:
+  operational: |
+    Your operational instructions here.
+  import-mode: merge
+```
+
 Rules:
-- `marketplaces` is a mapping: short name → `owner/repo` path
-- `plugins[].marketplace` must match a key in `marketplaces`
-- Include only the marketplaces for plugins that are actually installed
+- `version` must be the string `"1"` (quoted), not the integer `1`
+- `source` is `owner/repo` — no `marketplace:` key, no `marketplaces:` section
+- Only include `mcp-servers`, `env`, `instructions`, and `permissions` sections if the user provided content for them
+- Omit `metadata` if the user skipped the name/description questions
+- Do NOT include `harness-export` or `harness-import` in the output unless the user explicitly asks
 
 ---
 
@@ -103,6 +140,8 @@ Tell the user where the file was written:
 
 | Mistake | Fix |
 |---------|-----|
-| Including `harness-export` and `harness-import` in the output | Only include plugins the user actually uses. These meta-plugins don't need to be in their config. |
-| Using owner as marketplace key when the repo name is the identifier | For harness-kit: key is `harness-kit`, not `siracusa5`. Ask the user if unsure. |
-| Writing to a path without confirming | Write to `./harness.yaml` by default. If user specified a path in the invocation, use that. |
+| Using `version: 1` (integer) | Must be `version: "1"` (string) — this is what distinguishes the protocol format |
+| Using `marketplace: harness-kit` | Protocol format uses `source: siracusa5/harness-kit` — no `marketplaces:` section |
+| Including `harness-export` and `harness-import` in the output | Only include plugins the user actually uses |
+| Writing to a path without confirming | Write to `./harness.yaml` by default. If user specified a path in the invocation, use that |
+| Adding `mcp-servers:` / `env:` / `instructions:` as empty sections | Only include these sections when the user has actual content to put in them |

--- a/plugins/harness-share/skills/harness-import/SKILL.md
+++ b/plugins/harness-share/skills/harness-import/SKILL.md
@@ -1,11 +1,15 @@
 ---
 name: harness-import
-description: Use when user invokes /harness-import or wants to install plugins from a shared harness.yaml config file. Reads the config, presents each plugin interactively, and generates the Claude Code install commands for the ones the user selects.
+description: Use when user invokes /harness-import or wants to install plugins from a shared harness.yaml config file. Reads the config, presents each plugin interactively, and generates the Claude Code install commands for the ones the user selects. Handles both Harness Protocol v1 format (version: "1") and the legacy format (version: 1).
 ---
 
 # Import a Harness Configuration
 
 You are helping the user install plugins from a `harness.yaml` file — either all of them or a subset they choose.
+
+This skill handles both format versions:
+- **v1 protocol format** (`version: "1"` string) — uses `source: owner/repo` per plugin, may include `mcp-servers`, `env`, and `instructions` sections
+- **Legacy format** (`version: 1` integer) — uses `marketplace: key` per plugin with a `marketplaces:` section
 
 ## Workflow Order (MANDATORY)
 
@@ -22,7 +26,9 @@ Check for `harness.yaml` in this order:
 If no file is found at either location, tell the user:
 > "No `harness.yaml` found. Get one from a teammate or generate your own with `/harness-export`."
 
-Read and parse the file: extract the `marketplaces` mapping and the `plugins` list.
+Read and parse the file. Detect which format version it uses:
+- `version: "1"` (string) → **Protocol v1 format**
+- `version: 1` (integer) → **Legacy format**
 
 ---
 
@@ -33,10 +39,17 @@ Display the plugin list clearly before asking anything:
 ```
 Plugins in this config:
 
-  1. explain (harness-kit) — Layered explanations of files, functions, directories, or concepts
-  2. research (harness-kit) — Process any source into a structured, compounding knowledge base
-  3. superpowers (obra) — Structured dev workflows — TDD, systematic debugging, subagent delegation
+  1. explain (siracusa5/harness-kit) — Layered explanations of files, functions, directories, or concepts
+  2. research (siracusa5/harness-kit) — Process any source into a structured, compounding knowledge base
+  3. superpowers (obra/superpowers-marketplace) — Structured dev workflows — TDD, systematic debugging, subagent delegation
 ```
+
+For legacy format, resolve the `source` by looking up `plugins[].marketplace` → `marketplaces[key]`.
+
+Then, if the file contains any of the following sections, mention them briefly:
+- `mcp-servers:` — "This config also declares MCP servers. I'll ask about those after plugins."
+- `env:` — "This config declares environment variables. I'll surface those after plugins."
+- `instructions:` — "This config includes harness instructions. I'll offer to apply those after plugins."
 
 Then ask:
 > "Would you like to install all of these, pick a subset, or get more details on any before deciding?"
@@ -67,9 +80,9 @@ After all plugins: "Got it — you've selected: [list]. Ready to generate the in
 
 ### Step 5: Generate install commands
 
-Output the complete Claude Code command sequence. **Marketplaces come first, plugins second.** Only include marketplaces for the plugins actually selected.
+Output the complete Claude Code command sequence. **Marketplace adds come first, plugin installs second.**
 
-Format:
+For **protocol v1 format** (`source: owner/repo`), derive marketplace info from the `source` field:
 
 ```
 Run these in Claude Code:
@@ -81,16 +94,62 @@ Run these in Claude Code:
 /plugin install superpowers@obra
 ```
 
-To map a plugin's `marketplace` key to the full `owner/repo` path, look it up in the `marketplaces` section of the config. Example: `marketplace: harness-kit` + `marketplaces.harness-kit: siracusa5/harness-kit` → `/plugin marketplace add siracusa5/harness-kit`.
+The marketplace short name to use in `/plugin install` commands is the **repo name** (last segment of `owner/repo`). Example: `siracusa5/harness-kit` → short name `harness-kit`.
+
+For **legacy format** (`marketplace: key` + `marketplaces:` section), resolve as before:
+- `marketplace: harness-kit` + `marketplaces.harness-kit: siracusa5/harness-kit` → `/plugin marketplace add siracusa5/harness-kit`
+
+Only include marketplaces for plugins actually selected.
 
 Close with:
 > "Paste these into Claude Code and run them in order. Restart Claude Code after the installs complete."
 
 ---
 
-### Step 6: Offer shell fallback
+### Step 6: Handle MCP servers (if present)
 
-After the commands, add:
+If the config has a `mcp-servers:` section, walk through each server:
+
+> "This config declares an MCP server: **postgres** (stdio, `uvx mcp-server-postgres`). Would you like me to add this to your `.mcp.json`?"
+
+If yes, write or update `.mcp.json` in the current directory with the server definition.
+
+If the server command contains `${VAR}` references, note which env vars are needed (the `env:` section will cover them in Step 7).
+
+---
+
+### Step 7: Surface env declarations (if present)
+
+If the config has an `env:` section, display them clearly:
+
+```
+Environment variables required by this harness:
+
+  DB_CONNECTION_STRING (required, sensitive) — PostgreSQL connection string for the project database.
+  ANALYTICS_API_KEY (optional, sensitive) — API key for the analytics MCP server.
+```
+
+Tell the user:
+> "These environment variables need to be set before using the MCP servers or skills that depend on them. Set them in your shell profile, `.env` file, or secret manager."
+
+Do NOT ask for the values — sensitive vars must never be stored in the harness file or conversation.
+
+---
+
+### Step 8: Offer to apply instructions (if present)
+
+If the config has an `instructions:` section and `import-mode: merge` (or if import-mode is absent, default to merge), offer:
+
+> "This config includes harness instructions (operational guidance for the AI). Would you like me to append them to your `CLAUDE.md` or `AGENT.md`?"
+
+If yes, append to the file the user specifies. If `import-mode: replace` is set, warn:
+> "This config requests full replacement of existing instructions. That will overwrite your current CLAUDE.md/AGENT.md. Are you sure?"
+
+---
+
+### Step 9: Offer shell fallback
+
+After all the above, add:
 
 > "If you'd rather install without Claude Code, use the shell script:
 > ```bash
@@ -105,5 +164,7 @@ After the commands, add:
 | Mistake | Fix |
 |---------|-----|
 | Including marketplaces for plugins the user didn't select | Only add `marketplace add` lines for marketplaces that have at least one selected plugin |
-| Forgetting to explain the `@name` convention | The `@name` in `/plugin install` must match the marketplace key in the config, not the owner/repo |
+| Forgetting to explain the `@name` convention | The `@name` in `/plugin install` must match the marketplace short name (repo name), not the owner |
 | Skipping the marketplace add commands | They must come before the plugin installs, or the installs will fail |
+| Ignoring `mcp-servers`, `env`, `instructions` sections | Always check for these sections and handle them in the appropriate steps |
+| Prompting the user for sensitive env var values | Never ask for secret values — just tell the user which vars to set and where |

--- a/plugins/harness-share/skills/harness-validate/SKILL.md
+++ b/plugins/harness-share/skills/harness-validate/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: harness-validate
+description: Use when user invokes /harness-validate or wants to check whether a harness.yaml file is valid according to the Harness Protocol v1 JSON Schema. Reports validation errors with field paths and helpful fix suggestions.
+---
+
+# Validate a Harness Configuration
+
+You are helping the user validate a `harness.yaml` file against the Harness Protocol v1 JSON Schema.
+
+## Workflow Order (MANDATORY)
+
+**Follow these steps in order. Do not skip any step.**
+
+---
+
+### Step 1: Find the file
+
+Check for the harness file in this order:
+1. A path provided by the user after `/harness-validate` (e.g., `/harness-validate ~/dotfiles/harness.yaml`)
+2. `./harness.yaml` in the current directory
+
+If no file is found at either location, tell the user:
+> "No `harness.yaml` found. Specify a path: `/harness-validate path/to/harness.yaml`"
+
+Read the file contents.
+
+---
+
+### Step 2: Run validation
+
+Install the validation tools if not present and run validation:
+
+```bash
+python3 -m venv /tmp/hk-validate-venv 2>/dev/null || true
+/tmp/hk-validate-venv/bin/pip install jsonschema pyyaml -q 2>/dev/null || \
+  (python3 -m venv /tmp/hk-validate-venv && /tmp/hk-validate-venv/bin/pip install jsonschema pyyaml -q)
+```
+
+Then run this validation script:
+
+```python
+import json, sys, yaml
+
+try:
+    from jsonschema import validate, ValidationError, SchemaError
+    from jsonschema.validators import validator_for
+except ImportError:
+    print("ERROR: jsonschema not installed")
+    sys.exit(1)
+
+SCHEMA_URL = "https://raw.githubusercontent.com/siracusa5/harness-protocol/spec/v1-foundation/schema/draft/harness.schema.json"
+HARNESS_FILE = "harness.yaml"  # replace with actual path
+
+# Fetch the schema
+import urllib.request
+try:
+    with urllib.request.urlopen(SCHEMA_URL, timeout=5) as resp:
+        schema = json.loads(resp.read())
+except Exception as e:
+    print(f"WARN: Could not fetch remote schema ({e}). Falling back to basic checks.")
+    schema = None
+
+# Load the harness file
+try:
+    with open(HARNESS_FILE) as f:
+        doc = yaml.safe_load(f)
+except yaml.YAMLError as e:
+    print(f"FAIL: YAML parse error — {e}")
+    sys.exit(1)
+
+if schema is None:
+    # Basic offline checks
+    errors = []
+    if "version" not in doc:
+        errors.append("Missing required field: version")
+    elif doc["version"] not in ("1", 1):
+        errors.append(f"version must be \"1\" (string) or 1 (legacy integer), got: {doc['version']!r}")
+    if "metadata" not in doc:
+        errors.append("Missing required field: metadata")
+    elif "name" not in doc.get("metadata", {}):
+        errors.append("metadata.name is required")
+    if errors:
+        for e in errors:
+            print(f"FAIL: {e}")
+    else:
+        print("PASS (basic checks only — schema fetch failed)")
+    sys.exit(0)
+
+# Full schema validation
+try:
+    validate(instance=doc, schema=schema)
+    print("PASS")
+except ValidationError as e:
+    path = " → ".join(str(p) for p in e.absolute_path) or "(root)"
+    print(f"FAIL: {path}: {e.message}")
+except SchemaError as e:
+    print(f"ERROR: Schema itself is invalid — {e.message}")
+```
+
+Run the script with `/tmp/hk-validate-venv/bin/python3` and capture the output.
+
+---
+
+### Step 3: Report results
+
+**On PASS:**
+> "Your `harness.yaml` is valid — passes Harness Protocol v1 schema validation."
+
+If the file uses `version: 1` (integer, legacy format), add:
+> "Note: this is in the legacy format (`version: 1` integer). Run `/harness-export` to regenerate in Harness Protocol v1 format (`version: \"1\"` string)."
+
+**On FAIL (validation errors):**
+
+Display errors with clear field paths and fix suggestions:
+
+```
+✗ harness.yaml failed validation:
+
+  plugins → 0 → source: 'marketplace' is not a valid property
+    Fix: Use source: owner/repo instead of marketplace: key.
+    Example: source: siracusa5/harness-kit
+
+  env → 0: 'default' is not allowed when sensitive is true
+    Fix: Remove the default value — sensitive vars must be set by the user,
+    never baked into the harness file.
+
+  (root): version must be "1" (string), got 1 (integer)
+    Fix: Change version: 1 to version: "1" (add quotes).
+```
+
+**Common errors and their fixes:**
+
+| Error | Fix |
+|-------|-----|
+| `version` must be string `"1"` | Change `version: 1` to `version: "1"` |
+| `source` is not a valid property | Replace `marketplace: key` with `source: owner/repo` |
+| `default` not allowed when `sensitive: true` | Remove the `default` value |
+| `metadata.name` is required | Add a `metadata.name` field |
+| Unknown additional property | Check for typos in field names |
+
+After listing errors:
+> "Fix these issues and run `/harness-validate` again to confirm."
+
+**On YAML parse error:**
+> "Your `harness.yaml` has a YAML syntax error:
+> `[error details]`
+>
+> Common causes: wrong indentation, missing quotes around special characters (like `:` in strings), or a tab used instead of spaces."
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Reporting only the first error | Show all errors, not just the first one |
+| Giving up if schema fetch fails | Fall back to basic checks and tell the user the schema was unavailable |
+| Suggesting `marketplace:` as a fix | Always recommend `source: owner/repo` — that's the v1 format |


### PR DESCRIPTION
## Summary

- **harness-export**: Updated to emit Harness Protocol v1 format — `version: "1"` (string), `source: owner/repo` per plugin (replaces `marketplace:` key + `marketplaces:` section), `$schema:` header. Optionally includes `mcp-servers`, `env`, and `instructions` sections if the user has that content.
- **harness-import**: Now handles both protocol v1 (`version: "1"` string) and legacy (`version: 1` integer) formats. Added three new steps: offer to configure MCP servers in `.mcp.json`, surface env var declarations to the user, and offer to apply `instructions:` to CLAUDE.md/AGENT.md.
- **harness-validate** (new): Validates `harness.yaml` against the Harness Protocol v1 JSON Schema. Reports field-level errors with paths and fix suggestions. Falls back to basic checks when remote schema is unreachable.
- **harness.yaml.example**: Updated to protocol v1 format with a format note explaining the difference between `version: "1"` and `version: 1`. Shows all optional sections (`mcp-servers`, `env`, `instructions`) as commented examples.
- **README**: Updated harness-share skill row and Sharing Your Setup section to mention `/harness-validate` and link the Harness Protocol v1 spec.

## Context

The [Harness Protocol](https://harnessprotocol.ai) is an open spec for portable AI coding harnesses. This PR aligns harness-kit's sharing workflow with the v1 format — `source: owner/repo` is cleaner than the old two-level `marketplaces:` indirection, and the richer format (MCP servers, env, instructions) makes harness.yaml a full portable configuration.

## Test plan

- [ ] Run `/harness-export` in a project with installed plugins — verify output uses `version: "1"` string and `source:` keys
- [ ] Run `/harness-import` against a legacy `harness.yaml` (integer version) — verify it still installs correctly
- [ ] Run `/harness-import` against a v1 `harness.yaml` with `mcp-servers:` and `env:` — verify those sections are handled
- [ ] Run `/harness-validate` against `harness.yaml.example` — verify PASS
- [ ] Run `/harness-validate` against the data-engineer example from harness-protocol — verify PASS
- [ ] Run `/harness-validate` with a broken file — verify errors are reported with field paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)