### PR TITLE
feat: add ship-pr and pull-request-sweep skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -71,6 +71,22 @@
       "version": "0.2.0",
       "author": { "name": "siracusa5" },
       "license": "Apache-2.0"
+    },
+    {
+      "name": "ship-pr",
+      "source": "./ship-pr",
+      "description": "End-of-task shipping workflow: run tests, open a PR, code review, fix CI, sync base, then squash merge",
+      "version": "0.1.0",
+      "author": { "name": "harnessprotocol" },
+      "license": "Apache-2.0"
+    },
+    {
+      "name": "pull-request-sweep",
+      "source": "./pull-request-sweep",
+      "description": "Cross-repo PR sweep: triage all open PRs, run code reviews, merge what's ready, fix quick CI blockers, and report",
+      "version": "0.1.0",
+      "author": { "name": "harnessprotocol" },
+      "license": "Apache-2.0"
     }
   ]
 }

--- a/plugins/pull-request-sweep/.claude-plugin/plugin.json
+++ b/plugins/pull-request-sweep/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "pull-request-sweep",
+  "description": "Cross-repo PR sweep: triage all open PRs, run code reviews, merge what's ready, fix quick CI blockers",
+  "version": "0.1.0",
+  "requires": {
+    "env": [
+      {
+        "name": "GH_TOKEN",
+        "description": "GitHub personal access token — used by gh CLI for PR discovery, CI checks, merging, and rebasing",
+        "required": true,
+        "sensitive": true,
+        "when": "All pull-request-sweep operations require GitHub access"
+      }
+    ]
+  }
+}

--- a/plugins/pull-request-sweep/skills/pull-request-sweep/README.md
+++ b/plugins/pull-request-sweep/skills/pull-request-sweep/README.md
@@ -1,0 +1,39 @@
+# pull-request-sweep
+
+Cross-repo PR sweep — discover, triage, review, merge, and report on all your open PRs.
+
+## Usage
+
+```
+/plugin install pull-request-sweep@harness-kit
+```
+
+Then:
+
+```
+/pull-request-sweep
+```
+
+Or:
+
+> "Check my PRs."
+> "What's the status of all my open PRs?"
+> "Sweep my PRs."
+
+## What It Does
+
+1. Discovers all open (non-draft) PRs authored by you across all repos
+2. Enriches each PR with CI status and merge state
+3. Triages into: MERGE_READY / PENDING_CI / NEEDS_REVIEW / BEHIND_BASE / CI_FAILING / CHANGES_REQUESTED / CONFLICTING / BLOCKED
+4. Shows triage table and waits for your confirmation
+5. Acts: merges ready PRs, rebases behind ones, fixes quick CI failures (lint/format/typo), runs code reviews on unreviewed PRs
+6. Produces a full report
+
+## Notes
+
+- Requires the `gh` CLI (`brew install gh`, then `gh auth login`)
+- Uses the `review` skill for code reviews — install it alongside this plugin
+- Never acts on draft PRs
+- Never auto-resolves CHANGES_REQUESTED — flags for human follow-up
+- Safe to run repeatedly — idempotent, already-merged PRs won't reappear
+- Pairs with `/loop 30m /pull-request-sweep` for ongoing PR babysitting

--- a/plugins/pull-request-sweep/skills/pull-request-sweep/SKILL.md
+++ b/plugins/pull-request-sweep/skills/pull-request-sweep/SKILL.md
@@ -88,7 +88,7 @@ Wait for the user to confirm before proceeding to Step 4. This is important — 
 
 ## Step 4: Code Review (for NEEDS_REVIEW PRs)
 
-For each `NEEDS_REVIEW` PR, invoke the `superpowers:code-reviewer` skill to review the changes.
+For each `NEEDS_REVIEW` PR, invoke the `review` skill to review the changes.
 
 **If there are multiple NEEDS_REVIEW PRs:** dispatch code review subagents in parallel — one per PR — then collect all results before proceeding to Step 5. This is the most expensive step; parallelizing keeps total time reasonable.
 

--- a/plugins/pull-request-sweep/skills/pull-request-sweep/SKILL.md
+++ b/plugins/pull-request-sweep/skills/pull-request-sweep/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: pull-request-sweep
+description: Use when you want to sweep all open pull requests across all repos, triage their status, run code reviews on unreviewed PRs, merge what's ready, fix quick blockers, and produce a full status report. Trigger when the user says "check my PRs", "close out open PRs", "what's the status of my PRs", "sweep my PRs", "PR sweep", "pull request sweep", or wants a cross-repo PR status report. Future: pairs with the loop skill for ongoing automated PR management.
+---
+
+# Pull Request Sweep
+
+A cross-repo PR sweep: discover → enrich → triage → review → act → report.
+
+**Announce at start:** "I'm using the pull-request-sweep skill to sweep all open PRs."
+
+---
+
+## Step 1: Discover All Open PRs
+
+```bash
+gh search prs \
+  --author @me \
+  --state open \
+  --json number,title,url,isDraft,repository,headRefName,baseRefName,reviewDecision \
+  --limit 100
+```
+
+Parse the result into a working list. **Skip drafts immediately** — they're not ready for action.
+
+If you have more than 20 non-draft PRs, report the count and ask the user if they want to proceed or filter by repo.
+
+---
+
+## Step 2: Enrich Each PR
+
+For each non-draft PR, fetch CI and merge state in parallel (dispatch subagents or batch calls):
+
+```bash
+# CI status
+gh pr checks <number> --repo <owner/repo> --json name,state,conclusion
+
+# Merge state (up-to-date, behind, conflicting, etc.)
+gh pr view <number> --repo <owner/repo> --json mergeStateStatus,mergeable
+```
+
+Build a status object per PR:
+
+```
+{
+  repo, number, title, url,
+  ciStatus: passing | failing | pending | none,
+  mergeState: clean | behind | dirty | blocked,
+  reviewDecision: APPROVED | CHANGES_REQUESTED | REVIEW_REQUIRED | null
+}
+```
+
+---
+
+## Step 3: Triage
+
+Classify each PR into one category (in priority order — first match wins):
+
+| Category | Condition |
+|----------|-----------|
+| `MERGE_READY` | CI passing, review approved or not required, merge state clean |
+| `PENDING_CI` | CI still running, everything else clean |
+| `NEEDS_REVIEW` | No reviews yet (reviewDecision null or REVIEW_REQUIRED) |
+| `BEHIND_BASE` | Merge state is `behind` |
+| `CI_FAILING` | CI has failed conclusions |
+| `CHANGES_REQUESTED` | Reviewer has requested changes |
+| `CONFLICTING` | Merge state is `dirty` (merge conflicts) |
+| `BLOCKED` | Anything else preventing merge |
+
+Show the triage table to the user and wait for confirmation before taking any action:
+
+```
+PR Triage
+─────────────────────────────────────────────────────────────
+MERGE_READY    owner/repo #42  feat: add caching layer
+NEEDS_REVIEW   owner/repo #38  fix: auth token refresh
+BEHIND_BASE    other/repo #11  refactor: split service
+CI_FAILING     other/repo #9   feat: new export format
+CHANGES_REQUESTED  repo #7     fix: race condition
+─────────────────────────────────────────────────────────────
+Plan: merge 1, review 1, rebase 1, attempt CI fix 1, flag 1.
+Proceed?
+```
+
+Wait for the user to confirm before proceeding to Step 4. This is important — the sweep can merge multiple PRs and rebase branches across repos, so the user should know what's coming.
+
+---
+
+## Step 4: Code Review (for NEEDS_REVIEW PRs)
+
+For each `NEEDS_REVIEW` PR, invoke the `superpowers:code-reviewer` skill to review the changes.
+
+**If there are multiple NEEDS_REVIEW PRs:** dispatch code review subagents in parallel — one per PR — then collect all results before proceeding to Step 5. This is the most expensive step; parallelizing keeps total time reasonable.
+
+The review covers:
+- Baseline: correctness, security, error handling, performance, naming, test coverage
+- Codebase-specific: read the target repo's CLAUDE.md for any `## Code Review`, `## Standards`, or `## Gotchas` sections
+
+Each review produces:
+```
+[owner/repo #N] Code Review
+MUST FIX: <issue> — file:line
+SUGGESTION: <issue>
+CLEAN — no blocking issues
+```
+
+After review, re-classify:
+- No MUST FIX items → move to `MERGE_READY` (if CI also passing)
+- Has MUST FIX items → move to `BLOCKED` (with review notes)
+
+---
+
+## Step 5: Act
+
+Work through categories in this order:
+
+### MERGE_READY → Merge
+
+```bash
+gh pr merge <number> --repo <owner/repo> --squash --delete-branch
+```
+
+### BEHIND_BASE → Rebase
+
+```bash
+gh pr checkout <number> --repo <owner/repo>
+BASE=$(gh pr view <number> --repo <owner/repo> --json baseRefName --jq '.baseRefName')
+git fetch origin $BASE
+git rebase origin/$BASE
+git push --force-with-lease
+```
+
+Then re-check CI. If CI passes and no other blockers → merge. If CI fails → reclassify as `CI_FAILING`.
+
+### CI_FAILING → Attempt Quick Fix
+
+1. Read the failure output: `gh run view --log-failed --repo <owner/repo>`
+2. **Quick fix** (lint, format, import, typo): check out the PR branch, fix, commit, push
+3. **Complex failure**: flag it — don't attempt a fix. Note it in the report.
+
+### PENDING_CI → Wait and Recheck Once
+
+Poll using `--watch` with a timeout, then check the result:
+```bash
+gh pr checks <number> --repo <owner/repo> --watch --fail-fast
+```
+
+If still pending or if the command times out, leave as-is and flag in the report.
+
+### CHANGES_REQUESTED / CONFLICTING / BLOCKED → Flag Only
+
+These require human judgment. Note them clearly in the report — no auto-action.
+
+---
+
+## Step 6: Final Report
+
+After all actions complete, produce a full report:
+
+```
+PR Sweep Complete
+══════════════════════════════════════════════════════════════
+MERGED (2)
+  ✓ owner/repo #42  feat: add caching layer
+  ✓ owner/repo #38  fix: auth token refresh — reviewed, no blockers
+
+REBASED (1)
+  ↺ other/repo #11  refactor: split service — rebased on main, CI running
+
+FIXED & MERGED (1)
+  ✓ other/repo #9   feat: new export format — lint fix applied, merged
+
+NEEDS YOUR ATTENTION (2)
+  ✗ repo #7   fix: race condition — CHANGES_REQUESTED by @alice
+      Action needed: address review feedback
+
+  ✗ repo #5   feat: dashboard — CI failing (complex: flaky integration test)
+      Action needed: investigate test flakiness before merging
+
+CODE REVIEW FINDINGS
+  repo #38 — SUGGESTION: consider extracting token refresh logic to a helper
+══════════════════════════════════════════════════════════════
+Merged: 3  |  Pending: 1  |  Needs attention: 2
+```
+
+Surface suggestions from code reviews in the report even if they weren't blocking — they may inform follow-up work.
+
+---
+
+## Rules
+
+**Never:**
+- Act on draft PRs
+- Force-push to main/master
+- Merge with failing CI
+- Attempt to auto-resolve CHANGES_REQUESTED — that's a human conversation
+
+**Always:**
+- Triage and show the table before taking any action
+- Squash merge
+- Parallelize code review subagents when multiple PRs need review
+- Clean up PR branches after merge (`--delete-branch`)
+
+---
+
+## Future: Pairing with Loop
+
+This skill is designed to work with `/loop` for ongoing PR babysitting:
+
+```
+/loop 30m /pull-request-sweep
+```
+
+This is not yet recommended due to token costs, but the skill is designed to be idempotent — running it multiple times is safe. Already-merged PRs won't appear in the next sweep.

--- a/plugins/ship-pr/.claude-plugin/plugin.json
+++ b/plugins/ship-pr/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "ship-pr",
+  "description": "End-of-task workflow: run tests, open a PR, code review, fix CI, sync base, then squash merge",
+  "version": "0.1.0",
+  "requires": {
+    "env": [
+      {
+        "name": "GH_TOKEN",
+        "description": "GitHub personal access token — used by gh CLI for PR creation, CI status checks, and merging",
+        "required": true,
+        "sensitive": true,
+        "when": "All ship-pr operations require GitHub access"
+      }
+    ]
+  }
+}

--- a/plugins/ship-pr/skills/ship-pr/README.md
+++ b/plugins/ship-pr/skills/ship-pr/README.md
@@ -1,0 +1,36 @@
+# ship-pr
+
+End-of-task shipping workflow — open a PR, code review, fix CI, and squash merge.
+
+## Usage
+
+```
+/plugin install ship-pr@harness-kit
+```
+
+Then, when you're done with a feature:
+
+```
+/ship-pr
+```
+
+Or tell Claude you're ready:
+
+> "I'm done with this feature, let's ship it."
+> "Wrap this up and open a PR."
+
+## What It Does
+
+1. Runs local tests
+2. Creates a PR with a structured description (summary, test plan)
+3. Runs a code review via subagent — flags MUST FIX issues before proceeding
+4. Checks CI — attempts quick fixes (lint, format, typos) if failing
+5. Verifies the branch is up-to-date with base
+6. Confirms with you, then squash merges and cleans up the branch
+
+## Notes
+
+- Requires the `gh` CLI (`brew install gh`, then `gh auth login`)
+- Uses the `review` skill for code review — install it alongside this plugin
+- Skips drafts — draft PRs are not shipped
+- "Just ship it" mode available if you want to skip the confirmation gate

--- a/plugins/ship-pr/skills/ship-pr/SKILL.md
+++ b/plugins/ship-pr/skills/ship-pr/SKILL.md
@@ -104,7 +104,7 @@ Leave `--reviewer` and `--assignee` unset.
 
 ## Step 4: Code Review
 
-Invoke the `superpowers:code-reviewer` skill (use the Skill tool) to review all changes in this PR.
+Invoke the `review` skill (use the Skill tool) to review all changes in this PR.
 
 The review should cover:
 - **Baseline:** correctness, security, error handling, performance, naming clarity
@@ -204,7 +204,7 @@ Report: "PR merged. Branch cleaned up. Done."
 | 1. Local tests | Run test suite | Yes — fix first |
 | 2. PR check | Exists? | Skip to review |
 | 3. Create PR | Push + `gh pr create` | — |
-| 4. Code review | `superpowers:code-reviewer` | Yes for MUST FIX |
+| 4. Code review | `review` skill | Yes for MUST FIX |
 | 5. CI | `gh pr checks` | Yes — fix or plan |
 | 6. Base sync | Rebase if behind | Yes — resolve conflicts |
 | 7. Merge | `gh pr merge --squash` | — |

--- a/plugins/ship-pr/skills/ship-pr/SKILL.md
+++ b/plugins/ship-pr/skills/ship-pr/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: ship-pr
+description: Use when wrapping up a development task and ready to ship — runs local tests, creates a PR (if one doesn't exist) with a structured description template, conducts a code review via subagent, checks CI status and attempts quick fixes if failing, verifies the branch is up-to-date with base, then squash merges and cleans up. Trigger when the user says they're done with a feature, want to ship, wrap up, open a PR, finalize their work, or merge their branch. Also invoke proactively after completing all tasks in an implementation plan.
+---
+
+# Ship PR
+
+A structured end-of-task workflow: create PR → code review → CI → base sync → squash merge.
+
+**Announce at start:** "I'm using the ship-pr skill to wrap up this work."
+
+---
+
+## Step 1: Pre-flight — Run Local Tests
+
+Run the test suite before touching anything else. Detect the right command from project files:
+
+| Indicator | Command |
+|-----------|---------|
+| CLAUDE.md test command | Use that (takes precedence over all below) |
+| `go.mod` | `go test ./...` |
+| `package.json` | `npm test` or `yarn test` |
+| `pyproject.toml` / `setup.py` | `pytest` |
+| `Cargo.toml` | `cargo test` |
+
+If **tests fail:** Stop. Show the failures clearly. Don't proceed — fix them or ask the user how to handle. Do not skip or bypass test hooks.
+
+If **tests pass:** Continue.
+
+---
+
+## Step 2: Check for Existing PR
+
+```bash
+gh pr view --json number,url,state 2>/dev/null
+```
+
+- **PR already open:** Skip to [Step 4 — Code Review](#step-4-code-review).
+- **No PR:** Continue to Step 3.
+
+---
+
+## Step 3: Create the PR
+
+### Push the branch
+
+```bash
+git push -u origin $(git branch --show-current)
+```
+
+### Title
+
+Use the most meaningful commit message as a starting point, cleaned up to be concise. Follow conventional commit format (`feat:`, `fix:`, `refactor:`, etc.) if the repo uses it — check recent commits with `git log --oneline -10`.
+
+### Auto-detect labels
+
+Infer labels from the branch name and commits — apply with `--label` if the label exists in the repo:
+
+| Pattern | Label |
+|---------|-------|
+| `fix/`, `bug/`, "fix" in commits | `bug` |
+| `feat/`, `feature/` | `enhancement` |
+| `refactor/`, `chore/` | `refactor` |
+| `docs/` | `documentation` |
+
+Skip labels that don't exist in the repo rather than erroring.
+
+### PR description template
+
+Fill in every section based on the actual changes — no unfilled placeholders:
+
+```
+## Summary
+<!-- What this PR does and why — 2-4 sentences. Lead with intent, not implementation. -->
+
+## Changes
+<!-- Key changes. Be specific — not "updated code" but what and why. -->
+-
+
+## Test Plan
+<!-- How this was verified -->
+- [ ] Local tests pass
+- [ ] CI checks pass
+- [ ] <any manual or integration steps>
+
+## Notes
+<!-- Edge cases, follow-ups, known limitations, or anything a reviewer should know -->
+```
+
+### Create
+
+```bash
+gh pr create \
+  --title "<title>" \
+  --body "$(cat <<'EOF'
+<filled-template>
+EOF
+)"
+```
+
+Leave `--reviewer` and `--assignee` unset.
+
+---
+
+## Step 4: Code Review
+
+Invoke the `superpowers:code-reviewer` skill (use the Skill tool) to review all changes in this PR.
+
+The review should cover:
+- **Baseline:** correctness, security, error handling, performance, naming clarity
+- **Test coverage:** flag any new functionality that lacks tests
+- **Codebase-specific:** scan CLAUDE.md for any `## Code Review`, `## Standards`, or `## Gotchas` sections and incorporate those requirements
+
+After the review, present a clear report:
+
+```
+Code Review Report
+──────────────────
+[MUST FIX] <issue> — <file>:<line>
+[SUGGESTION] <issue>
+No blocking issues found.
+```
+
+**If MUST FIX items:** Address them, commit, push. Once resolved, continue to Step 5.
+
+**If only suggestions:** Note them for the user to follow up post-merge at their discretion.
+
+---
+
+## Step 5: CI Status
+
+```bash
+gh pr checks
+```
+
+**All passing:** Continue.
+
+**Failing:**
+1. Read the failure output — identify root cause
+2. **Quick fix** (lint, formatting, import, typo): Fix it, commit, push, wait for CI to rerun, then continue
+3. **Complex failure** (logic error, architecture issue, flaky infra): Stop and report clearly:
+   > "CI is failing due to [X]. This needs a dedicated fix before merging — let's plan it out."
+
+Never merge with failing CI.
+
+---
+
+## Step 6: Base Branch Sync
+
+Check whether the base branch has moved since branching:
+
+```bash
+BASE=$(gh pr view --json baseRefName --jq '.baseRefName')
+git fetch origin $BASE
+git log HEAD..origin/$BASE --oneline
+```
+
+**New commits exist:** Rebase and force-push:
+
+```bash
+git rebase origin/$BASE
+git push --force-with-lease
+```
+
+If rebase has conflicts, resolve them, then `git rebase --continue`.
+
+**No new commits:** Skip.
+
+---
+
+## Step 7: Confirm and Squash Merge
+
+Before merging, confirm with the user unless they've already said to proceed automatically:
+
+```
+Ready to squash merge PR #<N> ("<title>") into <base>.
+All checks passed. Proceed?
+```
+
+Wait for confirmation. If the user says to always proceed without asking (e.g. "just ship it", "auto-merge", "no need to confirm"), skip this prompt for the rest of the session.
+
+Once confirmed:
+
+```bash
+gh pr merge --squash --delete-branch
+```
+
+After merge, sync locally:
+
+```bash
+git checkout $BASE
+git pull
+git branch -d <feature-branch> 2>/dev/null || true
+```
+
+Report: "PR merged. Branch cleaned up. Done."
+
+---
+
+## Quick Reference
+
+| Step | Action | Block on failure? |
+|------|--------|-------------------|
+| 1. Local tests | Run test suite | Yes — fix first |
+| 2. PR check | Exists? | Skip to review |
+| 3. Create PR | Push + `gh pr create` | — |
+| 4. Code review | `superpowers:code-reviewer` | Yes for MUST FIX |
+| 5. CI | `gh pr checks` | Yes — fix or plan |
+| 6. Base sync | Rebase if behind | Yes — resolve conflicts |
+| 7. Merge | `gh pr merge --squash` | — |
+
+## Rules
+
+**Never:**
+- Merge with failing CI
+- Force-push to main/master
+- Use `--no-verify` to bypass hooks
+- Leave PR template sections unfilled
+- Set reviewer or assignee
+
+**Always:**
+- Squash merge
+- Delete the branch after merge
+- Address MUST FIX review items before merging


### PR DESCRIPTION
## Summary

Adds two new PR workflow skills to harness-kit:

- **ship-pr** — end-of-task workflow: runs local tests, creates a PR with a structured template (auto-detects labels from branch name), conducts a code review via `superpowers:code-reviewer` subagent, checks CI and attempts quick fixes on failures, syncs with the base branch, confirms with the user, then squash merges and cleans up
- **pull-request-sweep** — cross-repo sweep: discovers all open PRs via `gh search prs`, triages by status (MERGE_READY / NEEDS_REVIEW / BEHIND_BASE / CI_FAILING / CHANGES_REQUESTED / etc.), dispatches parallel code review subagents for unreviewed PRs, acts on what it can, and produces a full status report

## Changes

- `plugins/ship-pr/skills/ship-pr/SKILL.md` — 7-step ship workflow with merge confirmation gate
- `plugins/pull-request-sweep/skills/pull-request-sweep/SKILL.md` — cross-repo triage + act sweep, shows plan before taking any action

## Test Plan

- [ ] `ship-pr` triggers when user says they're done with a feature / ready to merge
- [ ] `pull-request-sweep` triggers on "check my PRs", "PR sweep", "babysit PRs"
- [ ] Both skills follow the `plugins/<name>/skills/<name>/SKILL.md` structure
- [ ] No reviewer or assignee set (by design)

## Notes

Both skills depend on `gh` CLI being authenticated and `superpowers:code-reviewer` being available in the user's skill set. The `pull-request-sweep` Future section documents `/loop` pairing as a planned enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)