### PR TITLE
feat: docs visual upgrade

### DIFF
--- a/website/app/docs/[[...slug]]/page.tsx
+++ b/website/app/docs/[[...slug]]/page.tsx
@@ -7,6 +7,21 @@ import {
 } from 'fumadocs-ui/page';
 import { notFound } from 'next/navigation';
 import defaultMdxComponents from 'fumadocs-ui/mdx';
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+import { Callout } from 'fumadocs-ui/components/callout';
+import { Step, Steps } from 'fumadocs-ui/components/steps';
+import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
+
+const mdxComponents = {
+  ...defaultMdxComponents,
+  Tab,
+  Tabs,
+  Callout,
+  Step,
+  Steps,
+  Accordion,
+  Accordions,
+};
 
 export default async function Page(props: {
   params: Promise<{ slug?: string[] }>;
@@ -22,7 +37,7 @@ export default async function Page(props: {
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
       <DocsBody>
-        <MDX components={{ ...defaultMdxComponents }} />
+        <MDX components={mdxComponents} />
       </DocsBody>
     </DocsPage>
   );

--- a/website/app/docs/layout.tsx
+++ b/website/app/docs/layout.tsx
@@ -27,7 +27,7 @@ export default function Layout({ children }: { children: ReactNode }) {
                 hk
               </text>
             </svg>
-            Harness Kit
+            <span className="font-display">Harness Kit</span>
           </span>
         ),
       }}

--- a/website/app/global.css
+++ b/website/app/global.css
@@ -28,6 +28,7 @@ body {
   --color-fd-secondary: 240 8% 95%;
   --color-fd-secondary-foreground: 230 15% 10%;
   --color-fd-ring: 256 80% 58%;
+  --fd-layout-width: 1400px;
 }
 
 /* ── Dark theme — deep, blue-tinted ── */
@@ -75,6 +76,9 @@ body {
 
 .glass {
   backdrop-filter: blur(12px);
+  background: hsla(230, 15%, 92%, 0.7);
+}
+.dark .glass {
   background: hsla(230, 15%, 8%, 0.7);
 }
 
@@ -94,18 +98,20 @@ body {
   animation: fadeInUp 0.5s ease-out both;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-in {
+    animation: none;
+  }
+}
+
 /* ── Heading typography ── */
 h1, h2, h3 {
   letter-spacing: -0.03em;
 }
 
-/* ── Docs layout width ── */
-:root {
-  --fd-layout-width: 1400px;
-}
-
 /* ── Nav bar gradient border ── */
 .dark [data-fumadocs-nav] {
+  position: relative;
   border-bottom: none;
   background: hsla(230, 15%, 4%, 0.85);
   backdrop-filter: blur(16px);

--- a/website/app/global.css
+++ b/website/app/global.css
@@ -1,40 +1,174 @@
 @import 'tailwindcss';
 @import 'fumadocs-ui/style.css';
 
+/* ── Font system ── */
+body {
+  font-family: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
+}
+
+.font-display {
+  font-family: var(--font-display), ui-sans-serif, system-ui, sans-serif;
+}
+
+/* ── Light theme ── */
 :root {
   --color-fd-primary: 256 80% 58%;
   --color-fd-primary-foreground: 0 0% 100%;
-  --color-fd-background: 0 0% 100%;
-  --color-fd-foreground: 240 10% 10%;
-  --color-fd-card: 240 5% 96%;
-  --color-fd-card-foreground: 240 10% 10%;
-  --color-fd-muted: 240 5% 92%;
-  --color-fd-muted-foreground: 240 4% 46%;
-  --color-fd-border: 240 6% 90%;
-  --color-fd-accent: 256 60% 95%;
+  --color-fd-background: 240 20% 99%;
+  --color-fd-foreground: 230 15% 10%;
+  --color-fd-card: 240 10% 96%;
+  --color-fd-card-foreground: 230 15% 10%;
+  --color-fd-muted: 240 8% 93%;
+  --color-fd-muted-foreground: 230 8% 42%;
+  --color-fd-border: 240 8% 88%;
+  --color-fd-accent: 256 60% 96%;
   --color-fd-accent-foreground: 256 80% 44%;
   --color-fd-popover: 0 0% 100%;
-  --color-fd-popover-foreground: 240 10% 10%;
-  --color-fd-secondary: 240 5% 94%;
-  --color-fd-secondary-foreground: 240 10% 10%;
+  --color-fd-popover-foreground: 230 15% 10%;
+  --color-fd-secondary: 240 8% 95%;
+  --color-fd-secondary-foreground: 230 15% 10%;
   --color-fd-ring: 256 80% 58%;
 }
 
+/* ── Dark theme — deep, blue-tinted ── */
 .dark {
-  --color-fd-primary: 256 80% 72%;
+  --color-fd-primary: 256 85% 72%;
   --color-fd-primary-foreground: 0 0% 100%;
-  --color-fd-background: 240 10% 4%;
+  --color-fd-background: 230 15% 4%;
   --color-fd-foreground: 0 0% 93%;
-  --color-fd-card: 240 6% 8%;
+  --color-fd-card: 230 10% 7%;
   --color-fd-card-foreground: 0 0% 93%;
-  --color-fd-muted: 240 4% 14%;
-  --color-fd-muted-foreground: 240 4% 58%;
-  --color-fd-border: 240 4% 16%;
+  --color-fd-muted: 230 8% 13%;
+  --color-fd-muted-foreground: 230 6% 55%;
+  --color-fd-border: 230 15% 14%;
   --color-fd-accent: 256 30% 14%;
   --color-fd-accent-foreground: 256 60% 80%;
-  --color-fd-popover: 240 6% 6%;
+  --color-fd-popover: 230 10% 6%;
   --color-fd-popover-foreground: 0 0% 93%;
-  --color-fd-secondary: 240 4% 12%;
+  --color-fd-secondary: 230 8% 10%;
   --color-fd-secondary-foreground: 0 0% 93%;
-  --color-fd-ring: 256 80% 72%;
+  --color-fd-ring: 256 85% 72%;
+}
+
+/* ── Utility classes ── */
+.glow-purple {
+  box-shadow: 0 0 40px -10px hsla(256, 80%, 60%, 0.3);
+}
+
+.gradient-border {
+  border: 1px solid transparent;
+  background-clip: padding-box;
+  position: relative;
+}
+.gradient-border::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1px;
+  background: linear-gradient(164deg, rgba(255,255,255,0.1), rgba(255,255,255,0.02));
+  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
+}
+
+.glass {
+  backdrop-filter: blur(12px);
+  background: hsla(230, 15%, 8%, 0.7);
+}
+
+/* ── Page fade-in ── */
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-fade-in {
+  animation: fadeInUp 0.5s ease-out both;
+}
+
+/* ── Heading typography ── */
+h1, h2, h3 {
+  letter-spacing: -0.03em;
+}
+
+/* ── Docs layout width ── */
+:root {
+  --fd-layout-width: 1400px;
+}
+
+/* ── Nav bar gradient border ── */
+.dark [data-fumadocs-nav] {
+  border-bottom: none;
+  background: hsla(230, 15%, 4%, 0.85);
+  backdrop-filter: blur(16px);
+}
+.dark [data-fumadocs-nav]::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, hsla(256, 85%, 72%, 0.2), transparent);
+}
+
+/* ── Sidebar active item ── */
+.dark [data-fumadocs-sidebar] [aria-current="page"],
+.dark [data-fumadocs-sidebar] [data-active="true"] {
+  border-left: 2px solid hsl(256, 85%, 72%);
+  background: hsla(256, 30%, 14%, 0.5);
+  padding-left: 10px;
+}
+
+/* ── TOC active item ── */
+.dark [data-fumadocs-toc] [data-active="true"] {
+  color: hsl(256, 85%, 72%);
+}
+
+/* ── Code blocks ── */
+.dark pre {
+  background: hsl(230, 12%, 6%) !important;
+  border: 1px solid hsla(230, 15%, 20%, 0.3);
+  border-radius: 0.75rem;
+}
+
+/* ── Blockquotes as callouts ── */
+.dark blockquote {
+  border-left: 3px solid hsl(256, 85%, 72%);
+  background: hsla(256, 20%, 12%, 0.3);
+  border-radius: 0 0.5rem 0.5rem 0;
+  padding: 0.75rem 1rem;
+}
+
+/* ── Tables ── */
+.dark table {
+  border: 1px solid hsla(230, 15%, 20%, 0.3);
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+.dark table thead {
+  background: hsla(230, 10%, 10%, 0.8);
+}
+.dark table tbody tr:nth-child(even) {
+  background: hsla(230, 10%, 8%, 0.5);
+}
+.dark table td,
+.dark table th {
+  border-color: hsla(230, 15%, 20%, 0.2);
+}
+
+/* ── Docs headings — display font ── */
+.dark [data-fumadocs-body] h1,
+.dark [data-fumadocs-body] h2,
+.dark [data-fumadocs-body] h3 {
+  font-family: var(--font-display), ui-sans-serif, system-ui, sans-serif;
+  letter-spacing: -0.03em;
 }

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -1,6 +1,17 @@
 import './global.css';
 import { RootProvider } from 'fumadocs-ui/provider';
+import { Inter, Space_Grotesk } from 'next/font/google';
 import type { ReactNode } from 'react';
+
+const inter = Inter({
+  subsets: ['latin'],
+  variable: '--font-inter',
+});
+
+const spaceGrotesk = Space_Grotesk({
+  subsets: ['latin'],
+  variable: '--font-display',
+});
 
 export const metadata = {
   title: {
@@ -12,13 +23,12 @@ export const metadata = {
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" suppressHydrationWarning>
-      <body
-        style={{
-          fontFamily:
-            '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif',
-        }}
-      >
+    <html
+      lang="en"
+      className={`${inter.variable} ${spaceGrotesk.variable}`}
+      suppressHydrationWarning
+    >
+      <body className="font-sans antialiased">
         <RootProvider
           theme={{
             defaultTheme: 'dark',

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 
 /* ── Lucide SVG icons (inline, no package needed) ── */
 const DownloadIcon = () => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
     <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
     <polyline points="7 10 12 15 17 10" />
     <line x1="12" y1="15" x2="12" y2="3" />
@@ -10,7 +10,7 @@ const DownloadIcon = () => (
 );
 
 const WorkflowIcon = () => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
     <rect x="3" y="3" width="8" height="8" rx="2" />
     <path d="M7 11v4a2 2 0 0 0 2 2h4" />
     <rect x="13" y="13" width="8" height="8" rx="2" />
@@ -18,7 +18,7 @@ const WorkflowIcon = () => (
 );
 
 const ShareIcon = () => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
     <circle cx="18" cy="5" r="3" />
     <circle cx="6" cy="12" r="3" />
     <circle cx="18" cy="19" r="3" />

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -1,23 +1,50 @@
 import Link from 'next/link';
 
+/* ── Lucide SVG icons (inline, no package needed) ── */
+const DownloadIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+    <polyline points="7 10 12 15 17 10" />
+    <line x1="12" y1="15" x2="12" y2="3" />
+  </svg>
+);
+
+const WorkflowIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="3" y="3" width="8" height="8" rx="2" />
+    <path d="M7 11v4a2 2 0 0 0 2 2h4" />
+    <rect x="13" y="13" width="8" height="8" rx="2" />
+  </svg>
+);
+
+const ShareIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="18" cy="5" r="3" />
+    <circle cx="6" cy="12" r="3" />
+    <circle cx="18" cy="19" r="3" />
+    <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+    <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+  </svg>
+);
+
 const features = [
   {
     title: 'Install once, use everywhere',
     description:
       'Install by name. Plugins follow you across every project without manual setup.',
-    icon: '→',
+    icon: <DownloadIcon />,
   },
   {
     title: 'More than prompts',
     description:
       'Each plugin encodes a complete workflow — what to gather, how to analyze it, what to produce.',
-    icon: '◈',
+    icon: <WorkflowIcon />,
   },
   {
     title: 'Share your setup',
     description:
       "Export your full setup as a harness.yaml. Share it with a teammate and they're running the same workflows.",
-    icon: '⇄',
+    icon: <ShareIcon />,
   },
 ];
 
@@ -71,33 +98,29 @@ const heroCards = [
     title: 'Getting Started',
     description: 'Install your first plugin in under a minute.',
     href: '/docs/getting-started/installation',
-    gradient: 'from-violet-500/20 to-purple-600/20',
   },
   {
     title: 'Browse Plugins',
     description: '7 plugins shipping today. Each packages a proven workflow.',
     href: '/docs/plugins/overview',
-    gradient: 'from-purple-500/20 to-indigo-600/20',
   },
   {
     title: 'Architecture',
     description: 'How skills, plugins, and the registry fit together.',
     href: '/docs/concepts/architecture',
-    gradient: 'from-indigo-500/20 to-blue-600/20',
   },
   {
     title: 'Cross-Harness',
     description: 'One config, every tool. Designed for portability across Claude Code, Copilot, Cursor, and more.',
     href: '/docs/cross-harness/setup-guide',
-    gradient: 'from-blue-500/20 to-cyan-600/20',
   },
 ];
 
 export default function HomePage() {
   return (
-    <main className="min-h-screen">
+    <main className="min-h-screen animate-fade-in">
       {/* Nav */}
-      <nav className="sticky top-0 z-50 border-b border-fd-border/50 bg-fd-background/80 backdrop-blur-xl">
+      <nav className="sticky top-0 z-50 border-b border-fd-border/30 bg-fd-background/80 backdrop-blur-xl">
         <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
           <Link href="/" className="flex items-center gap-2.5 font-bold text-fd-foreground no-underline">
             <svg
@@ -118,7 +141,7 @@ export default function HomePage() {
                 hk
               </text>
             </svg>
-            Harness Kit
+            <span className="font-display">Harness Kit</span>
           </Link>
           <div className="flex items-center gap-6 text-sm">
             <Link
@@ -147,32 +170,44 @@ export default function HomePage() {
 
       {/* Hero */}
       <section className="relative overflow-hidden">
+        {/* Ambient glow orb */}
+        <div className="pointer-events-none absolute left-1/2 top-0 -translate-x-1/2 -translate-y-1/4">
+          <div className="h-[500px] w-[700px] rounded-full bg-purple-500/15 blur-[120px]" />
+        </div>
         <div className="absolute inset-0 bg-gradient-to-b from-violet-500/5 via-transparent to-transparent" />
-        <div className="relative mx-auto max-w-4xl px-6 pb-16 pt-24 text-center">
-          <h1 className="mb-4 text-5xl font-bold tracking-tight text-fd-foreground sm:text-6xl">
+
+        <div className="relative mx-auto max-w-4xl px-6 pb-16 pt-28 text-center">
+          <h1 className="font-display mb-5 text-5xl font-bold tracking-tight text-fd-foreground sm:text-6xl lg:text-7xl">
             Your harness,{' '}
             <span className="bg-gradient-to-r from-violet-400 to-purple-500 bg-clip-text text-transparent">
               everywhere
             </span>
           </h1>
-          <p className="mx-auto mb-8 max-w-2xl text-lg text-fd-muted-foreground">
+          <p className="mx-auto mb-10 max-w-2xl text-lg leading-relaxed text-fd-muted-foreground">
             The configuration framework for AI coding tools.
             Install workflows by name, share your setup across teams and machines,
             and never rebuild from scratch again.
           </p>
-          <div className="mb-6 inline-block rounded-lg border border-fd-border bg-fd-card px-5 py-3 font-mono text-sm text-fd-foreground">
-            /plugin marketplace add harnessprotocol/harness-kit
+
+          {/* Command box with gradient border */}
+          <div className="relative mx-auto mb-8 inline-block">
+            <div className="absolute -inset-[1px] rounded-xl bg-gradient-to-r from-violet-500/30 via-purple-500/20 to-indigo-500/30 blur-[1px]" />
+            <div className="relative rounded-xl border border-white/5 bg-fd-card px-6 py-3.5 font-mono text-sm text-fd-foreground">
+              <span className="text-fd-muted-foreground">$</span>{' '}
+              /plugin marketplace add harnessprotocol/harness-kit
+            </div>
           </div>
+
           <div className="flex flex-wrap items-center justify-center gap-3">
             <Link
               href="/docs/getting-started/installation"
-              className="rounded-lg bg-violet-500 px-5 py-2.5 text-sm font-medium text-white no-underline transition-colors hover:bg-violet-600"
+              className="rounded-lg bg-violet-500 px-6 py-2.5 text-sm font-medium text-white no-underline shadow-lg shadow-violet-500/20 transition-all hover:bg-violet-600 hover:shadow-violet-500/30"
             >
               Get Started
             </Link>
             <Link
               href="/docs/plugins/overview"
-              className="rounded-lg border border-fd-border bg-fd-card px-5 py-2.5 text-sm font-medium text-fd-foreground no-underline transition-colors hover:border-fd-primary/50 hover:bg-fd-accent"
+              className="glass rounded-lg border border-white/10 px-6 py-2.5 text-sm font-medium text-fd-foreground no-underline transition-all hover:border-fd-primary/40 hover:bg-fd-accent/50"
             >
               Browse Plugins
             </Link>
@@ -180,27 +215,26 @@ export default function HomePage() {
         </div>
       </section>
 
-      {/* Hero Cards — Supermemory-inspired grid */}
-      <section className="mx-auto max-w-5xl px-6 pb-20">
+      {/* Hero Cards */}
+      <section className="mx-auto max-w-5xl px-6 pb-24">
         <div className="grid gap-4 sm:grid-cols-2">
           {heroCards.map((card) => (
             <Link
               key={card.title}
               href={card.href}
-              className="group relative overflow-hidden rounded-xl border border-fd-border bg-fd-card p-6 no-underline transition-all hover:border-fd-primary/40 hover:shadow-lg hover:shadow-violet-500/5"
+              className="group relative overflow-hidden rounded-xl border border-fd-border/50 bg-fd-card/80 p-6 no-underline backdrop-blur-sm transition-all duration-300 hover:border-fd-primary/30 hover:shadow-lg hover:shadow-violet-500/10"
             >
-              <div
-                className={`absolute inset-0 bg-gradient-to-br ${card.gradient} opacity-0 transition-opacity group-hover:opacity-100`}
-              />
+              {/* Gradient border overlay */}
+              <div className="pointer-events-none absolute inset-0 rounded-xl opacity-0 transition-opacity duration-300 group-hover:opacity-100" style={{ background: 'linear-gradient(164deg, rgba(139,122,255,0.08), transparent 60%)' }} />
               <div className="relative">
-                <h3 className="mb-2 text-lg font-semibold text-fd-foreground">
+                <h3 className="font-display mb-2 text-lg font-semibold text-fd-foreground">
                   {card.title}
                 </h3>
-                <p className="text-sm text-fd-muted-foreground">
+                <p className="text-sm leading-relaxed text-fd-muted-foreground">
                   {card.description}
                 </p>
               </div>
-              <div className="relative mt-4 text-sm font-medium text-fd-primary opacity-0 transition-opacity group-hover:opacity-100">
+              <div className="relative mt-4 text-sm font-medium text-fd-primary opacity-0 transition-opacity duration-300 group-hover:opacity-100">
                 Explore →
               </div>
             </Link>
@@ -209,24 +243,26 @@ export default function HomePage() {
       </section>
 
       {/* Features */}
-      <section className="border-t border-fd-border bg-fd-card/50">
-        <div className="mx-auto max-w-5xl px-6 py-20">
-          <h2 className="mb-2 text-center text-3xl font-bold text-fd-foreground">
+      <section className="relative border-t border-fd-border/30 bg-fd-card/30">
+        {/* Subtle radial gradient background */}
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_center,hsla(256,80%,60%,0.04),transparent_70%)]" />
+        <div className="relative mx-auto max-w-5xl px-6 py-24">
+          <h2 className="font-display mb-2 text-center text-3xl font-bold text-fd-foreground">
             How it works
           </h2>
-          <p className="mb-12 text-center text-fd-muted-foreground">
+          <p className="mb-14 text-center text-fd-muted-foreground">
             Install a plugin, invoke a command, get a repeatable workflow.
           </p>
           <div className="grid gap-6 sm:grid-cols-3">
             {features.map((f) => (
               <div
                 key={f.title}
-                className="rounded-xl border border-fd-border bg-fd-background p-6"
+                className="rounded-xl border border-fd-border/50 bg-fd-background/80 p-6 backdrop-blur-sm transition-all duration-300 hover:border-fd-primary/20 hover:shadow-lg hover:shadow-violet-500/5"
               >
-                <div className="mb-4 flex size-10 items-center justify-center rounded-lg bg-fd-accent text-lg text-fd-primary">
+                <div className="mb-4 flex size-10 items-center justify-center rounded-lg bg-fd-accent text-fd-primary">
                   {f.icon}
                 </div>
-                <h3 className="mb-2 font-semibold text-fd-foreground">
+                <h3 className="font-display mb-2 font-semibold text-fd-foreground">
                   {f.title}
                 </h3>
                 <p className="text-sm leading-relaxed text-fd-muted-foreground">
@@ -235,7 +271,7 @@ export default function HomePage() {
               </div>
             ))}
           </div>
-          <p className="mt-10 text-center text-sm text-fd-muted-foreground">
+          <p className="mt-12 text-center text-sm text-fd-muted-foreground">
             harness-kit is the reference implementation of the{' '}
             <a
               href="https://harnessprotocol.ai"
@@ -251,11 +287,11 @@ export default function HomePage() {
       </section>
 
       {/* Plugin showcase */}
-      <section className="mx-auto max-w-5xl px-6 py-20">
-        <h2 className="mb-2 text-center text-3xl font-bold text-fd-foreground">
+      <section className="mx-auto max-w-5xl px-6 py-24">
+        <h2 className="font-display mb-2 text-center text-3xl font-bold text-fd-foreground">
           7 plugins
         </h2>
-        <p className="mb-12 text-center text-fd-muted-foreground">
+        <p className="mb-14 text-center text-fd-muted-foreground">
           Each packages a proven workflow as a portable command.
         </p>
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
@@ -263,9 +299,9 @@ export default function HomePage() {
             <Link
               key={p.name}
               href={p.href}
-              className="group rounded-xl border border-fd-border bg-fd-card p-5 no-underline transition-all hover:border-fd-primary/40 hover:shadow-lg hover:shadow-violet-500/5"
+              className="group rounded-xl border border-fd-border/50 bg-fd-card/80 p-5 no-underline transition-all duration-300 hover:border-fd-primary/30 hover:shadow-lg hover:shadow-violet-500/10"
             >
-              <h4 className="mb-1.5 font-mono text-sm font-semibold text-fd-primary">
+              <h4 className="mb-1.5 font-mono text-sm font-semibold text-fd-primary brightness-110">
                 {p.name}
               </h4>
               <p className="text-sm leading-relaxed text-fd-muted-foreground">
@@ -277,17 +313,83 @@ export default function HomePage() {
       </section>
 
       {/* Footer */}
-      <footer className="border-t border-fd-border">
-        <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-6 text-sm text-fd-muted-foreground">
-          <span>Apache-2.0 License</span>
-          <a
-            href="https://github.com/harnessprotocol/harness-kit"
-            className="text-fd-muted-foreground transition-colors hover:text-fd-foreground no-underline"
-            target="_blank"
-            rel="noreferrer"
-          >
-            GitHub
-          </a>
+      <footer className="relative border-t border-fd-border/30">
+        {/* Top gradient border */}
+        <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-fd-primary/20 to-transparent" />
+        <div className="mx-auto grid max-w-5xl gap-8 px-6 py-12 text-sm sm:grid-cols-3">
+          {/* Brand */}
+          <div>
+            <div className="mb-3 flex items-center gap-2 font-bold text-fd-foreground">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 32 32"
+                className="size-6"
+              >
+                <rect width="32" height="32" rx="6" fill="#0d0d12" />
+                <text
+                  x="16"
+                  y="22"
+                  textAnchor="middle"
+                  fontFamily="system-ui, sans-serif"
+                  fontWeight="700"
+                  fontSize="16"
+                  fill="#8b7aff"
+                >
+                  hk
+                </text>
+              </svg>
+              <span className="font-display">Harness Kit</span>
+            </div>
+            <p className="text-fd-muted-foreground">
+              A harness-agnostic framework for AI coding tools.
+            </p>
+          </div>
+          {/* Links */}
+          <div>
+            <h5 className="mb-3 font-semibold text-fd-foreground">Resources</h5>
+            <ul className="space-y-2 text-fd-muted-foreground">
+              <li>
+                <Link href="/docs" className="transition-colors hover:text-fd-foreground no-underline">
+                  Documentation
+                </Link>
+              </li>
+              <li>
+                <Link href="/docs/plugins/overview" className="transition-colors hover:text-fd-foreground no-underline">
+                  Plugins
+                </Link>
+              </li>
+              <li>
+                <a
+                  href="https://github.com/harnessprotocol/harness-kit"
+                  className="transition-colors hover:text-fd-foreground no-underline"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  GitHub
+                </a>
+              </li>
+            </ul>
+          </div>
+          {/* Legal */}
+          <div>
+            <h5 className="mb-3 font-semibold text-fd-foreground">Legal</h5>
+            <ul className="space-y-2 text-fd-muted-foreground">
+              <li>Apache-2.0 License</li>
+              <li>
+                <a
+                  href="https://harnessprotocol.ai"
+                  className="transition-colors hover:text-fd-foreground no-underline"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Harness Protocol
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div className="border-t border-fd-border/20 px-6 py-4 text-center text-xs text-fd-muted-foreground">
+          © {new Date().getFullYear()} Harness Kit Contributors
         </div>
       </footer>
     </main>

--- a/website/content/docs/getting-started/installation.mdx
+++ b/website/content/docs/getting-started/installation.mdx
@@ -7,8 +7,8 @@ title: Installation
 
 The primary distribution channel is [Claude Code](https://claude.ai/claude-code)'s plugin marketplace. For other tools, see [Using with other tools](#using-with-other-tools) below.
 
-## Plugin Marketplace (Claude Code)
-
+<Tabs items={["Plugin Marketplace", "Install Script"]}>
+<Tab value="Plugin Marketplace">
 Add the marketplace once, then install plugins by name:
 
 ```
@@ -26,9 +26,9 @@ Repeat for any plugin you want:
 /plugin install review@harness-kit
 /plugin install docgen@harness-kit
 ```
+</Tab>
 
-## Fallback: Install Script
-
+<Tab value="Install Script">
 If your Claude Code build doesn't support the plugin marketplace yet:
 
 ```bash
@@ -36,6 +36,8 @@ curl -fsSL https://raw.githubusercontent.com/harnessprotocol/harness-kit/main/in
 ```
 
 This downloads skill files to `~/.claude/skills/` over HTTPS. It installs **only the skill files** — bundled scripts (like the research index rebuilder) require the full marketplace install.
+</Tab>
+</Tabs>
 
 ## Verify
 
@@ -46,7 +48,9 @@ After installing, invoke any skill to confirm it loaded:
 /explain src/main.ts
 ```
 
-If the skill responds with its workflow, you're set.
+<Callout type="success" title="Ready to go">
+  If the skill responds with its workflow, you're set.
+</Callout>
 
 ## Using with other tools
 
@@ -66,4 +70,6 @@ For per-tool setup instructions (Copilot, Cursor, Windsurf, MCP wiring), see [Us
 | review | `gh` CLI (PR review only) |
 | docgen | None |
 
-Some plugins require environment variables for optional features. See the [Secrets Management guide](/docs/guides/secrets-management) for how to configure them.
+<Callout type="warn" title="Environment variables">
+  Some plugins require environment variables for optional features. See the [Secrets Management guide](/docs/guides/secrets-management) for how to configure them.
+</Callout>

--- a/website/content/docs/getting-started/quick-start.mdx
+++ b/website/content/docs/getting-started/quick-start.mdx
@@ -7,21 +7,27 @@ title: Quick Start
 
 Install a plugin and try it in under a minute.
 
-## 1. Add the marketplace
+<Steps>
+<Step>
+### Add the marketplace
 
 ```
 /plugin marketplace add harnessprotocol/harness-kit
 ```
+</Step>
 
-## 2. Install a plugin
+<Step>
+### Install a plugin
 
 Start with `explain` — it works in any codebase with no setup:
 
 ```
 /plugin install explain@harness-kit
 ```
+</Step>
 
-## 3. Use it
+<Step>
+### Use it
 
 Point it at any file in your project:
 
@@ -30,8 +36,14 @@ Point it at any file in your project:
 ```
 
 You'll get a structured breakdown: summary, key components, how it connects, patterns, gotchas, and entry points for change.
+</Step>
+</Steps>
 
 ## Try more plugins
+
+<Callout type="info" title="No configuration needed">
+  All plugins work out of the box. Install and invoke — that's it.
+</Callout>
 
 ### Research a topic
 


### PR DESCRIPTION
## Summary

Visual overhaul of the Fumadocs site — typography, color depth, homepage redesign, docs layout polish, and MDX component registration. Transforms the docs from stock template to polished product page while staying on Fumadocs.

## Changes

- **Typography:** Inter (body) + Space Grotesk (display headings) via `next/font/google`, with CSS variable `--font-display` and tighter letter-spacing
- **Color palette:** Blue-tinted dark theme (`hsl(230, 15%, 4%)`), bumped purple saturation, semi-transparent borders, warmer light theme
- **Homepage:** Ambient purple glow orb, gradient-bordered command box, glassmorphism secondary CTA, SVG Lucide icons replacing Unicode, multi-column footer with gradient top border
- **Docs layout:** Wider content area (1400px), gradient nav border, purple active sidebar indicator, styled code blocks/blockquotes/tables, display font on doc headings
- **MDX components:** Registered `Tabs`, `Tab`, `Callout`, `Steps`, `Step`, `Accordion`, `Accordions`
- **Content:** Quick-start uses `<Steps>` walkthrough, Installation uses `<Tabs>` for marketplace vs. script, `<Callout>` tips on both pages
- **Polish:** Fade-in page animation, `.glass` / `.glow-purple` / `.gradient-border` utility classes

## Test Plan

- [x] `pnpm build` passes (33 pages, 0 errors)
- [ ] CI checks pass
- [ ] Visual review on dev server — homepage, docs pages, both themes, mobile viewport

## Notes

- Content files renamed `.md` → `.mdx` to support JSX component syntax
- `new Date().getFullYear()` in footer renders at build time (static export) — correct for this use case
- No new dependencies added — fonts via `next/font/google`, icons are inline SVG

🤖 Generated with [Claude Code](https://claude.com/claude-code)