### PR TITLE
feat: add usage-stats plugin — Claude Code usage dashboard

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -115,6 +115,16 @@
       "license": "Apache-2.0",
       "category": "devops",
       "tags": ["pull-request", "triage", "ci-cd", "code-review", "multi-repo"]
+    },
+    {
+      "name": "usage-stats",
+      "source": "./usage-stats",
+      "description": "Interactive dashboard for Claude Code usage — tokens, sessions, models, and activity patterns",
+      "version": "0.1.0",
+      "author": { "name": "harnessprotocol" },
+      "license": "Apache-2.0",
+      "category": "productivity",
+      "tags": ["usage", "statistics", "tokens", "sessions", "dashboard", "analytics"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Produces a structured explanation: summary, key components, how it connects, pat
 | [`orient`](plugins/orient/skills/orient/README.md) ¹ | Topic-focused session orientation across graph, knowledge, journal, and research | `/orient auth` |
 | [`capture-session`](plugins/capture-session/skills/capture-session/README.md) ¹ | Capture session information into a staging file for later reflection | `/capture-session` |
 | [`harness-share`](plugins/harness-share/skills/harness-export/README.md) | Export your plugin setup to `harness.yaml`, compile to native configs for Claude Code, Cursor, and Copilot, and keep them in sync | `/harness-export` · `/harness-import` · `/harness-validate` · `/harness-compile` · `/harness-sync` |
+| [`usage-stats`](plugins/usage-stats/skills/usage-stats/README.md) | Interactive HTML dashboard for Claude Code usage — tokens, sessions, models, and activity patterns | `/usage-stats` |
 
 ¹ Personal-workflow plugins designed for projects using the [knowledge graph + journal pattern](docs/claude-md-conventions.md).
 

--- a/plugins/usage-stats/.claude-plugin/plugin.json
+++ b/plugins/usage-stats/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "usage-stats",
+  "description": "Interactive dashboard for Claude Code usage — tokens, sessions, models, and activity patterns",
+  "version": "0.1.0",
+  "category": "productivity",
+  "tags": ["usage", "statistics", "tokens", "sessions", "dashboard", "analytics"]
+}

--- a/plugins/usage-stats/assets/dashboard.html
+++ b/plugins/usage-stats/assets/dashboard.html
@@ -1,0 +1,1403 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="dark">
+  <title>Claude Code Usage Dashboard</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-matrix@2/dist/chartjs-chart-matrix.umd.min.js"></script>
+  <style>
+    :root {
+      --bg: #08080a;
+      --surface: #111114;
+      --surface-hover: #19191e;
+      --border: #1e1e24;
+      --border-subtle: #151518;
+      --accent: #8b5cf6;
+      --accent-dim: rgba(139, 92, 246, 0.15);
+      --accent-glow: rgba(139, 92, 246, 0.25);
+      --text-primary: #e8e8f0;
+      --text-secondary: #6b6b7a;
+      --text-muted: #3a3a45;
+      --glass-bg: rgba(8, 8, 10, 0.85);
+      --glass-border: rgba(255, 255, 255, 0.06);
+      --green: #34d399;
+      --amber: #fbbf24;
+      --blue: #60a5fa;
+      --red: #f87171;
+      --purple-light: #a78bfa;
+    }
+
+    *, *::before, *::after {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      background: var(--bg);
+      color: var(--text-primary);
+      font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif;
+      font-weight: 300;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      line-height: 1.6;
+      min-height: 100vh;
+    }
+
+    body::before {
+      content: '';
+      position: fixed;
+      inset: 0;
+      z-index: 9999;
+      pointer-events: none;
+      opacity: 0.02;
+      background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='300' height='300'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.75' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='300' height='300' filter='url(%23n)' opacity='1'/%3E%3C/svg%3E");
+    }
+
+    .header {
+      position: sticky;
+      top: 0;
+      z-index: 100;
+      background: var(--glass-bg);
+      backdrop-filter: blur(20px);
+      border-bottom: 1px solid var(--glass-border);
+      padding: 16px 32px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .header-title {
+      font-size: 20px;
+      font-weight: 500;
+      letter-spacing: -0.02em;
+      text-shadow: 0 0 30px var(--accent-glow), 0 0 60px rgba(139, 92, 246, 0.1);
+    }
+
+    .header-meta {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+    }
+
+    .header-dates {
+      font-size: 14px;
+      color: var(--text-secondary);
+    }
+
+    .header-generated {
+      font-size: 12px;
+      color: var(--text-muted);
+    }
+
+    .filter-bar {
+      position: sticky;
+      top: 54px;
+      z-index: 99;
+      background: var(--glass-bg);
+      backdrop-filter: blur(20px);
+      border-bottom: 1px solid var(--glass-border);
+      padding: 12px 32px;
+      display: flex;
+      align-items: center;
+      gap: 20px;
+      flex-wrap: wrap;
+    }
+
+    .filter-group {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .filter-label {
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-muted);
+      white-space: nowrap;
+    }
+
+    .filter-date {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      color: var(--text-primary);
+      font-family: inherit;
+      font-size: 13px;
+      font-weight: 300;
+      padding: 6px 10px;
+      outline: none;
+      transition: border-color 0.2s;
+    }
+
+    .filter-date:focus {
+      border-color: var(--accent);
+    }
+
+    .filter-date::-webkit-calendar-picker-indicator {
+      filter: invert(0.5);
+    }
+
+    .pill-group {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+    }
+
+    .pill {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      color: var(--text-secondary);
+      font-family: inherit;
+      font-size: 12px;
+      font-weight: 400;
+      padding: 4px 14px;
+      cursor: pointer;
+      transition: all 0.2s;
+      user-select: none;
+    }
+
+    .pill:hover {
+      background: var(--surface-hover);
+      border-color: var(--accent);
+      color: var(--text-primary);
+    }
+
+    .pill.active {
+      background: var(--accent-dim);
+      border-color: var(--accent);
+      color: var(--accent);
+    }
+
+    .container {
+      max-width: 1400px;
+      margin: 0 auto;
+      padding: 24px 32px 64px;
+    }
+
+    .metric-grid {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 16px;
+      margin-bottom: 24px;
+    }
+
+    @media (max-width: 900px) {
+      .metric-grid {
+        grid-template-columns: repeat(2, 1fr);
+      }
+    }
+
+    @media (max-width: 500px) {
+      .metric-grid {
+        grid-template-columns: 1fr;
+      }
+      .container {
+        padding: 16px;
+      }
+      .header, .filter-bar {
+        padding: 12px 16px;
+      }
+    }
+
+    .card {
+      background: var(--glass-bg);
+      backdrop-filter: blur(20px);
+      border: 1px solid var(--glass-border);
+      border-radius: 16px;
+      padding: 24px;
+    }
+
+    .metric-card {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .metric-label {
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-muted);
+    }
+
+    .metric-value {
+      font-size: 32px;
+      font-weight: 500;
+      letter-spacing: -0.02em;
+      color: var(--text-primary);
+    }
+
+    .metric-sub {
+      font-size: 12px;
+      color: var(--text-secondary);
+    }
+
+    .chart-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 16px;
+      margin-bottom: 24px;
+    }
+
+    @media (max-width: 900px) {
+      .chart-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    .chart-card {
+      min-height: 340px;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .chart-title {
+      font-size: 14px;
+      font-weight: 400;
+      color: var(--text-secondary);
+      margin-bottom: 16px;
+    }
+
+    .chart-wrap {
+      flex: 1;
+      position: relative;
+      min-height: 260px;
+    }
+
+    .section-title {
+      font-size: 16px;
+      font-weight: 400;
+      color: var(--text-secondary);
+      margin-bottom: 12px;
+      margin-top: 8px;
+    }
+
+    .table-wrap {
+      overflow-x: auto;
+      margin-bottom: 24px;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 13px;
+    }
+
+    thead th {
+      text-align: left;
+      padding: 10px 14px;
+      font-size: 11px;
+      font-weight: 500;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--text-muted);
+      border-bottom: 1px solid var(--border);
+      cursor: pointer;
+      user-select: none;
+      white-space: nowrap;
+      transition: color 0.2s;
+    }
+
+    thead th:hover {
+      color: var(--text-secondary);
+    }
+
+    th[data-sort-dir="asc"]::after {
+      content: ' \25B2';
+      color: var(--accent);
+    }
+
+    th[data-sort-dir="desc"]::after {
+      content: ' \25BC';
+      color: var(--accent);
+    }
+
+    tbody tr {
+      border-bottom: 1px solid var(--border-subtle);
+      transition: background 0.15s;
+    }
+
+    tbody tr:nth-child(odd) {
+      background: var(--surface);
+    }
+
+    tbody tr:nth-child(even) {
+      background: var(--bg);
+    }
+
+    tbody tr:hover {
+      background: var(--surface-hover);
+    }
+
+    td {
+      padding: 9px 14px;
+      color: var(--text-secondary);
+    }
+
+    td.num {
+      text-align: right;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .show-all-btn {
+      display: inline-block;
+      margin-top: 8px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      color: var(--text-secondary);
+      font-family: inherit;
+      font-size: 13px;
+      font-weight: 300;
+      padding: 6px 16px;
+      cursor: pointer;
+      transition: all 0.2s;
+    }
+
+    .show-all-btn:hover {
+      border-color: var(--accent);
+      color: var(--text-primary);
+    }
+
+    .footer {
+      text-align: center;
+      padding: 32px;
+      font-size: 12px;
+      color: var(--text-muted);
+    }
+
+    .footer-link {
+      color: var(--text-secondary);
+    }
+
+    .empty-state {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 60vh;
+      text-align: center;
+    }
+
+    .empty-state p {
+      font-size: 16px;
+      color: var(--text-secondary);
+    }
+
+    .empty-state code {
+      background: var(--surface);
+      padding: 2px 8px;
+      border-radius: 4px;
+      font-size: 14px;
+    }
+
+    .doughnut-center {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -55%);
+      text-align: center;
+      pointer-events: none;
+    }
+
+    .doughnut-center .value {
+      font-size: 24px;
+      font-weight: 500;
+      color: var(--text-primary);
+    }
+
+    .doughnut-center .label {
+      font-size: 10px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-muted);
+    }
+
+    .chart-full-width {
+      grid-column: 1 / -1;
+    }
+  </style>
+</head>
+<body>
+  <script>
+    const DASHBOARD_DATA = /*__DASHBOARD_DATA__*/ {} /*__END__*/;
+  </script>
+
+  <div id="app"></div>
+
+  <script>
+    // Formatting helpers
+    function fmt(n) { return n.toLocaleString(); }
+    function fmtTokens(n) {
+      if (n >= 1e9) return (n / 1e9).toFixed(2) + 'B';
+      if (n >= 1e6) return (n / 1e6).toFixed(1) + 'M';
+      if (n >= 1e3) return (n / 1e3).toFixed(1) + 'K';
+      return n.toString();
+    }
+
+    function fmtDateRange(start, end) {
+      var s = new Date(start + 'T00:00:00');
+      var e = new Date(end + 'T00:00:00');
+      var sMonth = s.toLocaleDateString('en-US', { month: 'short' });
+      var eMonth = e.toLocaleDateString('en-US', { month: 'short' });
+      var sDay = s.getDate();
+      var eDay = e.getDate();
+      var sYear = s.getFullYear();
+      var eYear = e.getFullYear();
+      if (sYear === eYear && sMonth === eMonth) {
+        return sMonth + ' ' + sDay + ' \u2013 ' + eDay + ', ' + sYear;
+      }
+      if (sYear === eYear) {
+        return sMonth + ' ' + sDay + ' \u2013 ' + eMonth + ' ' + eDay + ', ' + sYear;
+      }
+      return sMonth + ' ' + sDay + ', ' + sYear + ' \u2013 ' + eMonth + ' ' + eDay + ', ' + eYear;
+    }
+
+    function fmtShortDate(dateStr) {
+      var d = new Date(dateStr + 'T00:00:00');
+      return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    }
+
+    function escapeText(str) {
+      var div = document.createElement('div');
+      div.textContent = str;
+      return div.textContent;
+    }
+
+    // Check for empty state
+    var data = DASHBOARD_DATA;
+    var hasData = data && data.daily && data.daily.length > 0;
+
+    if (!hasData) {
+      document.getElementById('app').textContent = '';
+      var header = document.createElement('div');
+      header.className = 'header';
+      var title = document.createElement('div');
+      title.className = 'header-title';
+      title.textContent = 'Claude Code Usage';
+      header.appendChild(title);
+      document.getElementById('app').appendChild(header);
+
+      var empty = document.createElement('div');
+      empty.className = 'empty-state';
+      var emptyInner = document.createElement('div');
+      var p1 = document.createElement('p');
+      p1.textContent = 'No usage data available.';
+      emptyInner.appendChild(p1);
+      var p2 = document.createElement('p');
+      p2.style.marginTop = '8px';
+      p2.textContent = 'Run ';
+      var code = document.createElement('code');
+      code.textContent = '/usage-stats';
+      p2.appendChild(code);
+      var span = document.createTextNode(' to generate a report.');
+      p2.appendChild(span);
+      emptyInner.appendChild(p2);
+      empty.appendChild(emptyInner);
+      document.getElementById('app').appendChild(empty);
+    } else {
+      // Chart.js global defaults
+      Chart.defaults.color = '#6b6b7a';
+      Chart.defaults.borderColor = 'rgba(30,30,36,0.5)';
+      Chart.defaults.font.family = "'SF Pro Display', -apple-system, sans-serif";
+      Chart.defaults.font.weight = 300;
+
+      var CHART_COLORS = ['#8b5cf6', '#34d399', '#fbbf24', '#60a5fa', '#f87171', '#a78bfa'];
+
+      var tooltipConfig = {
+        backgroundColor: '#111114',
+        borderColor: '#1e1e24',
+        borderWidth: 1,
+        titleColor: '#e8e8f0',
+        bodyColor: '#6b6b7a',
+        padding: 12,
+        cornerRadius: 8,
+        displayColors: true
+      };
+
+      // Filter state
+      var filters = {
+        dateStart: null,
+        dateEnd: null,
+        models: new Set(),
+        projects: new Set()
+      };
+
+      // Derive available models and projects
+      var allModels = new Set();
+      data.modelSplit.forEach(function(m) { allModels.add(m.model); });
+      var allProjects = new Set();
+      data.projectSplit.forEach(function(p) { allProjects.add(p.project); });
+
+      // Session display state
+      var showAllSessions = false;
+
+      // Build DOM using safe methods
+      function buildPage() {
+        var app = document.getElementById('app');
+        app.textContent = '';
+
+        // Header
+        var header = document.createElement('div');
+        header.className = 'header';
+        var htitle = document.createElement('div');
+        htitle.className = 'header-title';
+        htitle.textContent = 'Claude Code Usage';
+        header.appendChild(htitle);
+        var hmeta = document.createElement('div');
+        hmeta.className = 'header-meta';
+        var hdates = document.createElement('span');
+        hdates.className = 'header-dates';
+        hdates.id = 'header-dates';
+        hdates.textContent = fmtDateRange(data.meta.startDate, data.meta.endDate);
+        hmeta.appendChild(hdates);
+        var hgen = document.createElement('span');
+        hgen.className = 'header-generated';
+        hgen.textContent = 'Generated ' + (data.meta.generatedAt || '');
+        hmeta.appendChild(hgen);
+        header.appendChild(hmeta);
+        app.appendChild(header);
+
+        // Filter bar
+        var filterBar = document.createElement('div');
+        filterBar.className = 'filter-bar';
+
+        // Date filter group
+        var dateGroup = document.createElement('div');
+        dateGroup.className = 'filter-group';
+        var dateLabel = document.createElement('span');
+        dateLabel.className = 'filter-label';
+        dateLabel.textContent = 'Range';
+        dateGroup.appendChild(dateLabel);
+        var startInput = document.createElement('input');
+        startInput.type = 'date';
+        startInput.className = 'filter-date';
+        startInput.id = 'filter-start';
+        startInput.value = data.meta.startDate;
+        dateGroup.appendChild(startInput);
+        var endInput = document.createElement('input');
+        endInput.type = 'date';
+        endInput.className = 'filter-date';
+        endInput.id = 'filter-end';
+        endInput.value = data.meta.endDate;
+        dateGroup.appendChild(endInput);
+        filterBar.appendChild(dateGroup);
+
+        // Model filter group
+        var modelGroup = document.createElement('div');
+        modelGroup.className = 'filter-group';
+        var modelLabel = document.createElement('span');
+        modelLabel.className = 'filter-label';
+        modelLabel.textContent = 'Models';
+        modelGroup.appendChild(modelLabel);
+        var modelPills = document.createElement('div');
+        modelPills.className = 'pill-group';
+        modelPills.id = 'model-pills';
+        modelGroup.appendChild(modelPills);
+        filterBar.appendChild(modelGroup);
+
+        // Project filter group
+        var projGroup = document.createElement('div');
+        projGroup.className = 'filter-group';
+        var projLabel = document.createElement('span');
+        projLabel.className = 'filter-label';
+        projLabel.textContent = 'Projects';
+        projGroup.appendChild(projLabel);
+        var projPills = document.createElement('div');
+        projPills.className = 'pill-group';
+        projPills.id = 'project-pills';
+        projGroup.appendChild(projPills);
+        filterBar.appendChild(projGroup);
+
+        app.appendChild(filterBar);
+
+        // Container
+        var container = document.createElement('div');
+        container.className = 'container';
+
+        // Metric grid
+        var metricGrid = document.createElement('div');
+        metricGrid.className = 'metric-grid';
+
+        var metricDefs = [
+          { id: 'messages', label: 'Messages' },
+          { id: 'sessions', label: 'Sessions' },
+          { id: 'tokens', label: 'Output Tokens' },
+          { id: 'days', label: 'Days Active' }
+        ];
+        metricDefs.forEach(function(def) {
+          var card = document.createElement('div');
+          card.className = 'card metric-card';
+          var lbl = document.createElement('span');
+          lbl.className = 'metric-label';
+          lbl.textContent = def.label;
+          card.appendChild(lbl);
+          var val = document.createElement('span');
+          val.className = 'metric-value';
+          val.id = 'm-' + def.id;
+          val.textContent = '0';
+          card.appendChild(val);
+          var sub = document.createElement('span');
+          sub.className = 'metric-sub';
+          sub.id = 'm-' + def.id + '-sub';
+          card.appendChild(sub);
+          metricGrid.appendChild(card);
+        });
+        container.appendChild(metricGrid);
+
+        // Chart grid
+        var chartGrid = document.createElement('div');
+        chartGrid.className = 'chart-grid';
+
+        var chartDefs = [
+          { id: 'chart-daily', title: 'Daily Activity', fullWidth: false },
+          { id: 'chart-tokens', title: 'Token Usage Over Time', fullWidth: false },
+          { id: 'chart-models', title: 'Model Distribution', fullWidth: false, hasDoughnut: true },
+          { id: 'chart-hourly', title: 'Hourly Activity', fullWidth: false },
+          { id: 'chart-projects', title: 'Project Breakdown', fullWidth: true }
+        ];
+        chartDefs.forEach(function(def) {
+          var card = document.createElement('div');
+          card.className = 'card chart-card' + (def.fullWidth ? ' chart-full-width' : '');
+          var ctitle = document.createElement('div');
+          ctitle.className = 'chart-title';
+          ctitle.textContent = def.title;
+          card.appendChild(ctitle);
+          var wrap = document.createElement('div');
+          wrap.className = 'chart-wrap';
+          if (def.hasDoughnut) wrap.style.position = 'relative';
+          var canvas = document.createElement('canvas');
+          canvas.id = def.id;
+          wrap.appendChild(canvas);
+          if (def.hasDoughnut) {
+            var dcenter = document.createElement('div');
+            dcenter.className = 'doughnut-center';
+            var dval = document.createElement('div');
+            dval.className = 'value';
+            dval.id = 'doughnut-value';
+            dval.textContent = '0';
+            dcenter.appendChild(dval);
+            var dlbl = document.createElement('div');
+            dlbl.className = 'label';
+            dlbl.textContent = 'output tokens';
+            dcenter.appendChild(dlbl);
+            wrap.appendChild(dcenter);
+          }
+          card.appendChild(wrap);
+          chartGrid.appendChild(card);
+        });
+        container.appendChild(chartGrid);
+
+        // Daily Breakdown section
+        var dailyTitle = document.createElement('h3');
+        dailyTitle.className = 'section-title';
+        dailyTitle.textContent = 'Daily Breakdown';
+        container.appendChild(dailyTitle);
+
+        var dailyWrap = document.createElement('div');
+        dailyWrap.className = 'card table-wrap';
+        var dailyTable = document.createElement('table');
+        dailyTable.id = 'table-daily';
+        var dailyThead = document.createElement('thead');
+        var dailyHeadRow = document.createElement('tr');
+        ['Date', 'Messages', 'Sessions', 'Tool Calls', 'Output Tokens', 'Primary Model'].forEach(function(h) {
+          var th = document.createElement('th');
+          th.textContent = h;
+          dailyHeadRow.appendChild(th);
+        });
+        dailyThead.appendChild(dailyHeadRow);
+        dailyTable.appendChild(dailyThead);
+        var dailyTbody = document.createElement('tbody');
+        dailyTbody.id = 'tbody-daily';
+        dailyTable.appendChild(dailyTbody);
+        dailyWrap.appendChild(dailyTable);
+        container.appendChild(dailyWrap);
+
+        // Sessions section
+        var sessTitle = document.createElement('h3');
+        sessTitle.className = 'section-title';
+        sessTitle.textContent = 'Sessions';
+        container.appendChild(sessTitle);
+
+        var sessWrap = document.createElement('div');
+        sessWrap.className = 'card table-wrap';
+        var sessTable = document.createElement('table');
+        sessTable.id = 'table-sessions';
+        var sessThead = document.createElement('thead');
+        var sessHeadRow = document.createElement('tr');
+        ['Date', 'Project', 'Messages', 'Output Tokens', 'Model', 'Tool Calls'].forEach(function(h) {
+          var th = document.createElement('th');
+          th.textContent = h;
+          sessHeadRow.appendChild(th);
+        });
+        sessThead.appendChild(sessHeadRow);
+        sessTable.appendChild(sessThead);
+        var sessTbody = document.createElement('tbody');
+        sessTbody.id = 'tbody-sessions';
+        sessTable.appendChild(sessTbody);
+        sessWrap.appendChild(sessTable);
+        var toggleWrap = document.createElement('div');
+        toggleWrap.id = 'session-toggle-wrap';
+        toggleWrap.style.display = 'none';
+        var showAllBtn = document.createElement('button');
+        showAllBtn.className = 'show-all-btn';
+        showAllBtn.id = 'btn-show-all';
+        showAllBtn.textContent = 'Show all';
+        toggleWrap.appendChild(showAllBtn);
+        sessWrap.appendChild(toggleWrap);
+        container.appendChild(sessWrap);
+
+        app.appendChild(container);
+
+        // Footer
+        var footer = document.createElement('div');
+        footer.className = 'footer';
+        footer.textContent = 'Generated by usage-stats plugin \u00b7 ';
+        var footerLink = document.createElement('span');
+        footerLink.className = 'footer-link';
+        footerLink.textContent = 'harnessprotocol/harness-kit';
+        footer.appendChild(footerLink);
+        app.appendChild(footer);
+      }
+
+      buildPage();
+
+      // Render filter pills
+      function renderPills() {
+        var modelContainer = document.getElementById('model-pills');
+        modelContainer.textContent = '';
+        allModels.forEach(function(model) {
+          var pill = document.createElement('button');
+          pill.className = 'pill' + (filters.models.size === 0 || filters.models.has(model) ? ' active' : '');
+          pill.textContent = model;
+          pill.addEventListener('click', function() { toggleModelFilter(model); });
+          modelContainer.appendChild(pill);
+        });
+
+        var projectContainer = document.getElementById('project-pills');
+        projectContainer.textContent = '';
+        allProjects.forEach(function(project) {
+          var pill = document.createElement('button');
+          pill.className = 'pill' + (filters.projects.size === 0 || filters.projects.has(project) ? ' active' : '');
+          pill.textContent = project;
+          pill.addEventListener('click', function() { toggleProjectFilter(project); });
+          projectContainer.appendChild(pill);
+        });
+      }
+
+      function toggleModelFilter(model) {
+        if (filters.models.size === 0) {
+          filters.models.add(model);
+        } else if (filters.models.has(model)) {
+          filters.models.delete(model);
+        } else {
+          filters.models.add(model);
+          if (filters.models.size === allModels.size) {
+            filters.models.clear();
+          }
+        }
+        applyFilters();
+      }
+
+      function toggleProjectFilter(project) {
+        if (filters.projects.size === 0) {
+          filters.projects.add(project);
+        } else if (filters.projects.has(project)) {
+          filters.projects.delete(project);
+        } else {
+          filters.projects.add(project);
+          if (filters.projects.size === allProjects.size) {
+            filters.projects.clear();
+          }
+        }
+        applyFilters();
+      }
+
+      // Date filter listeners
+      function bindDateFilters() {
+        document.getElementById('filter-start').addEventListener('change', function(e) {
+          filters.dateStart = e.target.value || null;
+          applyFilters();
+        });
+        document.getElementById('filter-end').addEventListener('change', function(e) {
+          filters.dateEnd = e.target.value || null;
+          applyFilters();
+        });
+      }
+
+      // Session show-all toggle
+      function bindSessionToggle() {
+        document.getElementById('btn-show-all').addEventListener('click', function() {
+          showAllSessions = !showAllSessions;
+          applyFilters();
+        });
+      }
+
+      // Filter logic
+      function getFilteredDaily() {
+        var daily = data.daily;
+        var start = filters.dateStart || data.meta.startDate;
+        var end = filters.dateEnd || data.meta.endDate;
+
+        daily = daily.filter(function(d) { return d.date >= start && d.date <= end; });
+
+        if (filters.models.size > 0) {
+          daily = daily.filter(function(d) {
+            if (!d.tokensByModel) return false;
+            return Object.keys(d.tokensByModel).some(function(m) { return filters.models.has(m); });
+          });
+        }
+
+        return daily;
+      }
+
+      function getFilteredSessions() {
+        var sessions = data.sessions ? data.sessions.slice() : [];
+        var start = filters.dateStart || data.meta.startDate;
+        var end = filters.dateEnd || data.meta.endDate;
+
+        sessions = sessions.filter(function(s) { return s.date >= start && s.date <= end; });
+
+        if (filters.models.size > 0) {
+          sessions = sessions.filter(function(s) { return filters.models.has(s.primaryModel); });
+        }
+
+        if (filters.projects.size > 0) {
+          sessions = sessions.filter(function(s) { return filters.projects.has(s.project); });
+        }
+
+        return sessions;
+      }
+
+      function computeSummary(daily) {
+        var summary = {
+          totalMessages: 0,
+          totalSessions: 0,
+          totalToolCalls: 0,
+          totalOutputTokens: 0,
+          totalInputTokens: 0,
+          totalCacheReadTokens: 0,
+          daysActive: 0,
+          daysInRange: daily.length
+        };
+
+        daily.forEach(function(d) {
+          summary.totalMessages += d.messages || 0;
+          summary.totalSessions += d.sessions || 0;
+          summary.totalToolCalls += d.toolCalls || 0;
+          summary.totalOutputTokens += d.outputTokens || 0;
+          summary.totalInputTokens += d.inputTokens || 0;
+          summary.totalCacheReadTokens += d.cacheReadTokens || 0;
+          if (d.messages > 0) summary.daysActive++;
+        });
+
+        return summary;
+      }
+
+      function computeModelSplit(daily) {
+        var modelMap = {};
+        daily.forEach(function(d) {
+          if (d.tokensByModel) {
+            Object.keys(d.tokensByModel).forEach(function(model) {
+              if (filters.models.size > 0 && !filters.models.has(model)) return;
+              if (!modelMap[model]) modelMap[model] = { model: model, outputTokens: 0, messages: 0 };
+              modelMap[model].outputTokens += d.tokensByModel[model];
+            });
+          }
+        });
+        return Object.values(modelMap).sort(function(a, b) { return b.outputTokens - a.outputTokens; });
+      }
+
+      function computeProjectSplit(sessions) {
+        var projMap = {};
+        sessions.forEach(function(s) {
+          if (!projMap[s.project]) projMap[s.project] = { project: s.project, sessions: 0, outputTokens: 0, messages: 0 };
+          projMap[s.project].sessions++;
+          projMap[s.project].outputTokens += s.outputTokens || 0;
+          projMap[s.project].messages += s.messages || 0;
+        });
+        return Object.values(projMap).sort(function(a, b) { return b.outputTokens - a.outputTokens; });
+      }
+
+      // Chart instances
+      var chartDaily, chartTokens, chartModels, chartHourly, chartProjects;
+
+      function createCharts() {
+        var filteredDaily = getFilteredDaily();
+        var filteredSessions = getFilteredSessions();
+        var summary = computeSummary(filteredDaily);
+        var modelSplit = computeModelSplit(filteredDaily);
+        var projectSplit = computeProjectSplit(filteredSessions);
+
+        // Metric cards
+        updateMetrics(summary, filteredDaily);
+
+        // Chart A: Daily Activity
+        var dailyLabels = filteredDaily.map(function(d) { return fmtShortDate(d.date); });
+        var ctxDaily = document.getElementById('chart-daily').getContext('2d');
+        chartDaily = new Chart(ctxDaily, {
+          type: 'bar',
+          data: {
+            labels: dailyLabels,
+            datasets: [
+              {
+                label: 'Messages',
+                data: filteredDaily.map(function(d) { return d.messages || 0; }),
+                backgroundColor: 'rgba(139, 92, 246, 0.7)',
+                borderRadius: 3
+              },
+              {
+                label: 'Sessions',
+                data: filteredDaily.map(function(d) { return d.sessions || 0; }),
+                backgroundColor: 'rgba(96, 165, 250, 0.7)',
+                borderRadius: 3
+              },
+              {
+                label: 'Tool Calls',
+                data: filteredDaily.map(function(d) { return d.toolCalls || 0; }),
+                backgroundColor: 'rgba(52, 211, 153, 0.7)',
+                borderRadius: 3
+              }
+            ]
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+              x: { stacked: true, grid: { display: false } },
+              y: { stacked: true, grid: { color: 'rgba(30,30,36,0.5)' } }
+            },
+            plugins: {
+              tooltip: tooltipConfig,
+              legend: { labels: { boxWidth: 12, padding: 16 } }
+            }
+          }
+        });
+
+        // Chart B: Token Usage Over Time
+        var ctxTokens = document.getElementById('chart-tokens').getContext('2d');
+        chartTokens = new Chart(ctxTokens, {
+          type: 'line',
+          data: {
+            labels: dailyLabels,
+            datasets: [
+              {
+                label: 'Output Tokens',
+                data: filteredDaily.map(function(d) { return d.outputTokens || 0; }),
+                borderColor: '#8b5cf6',
+                backgroundColor: 'rgba(139, 92, 246, 0.15)',
+                fill: true,
+                tension: 0.3,
+                pointRadius: 3,
+                pointBackgroundColor: '#8b5cf6',
+                borderWidth: 2
+              },
+              {
+                label: 'Input Tokens',
+                data: filteredDaily.map(function(d) { return d.inputTokens || 0; }),
+                borderColor: 'rgba(107, 107, 122, 0.5)',
+                backgroundColor: 'rgba(107, 107, 122, 0.05)',
+                fill: true,
+                tension: 0.3,
+                pointRadius: 2,
+                pointBackgroundColor: '#6b6b7a',
+                borderWidth: 1.5
+              }
+            ]
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+              x: { grid: { display: false } },
+              y: {
+                grid: { color: 'rgba(30,30,36,0.5)' },
+                ticks: {
+                  callback: function(value) { return fmtTokens(value); }
+                }
+              }
+            },
+            plugins: {
+              tooltip: {
+                backgroundColor: tooltipConfig.backgroundColor,
+                borderColor: tooltipConfig.borderColor,
+                borderWidth: tooltipConfig.borderWidth,
+                titleColor: tooltipConfig.titleColor,
+                bodyColor: tooltipConfig.bodyColor,
+                padding: tooltipConfig.padding,
+                cornerRadius: tooltipConfig.cornerRadius,
+                displayColors: tooltipConfig.displayColors,
+                callbacks: {
+                  label: function(ctx) {
+                    return ctx.dataset.label + ': ' + fmt(ctx.raw);
+                  }
+                }
+              },
+              legend: { labels: { boxWidth: 12, padding: 16 } }
+            }
+          }
+        });
+
+        // Chart C: Model Distribution
+        var ctxModels = document.getElementById('chart-models').getContext('2d');
+        var modelLabels = modelSplit.map(function(m) { return m.model; });
+        var modelData = modelSplit.map(function(m) { return m.outputTokens; });
+        var modelColors = modelSplit.map(function(_, i) { return CHART_COLORS[i % CHART_COLORS.length]; });
+        var totalOutputTokens = modelData.reduce(function(a, b) { return a + b; }, 0);
+        document.getElementById('doughnut-value').textContent = fmtTokens(totalOutputTokens);
+
+        chartModels = new Chart(ctxModels, {
+          type: 'doughnut',
+          data: {
+            labels: modelLabels,
+            datasets: [{
+              data: modelData,
+              backgroundColor: modelColors,
+              borderColor: '#08080a',
+              borderWidth: 2
+            }]
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            cutout: '65%',
+            plugins: {
+              tooltip: {
+                backgroundColor: tooltipConfig.backgroundColor,
+                borderColor: tooltipConfig.borderColor,
+                borderWidth: tooltipConfig.borderWidth,
+                titleColor: tooltipConfig.titleColor,
+                bodyColor: tooltipConfig.bodyColor,
+                padding: tooltipConfig.padding,
+                cornerRadius: tooltipConfig.cornerRadius,
+                displayColors: tooltipConfig.displayColors,
+                callbacks: {
+                  label: function(ctx) {
+                    var total = ctx.dataset.data.reduce(function(a, b) { return a + b; }, 0);
+                    var pct = ((ctx.raw / total) * 100).toFixed(1);
+                    return ctx.label + ': ' + fmtTokens(ctx.raw) + ' (' + pct + '%)';
+                  }
+                }
+              },
+              legend: {
+                position: 'bottom',
+                labels: { boxWidth: 12, padding: 12 }
+              }
+            }
+          }
+        });
+
+        // Chart D: Hourly Activity
+        var hourlyData = data.hourlyDistribution || {};
+        var hourLabels = [];
+        var hourValues = [];
+        for (var h = 0; h < 24; h++) {
+          hourLabels.push(h);
+          hourValues.push(hourlyData[h] || 0);
+        }
+        var peakHour = 0;
+        for (var i = 1; i < 24; i++) {
+          if (hourValues[i] > hourValues[peakHour]) peakHour = i;
+        }
+        var hourColors = hourLabels.map(function(h) {
+          return h === peakHour ? '#8b5cf6' : 'rgba(139, 92, 246, 0.4)';
+        });
+
+        var ctxHourly = document.getElementById('chart-hourly').getContext('2d');
+        chartHourly = new Chart(ctxHourly, {
+          type: 'bar',
+          data: {
+            labels: hourLabels.map(function(h) { return h.toString().padStart(2, '0') + ':00'; }),
+            datasets: [{
+              label: 'Messages',
+              data: hourValues,
+              backgroundColor: hourColors,
+              borderRadius: 3
+            }]
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+              x: { grid: { display: false } },
+              y: { grid: { color: 'rgba(30,30,36,0.5)' } }
+            },
+            plugins: {
+              tooltip: tooltipConfig,
+              legend: { display: false }
+            }
+          }
+        });
+
+        // Chart E: Project Breakdown
+        var ctxProjects = document.getElementById('chart-projects').getContext('2d');
+        chartProjects = new Chart(ctxProjects, {
+          type: 'bar',
+          data: {
+            labels: projectSplit.map(function(p) { return p.project; }),
+            datasets: [{
+              label: 'Output Tokens',
+              data: projectSplit.map(function(p) { return p.outputTokens; }),
+              backgroundColor: 'rgba(139, 92, 246, 0.7)',
+              borderRadius: 4
+            }]
+          },
+          options: {
+            indexAxis: 'y',
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+              x: {
+                grid: { color: 'rgba(30,30,36,0.5)' },
+                ticks: {
+                  callback: function(value) { return fmtTokens(value); }
+                }
+              },
+              y: { grid: { display: false } }
+            },
+            plugins: {
+              tooltip: {
+                backgroundColor: tooltipConfig.backgroundColor,
+                borderColor: tooltipConfig.borderColor,
+                borderWidth: tooltipConfig.borderWidth,
+                titleColor: tooltipConfig.titleColor,
+                bodyColor: tooltipConfig.bodyColor,
+                padding: tooltipConfig.padding,
+                cornerRadius: tooltipConfig.cornerRadius,
+                displayColors: tooltipConfig.displayColors,
+                callbacks: {
+                  label: function(ctx) {
+                    return 'Output Tokens: ' + fmt(ctx.raw);
+                  }
+                }
+              },
+              legend: { display: false }
+            }
+          }
+        });
+
+        // Tables
+        renderDailyTable(filteredDaily);
+        renderSessionTable(filteredSessions);
+
+        // Make tables sortable
+        makeTableSortable(document.getElementById('table-daily'));
+        makeTableSortable(document.getElementById('table-sessions'));
+      }
+
+      // Update metrics
+      function updateMetrics(summary) {
+        document.getElementById('m-messages').textContent = fmt(summary.totalMessages);
+        var avgPerDay = summary.daysActive > 0 ? Math.round(summary.totalMessages / summary.daysActive) : 0;
+        document.getElementById('m-messages-sub').textContent = 'avg ' + fmt(avgPerDay) + '/day';
+
+        document.getElementById('m-sessions').textContent = fmt(summary.totalSessions);
+        var avgSessions = summary.daysActive > 0 ? Math.round(summary.totalSessions / summary.daysActive) : 0;
+        document.getElementById('m-sessions-sub').textContent = 'avg ' + fmt(avgSessions) + '/day';
+
+        document.getElementById('m-tokens').textContent = fmtTokens(summary.totalOutputTokens);
+        document.getElementById('m-tokens-sub').textContent = fmt(summary.totalOutputTokens) + ' total';
+
+        document.getElementById('m-days').textContent = summary.daysActive + ' / ' + summary.daysInRange;
+        var pct = summary.daysInRange > 0 ? Math.round((summary.daysActive / summary.daysInRange) * 100) : 0;
+        document.getElementById('m-days-sub').textContent = pct + '% of range';
+      }
+
+      // Render daily table (safe DOM)
+      function renderDailyTable(daily) {
+        var tbody = document.getElementById('tbody-daily');
+        tbody.textContent = '';
+        daily.forEach(function(d) {
+          var tr = document.createElement('tr');
+
+          var tdDate = document.createElement('td');
+          tdDate.dataset.sort = d.date;
+          tdDate.textContent = fmtShortDate(d.date);
+          tr.appendChild(tdDate);
+
+          var tdMsg = document.createElement('td');
+          tdMsg.className = 'num';
+          tdMsg.dataset.sort = String(d.messages || 0);
+          tdMsg.textContent = fmt(d.messages || 0);
+          tr.appendChild(tdMsg);
+
+          var tdSess = document.createElement('td');
+          tdSess.className = 'num';
+          tdSess.dataset.sort = String(d.sessions || 0);
+          tdSess.textContent = fmt(d.sessions || 0);
+          tr.appendChild(tdSess);
+
+          var tdTool = document.createElement('td');
+          tdTool.className = 'num';
+          tdTool.dataset.sort = String(d.toolCalls || 0);
+          tdTool.textContent = fmt(d.toolCalls || 0);
+          tr.appendChild(tdTool);
+
+          var tdTokens = document.createElement('td');
+          tdTokens.className = 'num';
+          tdTokens.dataset.sort = String(d.outputTokens || 0);
+          tdTokens.textContent = fmt(d.outputTokens || 0);
+          tr.appendChild(tdTokens);
+
+          var tdModel = document.createElement('td');
+          tdModel.textContent = d.primaryModel || '-';
+          tr.appendChild(tdModel);
+
+          tbody.appendChild(tr);
+        });
+      }
+
+      // Render session table (safe DOM)
+      function renderSessionTable(sessions) {
+        var sorted = sessions.slice().sort(function(a, b) { return (b.outputTokens || 0) - (a.outputTokens || 0); });
+        var showToggle = sorted.length > 100;
+        var display = showAllSessions ? sorted : sorted.slice(0, 100);
+
+        var tbody = document.getElementById('tbody-sessions');
+        tbody.textContent = '';
+        display.forEach(function(s) {
+          var tr = document.createElement('tr');
+
+          var tdDate = document.createElement('td');
+          tdDate.dataset.sort = s.date;
+          tdDate.textContent = fmtShortDate(s.date);
+          tr.appendChild(tdDate);
+
+          var tdProj = document.createElement('td');
+          tdProj.textContent = s.project || '-';
+          tr.appendChild(tdProj);
+
+          var tdMsg = document.createElement('td');
+          tdMsg.className = 'num';
+          tdMsg.dataset.sort = String(s.messages || 0);
+          tdMsg.textContent = fmt(s.messages || 0);
+          tr.appendChild(tdMsg);
+
+          var tdTokens = document.createElement('td');
+          tdTokens.className = 'num';
+          tdTokens.dataset.sort = String(s.outputTokens || 0);
+          tdTokens.textContent = fmt(s.outputTokens || 0);
+          tr.appendChild(tdTokens);
+
+          var tdModel = document.createElement('td');
+          tdModel.textContent = s.primaryModel || '-';
+          tr.appendChild(tdModel);
+
+          var tdTool = document.createElement('td');
+          tdTool.className = 'num';
+          tdTool.dataset.sort = String(s.toolCalls || 0);
+          tdTool.textContent = fmt(s.toolCalls || 0);
+          tr.appendChild(tdTool);
+
+          tbody.appendChild(tr);
+        });
+
+        var toggleWrap = document.getElementById('session-toggle-wrap');
+        if (showToggle) {
+          toggleWrap.style.display = 'block';
+          document.getElementById('btn-show-all').textContent = showAllSessions
+            ? 'Show top 100'
+            : 'Show all (' + sorted.length + ')';
+        } else {
+          toggleWrap.style.display = 'none';
+        }
+      }
+
+      // Table sorting
+      function makeTableSortable(table) {
+        var headers = table.querySelectorAll('th');
+        headers.forEach(function(th, idx) {
+          th.style.cursor = 'pointer';
+          th.addEventListener('click', function() {
+            var asc = th.dataset.sortDir !== 'asc';
+            headers.forEach(function(h) { h.dataset.sortDir = ''; });
+            th.dataset.sortDir = asc ? 'asc' : 'desc';
+            sortTable(table, idx, asc);
+          });
+        });
+      }
+
+      function sortTable(table, colIdx, asc) {
+        var tbody = table.querySelector('tbody');
+        var rows = Array.from(tbody.querySelectorAll('tr'));
+        rows.sort(function(a, b) {
+          var aVal = a.children[colIdx].dataset.sort !== undefined ? a.children[colIdx].dataset.sort : a.children[colIdx].textContent.replace(/,/g, '');
+          var bVal = b.children[colIdx].dataset.sort !== undefined ? b.children[colIdx].dataset.sort : b.children[colIdx].textContent.replace(/,/g, '');
+          var numA = parseFloat(aVal), numB = parseFloat(bVal);
+          if (!isNaN(numA) && !isNaN(numB)) return asc ? numA - numB : numB - numA;
+          return asc ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal);
+        });
+        rows.forEach(function(r) { tbody.appendChild(r); });
+      }
+
+      // Apply filters
+      function applyFilters() {
+        var filteredDaily = getFilteredDaily();
+        var filteredSessions = getFilteredSessions();
+        var summary = computeSummary(filteredDaily);
+        var modelSplit = computeModelSplit(filteredDaily);
+        var projectSplit = computeProjectSplit(filteredSessions);
+
+        // Update metrics
+        updateMetrics(summary);
+
+        // Update pills
+        renderPills();
+
+        // Update header date range
+        var start = filters.dateStart || data.meta.startDate;
+        var end = filters.dateEnd || data.meta.endDate;
+        document.getElementById('header-dates').textContent = fmtDateRange(start, end);
+
+        // Chart A: Daily Activity
+        var dailyLabels = filteredDaily.map(function(d) { return fmtShortDate(d.date); });
+        chartDaily.data.labels = dailyLabels;
+        chartDaily.data.datasets[0].data = filteredDaily.map(function(d) { return d.messages || 0; });
+        chartDaily.data.datasets[1].data = filteredDaily.map(function(d) { return d.sessions || 0; });
+        chartDaily.data.datasets[2].data = filteredDaily.map(function(d) { return d.toolCalls || 0; });
+        chartDaily.update('none');
+
+        // Chart B: Token Usage
+        chartTokens.data.labels = dailyLabels;
+        chartTokens.data.datasets[0].data = filteredDaily.map(function(d) { return d.outputTokens || 0; });
+        chartTokens.data.datasets[1].data = filteredDaily.map(function(d) { return d.inputTokens || 0; });
+        chartTokens.update('none');
+
+        // Chart C: Model Distribution
+        var mLabels = modelSplit.map(function(m) { return m.model; });
+        var mData = modelSplit.map(function(m) { return m.outputTokens; });
+        var mColors = modelSplit.map(function(_, i) { return CHART_COLORS[i % CHART_COLORS.length]; });
+        var totalOut = mData.reduce(function(a, b) { return a + b; }, 0);
+        chartModels.data.labels = mLabels;
+        chartModels.data.datasets[0].data = mData;
+        chartModels.data.datasets[0].backgroundColor = mColors;
+        chartModels.update('none');
+        document.getElementById('doughnut-value').textContent = fmtTokens(totalOut);
+
+        // Chart E: Project Breakdown
+        chartProjects.data.labels = projectSplit.map(function(p) { return p.project; });
+        chartProjects.data.datasets[0].data = projectSplit.map(function(p) { return p.outputTokens; });
+        chartProjects.update('none');
+
+        // Tables
+        renderDailyTable(filteredDaily);
+        renderSessionTable(filteredSessions);
+        makeTableSortable(document.getElementById('table-daily'));
+        makeTableSortable(document.getElementById('table-sessions'));
+      }
+
+      // Initialize
+      renderPills();
+      bindDateFilters();
+      bindSessionToggle();
+      createCharts();
+    }
+  </script>
+</body>
+</html>

--- a/plugins/usage-stats/scripts/generate_dashboard.py
+++ b/plugins/usage-stats/scripts/generate_dashboard.py
@@ -1,0 +1,674 @@
+#!/usr/bin/env python3
+"""Aggregate Claude Code usage data and produce an interactive HTML dashboard.
+
+Reads from:
+  ~/.claude/stats-cache.json   – pre-computed daily totals
+  ~/.claude/projects/*/‌*.jsonl  – session transcripts
+  ~/.claude/history.jsonl      – command history (sessionId → project mapping)
+
+Outputs a self-contained HTML file with embedded JSON data.
+
+Python 3.10+ stdlib only — no pip dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import subprocess
+import sys
+import time
+from collections import defaultdict
+from datetime import datetime, date, timedelta
+from pathlib import Path
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Model name shortening
+# ---------------------------------------------------------------------------
+
+def shorten_model(name: str) -> str:
+    """Strip 'claude-' prefix and date suffixes from model identifiers.
+
+    Examples:
+        claude-opus-4-6             → opus-4-6
+        claude-sonnet-4-5-20250929  → sonnet-4-5
+        claude-haiku-4-5-20251001   → haiku-4-5
+        qwen2.5:7b                  → qwen2.5:7b
+    """
+    if not name.startswith("claude-"):
+        return name
+    short = name[len("claude-"):]
+    # Trim everything from the second occurrence of "-202" onward.
+    # The *first* "-202" might be part of the model id itself (unlikely today
+    # but we follow the spec literally: "second -202").
+    idx = short.find("-202")
+    if idx != -1:
+        short = short[:idx]
+    return short
+
+
+# ---------------------------------------------------------------------------
+# Project name helpers
+# ---------------------------------------------------------------------------
+
+def decode_project_dir(dirname: str) -> str:
+    """Convert an encoded directory name back to a filesystem path.
+
+    '-Users-john-repos-harness-kit' → '/Users/john/repos/harness-kit'
+    """
+    if dirname.startswith("-"):
+        return "/" + dirname[1:].replace("-", "/")
+    return dirname.replace("-", "/")
+
+
+def shorten_project(full_path: str) -> str:
+    """Derive a human-friendly short name from a project path.
+
+    Strips the user's home prefix and returns the last meaningful segment(s).
+    """
+    home = os.path.expanduser("~")
+    rel = full_path
+    if rel.startswith(home):
+        rel = rel[len(home):]
+    # Take last non-empty segment
+    parts = [p for p in rel.split("/") if p]
+    if parts:
+        return parts[-1]
+    return full_path
+
+
+# ---------------------------------------------------------------------------
+# Data loading
+# ---------------------------------------------------------------------------
+
+def load_stats_cache(claude_dir: Path) -> dict | None:
+    cache_path = claude_dir / "stats-cache.json"
+    if not cache_path.exists():
+        return None
+    try:
+        with open(cache_path) as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"Warning: could not read stats-cache.json: {exc}", file=sys.stderr)
+        return None
+
+
+def load_history(claude_dir: Path) -> tuple[dict[str, str], dict[str, str]]:
+    """Return (sessionId → project_path, encoded_dir → real_path) from history.jsonl."""
+    session_map: dict[str, str] = {}
+    dir_map: dict[str, str] = {}
+    history_path = claude_dir / "history.jsonl"
+    if not history_path.exists():
+        return session_map, dir_map
+    try:
+        with open(history_path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                    sid = entry.get("sessionId")
+                    proj = entry.get("project")
+                    if sid and proj:
+                        session_map[sid] = proj
+                        # Build encoded dir name → real path mapping
+                        # Claude Code encodes paths by replacing / and _ with -
+                        encoded = proj.replace("/", "-").replace("_", "-")
+                        dir_map[encoded] = proj
+                except json.JSONDecodeError:
+                    continue
+    except OSError:
+        pass
+    return session_map, dir_map
+
+
+# ---------------------------------------------------------------------------
+# JSONL scanning
+# ---------------------------------------------------------------------------
+
+def scan_jsonl_files(
+    claude_dir: Path,
+    start_date: date,
+    end_date: date,
+    session_project_map: dict[str, str],
+    dir_project_map: dict[str, str] | None = None,
+) -> dict:
+    """Scan session JSONL files and return aggregated data.
+
+    Returns dict with keys:
+        daily        – {date_str: {messages, sessions set, toolCalls,
+                        outputTokens, inputTokens, cacheReadTokens,
+                        tokensByModel}}
+        projects     – {full_path: {sessions set, outputTokens, messages}}
+        hourly       – {hour_int: count}
+        sessions     – {session_id: {project, date, messages, outputTokens,
+                        primaryModel, toolCalls, tokensByModel}}
+    """
+    daily: dict[str, dict] = defaultdict(lambda: {
+        "messages": 0,
+        "sessions": set(),
+        "toolCalls": 0,
+        "outputTokens": 0,
+        "inputTokens": 0,
+        "cacheReadTokens": 0,
+        "tokensByModel": defaultdict(int),
+    })
+    projects: dict[str, dict] = defaultdict(lambda: {
+        "sessions": set(),
+        "outputTokens": 0,
+        "messages": 0,
+    })
+    hourly: dict[int, int] = defaultdict(int)
+    sessions: dict[str, dict] = {}
+
+    projects_dir = claude_dir / "projects"
+    if not projects_dir.is_dir():
+        return {"daily": daily, "projects": projects, "hourly": hourly, "sessions": sessions}
+
+    # Collect all JSONL files, skipping subagents dirs
+    jsonl_files: list[tuple[Path, str]] = []  # (path, project_dir_name)
+    start_ts = datetime(start_date.year, start_date.month, start_date.day).timestamp()
+
+    for proj_entry in projects_dir.iterdir():
+        if not proj_entry.is_dir():
+            continue
+        proj_dir_name = proj_entry.name
+        for item in proj_entry.iterdir():
+            if item.is_dir() and item.name == "subagents":
+                continue
+            if item.is_dir():
+                continue
+            if not item.name.endswith(".jsonl"):
+                continue
+            # Skip files last modified before start_date
+            try:
+                mtime = os.path.getmtime(item)
+                if mtime < start_ts:
+                    continue
+            except OSError:
+                continue
+            jsonl_files.append((item, proj_dir_name))
+
+    print(f"Scanning {len(jsonl_files)} files...", file=sys.stderr)
+
+    start_str = start_date.isoformat()
+    end_str = end_date.isoformat()
+
+    for filepath, proj_dir_name in jsonl_files:
+        # Derive project full path from dir name
+        # First try the history-based mapping (preserves hyphens in real paths)
+        if dir_project_map and proj_dir_name in dir_project_map:
+            proj_full_path = dir_project_map[proj_dir_name]
+        else:
+            proj_full_path = decode_project_dir(proj_dir_name)
+
+        try:
+            with open(filepath) as f:
+                for line in f:
+                    # Quick pre-filter before JSON parsing
+                    is_assistant = '"type":"assistant"' in line or '"type": "assistant"' in line
+                    is_human = '"type":"human"' in line or '"type": "human"' in line
+                    if not is_assistant and not is_human:
+                        continue
+
+                    try:
+                        entry = json.loads(line)
+                    except json.JSONDecodeError:
+                        print(f"Warning: malformed JSONL line in {filepath}", file=sys.stderr)
+                        continue
+
+                    entry_type = entry.get("type")
+                    if entry_type not in ("assistant", "human"):
+                        continue
+
+                    ts_str = entry.get("timestamp", "")
+                    if not ts_str or len(ts_str) < 10:
+                        continue
+
+                    entry_date = ts_str[:10]  # YYYY-MM-DD
+                    if entry_date < start_str or entry_date > end_str:
+                        continue
+
+                    session_id = entry.get("sessionId", "")
+
+                    # Resolve project from history mapping if possible
+                    resolved_path = session_project_map.get(session_id, proj_full_path)
+
+                    # Parse hour from timestamp
+                    try:
+                        hour = int(ts_str[11:13])
+                    except (ValueError, IndexError):
+                        hour = 0
+
+                    day = daily[entry_date]
+                    day["messages"] += 1
+                    if session_id:
+                        day["sessions"].add(session_id)
+                    hourly[hour] += 1
+
+                    # Project tracking
+                    proj_data = projects[resolved_path]
+                    proj_data["messages"] += 1
+                    if session_id:
+                        proj_data["sessions"].add(session_id)
+
+                    # Session tracking
+                    if session_id and session_id not in sessions:
+                        sessions[session_id] = {
+                            "project": shorten_project(resolved_path),
+                            "date": entry_date,
+                            "messages": 0,
+                            "outputTokens": 0,
+                            "primaryModel": "",
+                            "toolCalls": 0,
+                            "tokensByModel": defaultdict(int),
+                        }
+                    if session_id:
+                        sessions[session_id]["messages"] += 1
+
+                    if entry_type == "assistant":
+                        msg = entry.get("message", {})
+                        if not isinstance(msg, dict):
+                            continue
+
+                        model = msg.get("model", "")
+                        short_model = shorten_model(model) if model else ""
+                        usage = msg.get("usage", {})
+                        if not isinstance(usage, dict):
+                            usage = {}
+
+                        out_tok = usage.get("output_tokens", 0) or 0
+                        in_tok = usage.get("input_tokens", 0) or 0
+                        cache_tok = usage.get("cache_read_input_tokens", 0) or 0
+
+                        day["outputTokens"] += out_tok
+                        day["inputTokens"] += in_tok
+                        day["cacheReadTokens"] += cache_tok
+                        if short_model:
+                            day["tokensByModel"][short_model] += out_tok
+
+                        proj_data["outputTokens"] += out_tok
+
+                        if session_id and session_id in sessions:
+                            sessions[session_id]["outputTokens"] += out_tok
+                            if short_model:
+                                sessions[session_id]["tokensByModel"][short_model] += out_tok
+
+                        # Count tool_use blocks
+                        content = msg.get("content", [])
+                        if isinstance(content, list):
+                            tc = sum(1 for c in content if isinstance(c, dict) and c.get("type") == "tool_use")
+                            day["toolCalls"] += tc
+                            if session_id and session_id in sessions:
+                                sessions[session_id]["toolCalls"] += tc
+
+        except OSError as exc:
+            print(f"Warning: could not read {filepath}: {exc}", file=sys.stderr)
+            continue
+
+    # Determine primary model for each session
+    for sid, sdata in sessions.items():
+        tbm = sdata["tokensByModel"]
+        if tbm:
+            sdata["primaryModel"] = max(tbm, key=tbm.get)  # type: ignore[arg-type]
+
+    return {"daily": daily, "projects": projects, "hourly": hourly, "sessions": sessions}
+
+
+# ---------------------------------------------------------------------------
+# Report assembly
+# ---------------------------------------------------------------------------
+
+def build_report(
+    start_date: date,
+    end_date: date,
+    cache: dict | None,
+    scanned: dict,
+) -> dict[str, Any]:
+    """Merge cached and scanned data into the final report structure."""
+
+    cache_through: str | None = None
+    if cache:
+        cache_through = cache.get("lastComputedDate")
+
+    # Build daily array
+    daily_list: list[dict] = []
+    all_dates: set[str] = set()
+
+    # Cached daily data
+    if cache and cache_through:
+        cached_activity = {d["date"]: d for d in cache.get("dailyActivity", [])}
+        cached_tokens = {d["date"]: d for d in cache.get("dailyModelTokens", [])}
+
+        d = start_date
+        while d.isoformat() <= cache_through and d <= end_date:
+            ds = d.isoformat()
+            act = cached_activity.get(ds)
+            tok = cached_tokens.get(ds)
+            if act:
+                all_dates.add(ds)
+                tokens_by_model_raw = tok.get("tokensByModel", {}) if tok else {}
+                tokens_by_model = {shorten_model(k): v for k, v in tokens_by_model_raw.items()}
+                primary = max(tokens_by_model, key=tokens_by_model.get) if tokens_by_model else ""  # type: ignore[arg-type]
+                daily_list.append({
+                    "date": ds,
+                    "messages": act.get("messageCount", 0),
+                    "sessions": act.get("sessionCount", 0),
+                    "toolCalls": act.get("toolCallCount", 0),
+                    "outputTokens": 0,  # cache doesn't have per-day output tokens
+                    "inputTokens": 0,
+                    "cacheReadTokens": 0,
+                    "primaryModel": primary,
+                    "tokensByModel": tokens_by_model,
+                })
+            d += timedelta(days=1)
+
+    # Scanned daily data — for dates beyond cache
+    scanned_daily = scanned["daily"]
+    for ds in sorted(scanned_daily.keys()):
+        if ds < start_date.isoformat() or ds > end_date.isoformat():
+            continue
+        # Skip dates already covered by cache
+        if cache_through and ds <= cache_through:
+            continue
+        all_dates.add(ds)
+        day = scanned_daily[ds]
+        tbm = dict(day["tokensByModel"])
+        primary = max(tbm, key=tbm.get) if tbm else ""  # type: ignore[arg-type]
+        daily_list.append({
+            "date": ds,
+            "messages": day["messages"],
+            "sessions": len(day["sessions"]),
+            "toolCalls": day["toolCalls"],
+            "outputTokens": day["outputTokens"],
+            "inputTokens": day["inputTokens"],
+            "cacheReadTokens": day["cacheReadTokens"],
+            "primaryModel": primary,
+            "tokensByModel": tbm,
+        })
+
+    daily_list.sort(key=lambda x: x["date"])
+
+    # Summary
+    total_messages = sum(d["messages"] for d in daily_list)
+    total_sessions = sum(d["sessions"] for d in daily_list)
+    total_tool_calls = sum(d["toolCalls"] for d in daily_list)
+    total_output = sum(d["outputTokens"] for d in daily_list)
+    total_input = sum(d["inputTokens"] for d in daily_list)
+    total_cache = sum(d["cacheReadTokens"] for d in daily_list)
+    days_in_range = (end_date - start_date).days + 1
+    days_active = len(all_dates)
+
+    avg_msg = total_messages / days_active if days_active else 0
+
+    busiest = max(daily_list, key=lambda x: x["messages"]) if daily_list else {"date": "", "messages": 0}
+    # Quietest among days with > 0 messages
+    active_days = [d for d in daily_list if d["messages"] > 0]
+    quietest = min(active_days, key=lambda x: x["messages"]) if active_days else {"date": "", "messages": 0}
+
+    # Model split — aggregate across all daily
+    model_agg: dict[str, dict] = defaultdict(lambda: {
+        "outputTokens": 0, "inputTokens": 0, "messages": 0,
+    })
+    for d in daily_list:
+        for model, out_tok in d["tokensByModel"].items():
+            model_agg[model]["outputTokens"] += out_tok
+    # Also aggregate from scanned sessions for message counts per model
+    for sid, sdata in scanned["sessions"].items():
+        for model, out_tok in sdata["tokensByModel"].items():
+            model_agg[model]["messages"] += sdata["messages"] if model == sdata.get("primaryModel") else 0
+            # outputTokens already counted above for scanned dates
+    # For input tokens, we don't have per-model breakdown from cache
+    # Use scanned data for what we can
+    for ds, day in scanned["daily"].items():
+        if cache_through and ds <= cache_through:
+            continue
+        if ds < start_date.isoformat() or ds > end_date.isoformat():
+            continue
+        # inputTokens not split by model in our data, skip per-model input
+
+    total_model_output = sum(m["outputTokens"] for m in model_agg.values())
+    model_split = []
+    for model, data in sorted(model_agg.items(), key=lambda x: x[1]["outputTokens"], reverse=True):
+        if data["outputTokens"] == 0 and data["messages"] == 0:
+            continue
+        pct = (data["outputTokens"] / total_model_output * 100) if total_model_output else 0
+        model_split.append({
+            "model": model,
+            "outputTokens": data["outputTokens"],
+            "inputTokens": data["inputTokens"],
+            "percentage": round(pct, 1),
+            "messages": data["messages"],
+        })
+
+    # Project split — from scanned data only
+    project_split = []
+    for full_path, pdata in sorted(scanned["projects"].items(), key=lambda x: x[1]["outputTokens"], reverse=True):
+        project_split.append({
+            "project": shorten_project(full_path),
+            "fullPath": full_path,
+            "sessions": len(pdata["sessions"]),
+            "outputTokens": pdata["outputTokens"],
+            "messages": pdata["messages"],
+        })
+
+    # Hourly distribution
+    hourly_dist = {str(h): c for h, c in scanned["hourly"].items()}
+
+    # Sessions list
+    sessions_list = []
+    for sid, sdata in scanned["sessions"].items():
+        sessions_list.append({
+            "id": sid,
+            "project": sdata["project"],
+            "date": sdata["date"],
+            "messages": sdata["messages"],
+            "outputTokens": sdata["outputTokens"],
+            "primaryModel": sdata["primaryModel"],
+            "toolCalls": sdata["toolCalls"],
+        })
+    sessions_list.sort(key=lambda x: (x["date"], x["messages"]), reverse=True)
+
+    return {
+        "meta": {
+            "startDate": start_date.isoformat(),
+            "endDate": end_date.isoformat(),
+            "daysInRange": days_in_range,
+            "daysActive": days_active,
+            "cacheCoversThrough": cache_through,
+            "generatedAt": datetime.now().isoformat(timespec="seconds"),
+        },
+        "daily": daily_list,
+        "summary": {
+            "totalMessages": total_messages,
+            "totalSessions": total_sessions,
+            "totalToolCalls": total_tool_calls,
+            "totalOutputTokens": total_output,
+            "totalInputTokens": total_input,
+            "totalCacheReadTokens": total_cache,
+            "avgMessagesPerDay": round(avg_msg),
+            "busiestDay": {"date": busiest["date"], "messages": busiest["messages"]},
+            "quietestDay": {"date": quietest["date"], "messages": quietest["messages"]},
+        },
+        "modelSplit": model_split,
+        "projectSplit": project_split,
+        "hourlyDistribution": hourly_dist,
+        "sessions": sessions_list,
+    }
+
+
+# ---------------------------------------------------------------------------
+# HTML injection
+# ---------------------------------------------------------------------------
+
+PLACEHOLDER = "/*__DASHBOARD_DATA__*/ {} /*__END__*/"
+
+
+def inject_into_template(report: dict, script_dir: Path) -> str:
+    """Read the HTML template and inject the report JSON."""
+    template_path = script_dir.parent / "assets" / "dashboard.html"
+    if not template_path.exists():
+        print(f"Error: template not found at {template_path}", file=sys.stderr)
+        sys.exit(1)
+
+    template = template_path.read_text()
+
+    if PLACEHOLDER not in template:
+        print("Error: placeholder string not found in template", file=sys.stderr)
+        sys.exit(1)
+
+    data_json = json.dumps(report)
+    replacement = f"/*__DASHBOARD_DATA__*/ {data_json} /*__END__*/"
+    return template.replace(PLACEHOLDER, replacement)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate Claude Code usage dashboard",
+    )
+    parser.add_argument(
+        "--start",
+        type=str,
+        default=None,
+        help="Start date YYYY-MM-DD (default: 14 days ago)",
+    )
+    parser.add_argument(
+        "--end",
+        type=str,
+        default=None,
+        help="End date YYYY-MM-DD (default: today)",
+    )
+    parser.add_argument(
+        "--range",
+        type=str,
+        default=None,
+        choices=["week", "month", "30d", "14d", "all"],
+        help="Preset range (overrides --start)",
+    )
+    parser.add_argument(
+        "--claude-dir",
+        type=str,
+        default=None,
+        help="Override ~/.claude location",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Output HTML path (default: /tmp/claude-usage-YYYY-MM-DD.html)",
+    )
+    parser.add_argument(
+        "--no-open",
+        action="store_true",
+        help="Don't auto-open browser",
+    )
+    return parser.parse_args()
+
+
+def resolve_dates(args: argparse.Namespace, cache: dict | None) -> tuple[date, date]:
+    """Compute (start_date, end_date) from CLI arguments."""
+    today = date.today()
+    end_date = today
+    if args.end:
+        end_date = date.fromisoformat(args.end)
+
+    if args.range:
+        presets = {
+            "week": 7,
+            "14d": 14,
+            "30d": 30,
+            "month": 30,
+        }
+        if args.range == "all":
+            # Go back to first known date
+            if cache and cache.get("firstSessionDate"):
+                first = cache["firstSessionDate"]
+                start_date = date.fromisoformat(first[:10])
+            elif cache and cache.get("dailyActivity"):
+                dates = [d["date"] for d in cache["dailyActivity"]]
+                start_date = date.fromisoformat(min(dates))
+            else:
+                start_date = today - timedelta(days=365)
+        else:
+            start_date = end_date - timedelta(days=presets[args.range] - 1)
+    elif args.start:
+        start_date = date.fromisoformat(args.start)
+    else:
+        start_date = end_date - timedelta(days=13)  # 14 days inclusive
+
+    return start_date, end_date
+
+
+def main() -> None:
+    t0 = time.monotonic()
+    args = parse_args()
+
+    # Resolve Claude directory
+    claude_dir = Path(args.claude_dir) if args.claude_dir else Path.home() / ".claude"
+    if not claude_dir.is_dir():
+        print(f"Error: Claude directory not found at {claude_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    # Load cache
+    cache = load_stats_cache(claude_dir)
+
+    # Resolve date range
+    start_date, end_date = resolve_dates(args, cache)
+    print(f"Date range: {start_date} to {end_date}", file=sys.stderr)
+
+    # Determine which dates the cache covers vs which need scanning
+    cache_through: date | None = None
+    if cache and cache.get("lastComputedDate"):
+        cache_through = date.fromisoformat(cache["lastComputedDate"])
+
+    # We always scan for project breakdown, hourly, and sessions.
+    # But for daily aggregates, we use cache for dates <= cache_through.
+    # Scan start = max(start_date, cache_through + 1) for daily merging,
+    # but we scan ALL dates for project/session/hourly data.
+
+    # Load history mapping
+    session_project_map, dir_project_map = load_history(claude_dir)
+
+    # Scan JSONL files for the full date range
+    scanned = scan_jsonl_files(claude_dir, start_date, end_date, session_project_map, dir_project_map)
+
+    # Build report
+    report = build_report(start_date, end_date, cache, scanned)
+
+    # Inject into template
+    script_dir = Path(__file__).resolve().parent
+    html = inject_into_template(report, script_dir)
+
+    # Write output
+    if args.output:
+        output_path = Path(args.output)
+    else:
+        output_path = Path(f"/tmp/claude-usage-{date.today().isoformat()}.html")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(html)
+
+    elapsed = time.monotonic() - t0
+    print(f"Dashboard written to {output_path}", file=sys.stderr)
+    print(f"Done in {elapsed:.1f}s", file=sys.stderr)
+
+    # Open in browser
+    if not args.no_open:
+        system = platform.system()
+        if system == "Darwin":
+            subprocess.run(["open", str(output_path)])
+        elif system == "Linux":
+            subprocess.run(["xdg-open", str(output_path)])
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/usage-stats/scripts/generate_dashboard.py
+++ b/plugins/usage-stats/scripts/generate_dashboard.py
@@ -42,9 +42,7 @@ def shorten_model(name: str) -> str:
     if not name.startswith("claude-"):
         return name
     short = name[len("claude-"):]
-    # Trim everything from the second occurrence of "-202" onward.
-    # The *first* "-202" might be part of the model id itself (unlikely today
-    # but we follow the spec literally: "second -202").
+    # Trim everything from "-202" onward (date suffixes like -20250929).
     idx = short.find("-202")
     if idx != -1:
         short = short[:idx]
@@ -56,9 +54,15 @@ def shorten_model(name: str) -> str:
 # ---------------------------------------------------------------------------
 
 def decode_project_dir(dirname: str) -> str:
-    """Convert an encoded directory name back to a filesystem path.
+    """Best-effort conversion of an encoded project directory name to a path.
 
-    '-Users-john-repos-harness-kit' → '/Users/john/repos/harness-kit'
+    Claude Code encodes project paths by replacing '/' with '-', so hyphens
+    in the original path are indistinguishable from separators. The result is
+    a best-effort display name only — not a reliable filesystem path. Prefer
+    using dir_project_map (from history.jsonl) which records the actual path.
+
+    Example: '-Users-john-repos-my-project' → '/Users/john/repos/my/project'
+    (wrong if the repo name contains hyphens; dir_project_map avoids this)
     """
     if dirname.startswith("-"):
         return "/" + dirname[1:].replace("-", "/")
@@ -579,7 +583,11 @@ def resolve_dates(args: argparse.Namespace, cache: dict | None) -> tuple[date, d
     today = date.today()
     end_date = today
     if args.end:
-        end_date = date.fromisoformat(args.end)
+        try:
+            end_date = date.fromisoformat(args.end)
+        except ValueError:
+            print(f"Error: invalid --end date '{args.end}' — expected YYYY-MM-DD", file=sys.stderr)
+            sys.exit(1)
 
     if args.range:
         presets = {
@@ -590,18 +598,26 @@ def resolve_dates(args: argparse.Namespace, cache: dict | None) -> tuple[date, d
         }
         if args.range == "all":
             # Go back to first known date
+            start_date = today - timedelta(days=365)  # fallback
             if cache and cache.get("firstSessionDate"):
-                first = cache["firstSessionDate"]
-                start_date = date.fromisoformat(first[:10])
+                try:
+                    start_date = date.fromisoformat(cache["firstSessionDate"][:10])
+                except ValueError:
+                    pass  # keep fallback
             elif cache and cache.get("dailyActivity"):
-                dates = [d["date"] for d in cache["dailyActivity"]]
-                start_date = date.fromisoformat(min(dates))
-            else:
-                start_date = today - timedelta(days=365)
+                try:
+                    dates = [d["date"] for d in cache["dailyActivity"]]
+                    start_date = date.fromisoformat(min(dates))
+                except (ValueError, KeyError):
+                    pass  # keep fallback
         else:
             start_date = end_date - timedelta(days=presets[args.range] - 1)
     elif args.start:
-        start_date = date.fromisoformat(args.start)
+        try:
+            start_date = date.fromisoformat(args.start)
+        except ValueError:
+            print(f"Error: invalid --start date '{args.start}' — expected YYYY-MM-DD", file=sys.stderr)
+            sys.exit(1)
     else:
         start_date = end_date - timedelta(days=13)  # 14 days inclusive
 
@@ -660,6 +676,24 @@ def main() -> None:
     elapsed = time.monotonic() - t0
     print(f"Dashboard written to {output_path}", file=sys.stderr)
     print(f"Done in {elapsed:.1f}s", file=sys.stderr)
+
+    # Emit summary JSON to stdout for the skill to read
+    summary = report["summary"]
+    top_model = report["modelSplit"][0]["model"] if report["modelSplit"] else "unknown"
+    print(json.dumps({
+        "outputPath": str(output_path),
+        "startDate": report["meta"]["startDate"],
+        "endDate": report["meta"]["endDate"],
+        "daysActive": report["meta"]["daysActive"],
+        "totalMessages": summary["totalMessages"],
+        "totalSessions": summary["totalSessions"],
+        "totalOutputTokens": summary["totalOutputTokens"],
+        "totalInputTokens": summary["totalInputTokens"],
+        "totalCacheReadTokens": summary["totalCacheReadTokens"],
+        "busiestDay": summary["busiestDay"],
+        "quietestDay": summary["quietestDay"],
+        "topModel": top_model,
+    }))
 
     # Open in browser
     if not args.no_open:

--- a/plugins/usage-stats/skills/usage-stats/README.md
+++ b/plugins/usage-stats/skills/usage-stats/README.md
@@ -1,0 +1,47 @@
+# usage-stats
+
+Generate an interactive HTML dashboard for your Claude Code usage.
+
+## Usage
+
+```
+/usage-stats                    # last 14 days (default)
+/usage-stats last week          # last 7 days
+/usage-stats last month         # last 30 days
+/usage-stats all time           # everything since first session
+/usage-stats Mar 1 to Mar 10   # specific date range
+```
+
+## What You Get
+
+An HTML dashboard opens in your browser with:
+
+- **Summary cards** — total messages, sessions, output tokens, active days
+- **Daily activity chart** — stacked bar chart of messages, sessions, and tool calls
+- **Token usage trend** — line chart of output tokens over time
+- **Model distribution** — donut chart showing which models you used
+- **Hourly pattern** — when you're most active during the day
+- **Project breakdown** — where you spent your tokens
+- **Sortable tables** — daily and session-level detail with click-to-sort headers
+- **Live filtering** — filter by date range, model, or project without re-running
+
+## Data Sources
+
+The plugin reads from `~/.claude/`:
+
+- `stats-cache.json` — pre-computed daily aggregates (fast, may be slightly stale)
+- `projects/**/*.jsonl` — full session transcripts (scanned for recent data)
+- `history.jsonl` — command history for project path mapping
+
+All data stays local. Nothing is sent to any server.
+
+## Limitations
+
+- **Not a billing tool.** Token counts are not costs — pricing depends on your plan.
+- **Cache staleness.** `stats-cache.json` may lag behind by a few days. The script fills the gap by scanning recent session files directly.
+- **Large histories.** Scanning "all time" with thousands of sessions can take 10-30 seconds.
+
+## Requirements
+
+- Python 3.10+
+- Browser (for viewing the dashboard)

--- a/plugins/usage-stats/skills/usage-stats/README.md
+++ b/plugins/usage-stats/skills/usage-stats/README.md
@@ -44,4 +44,4 @@ All data stays local. Nothing is sent to any server.
 ## Requirements
 
 - Python 3.10+
-- Browser (for viewing the dashboard)
+- Browser with internet access (charts use Chart.js from cdn.jsdelivr.net — they'll be blank if you're offline or behind a proxy that blocks CDN traffic)

--- a/plugins/usage-stats/skills/usage-stats/SKILL.md
+++ b/plugins/usage-stats/skills/usage-stats/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: usage-stats
+description: Use when user invokes /usage-stats or asks about Claude Code usage, token consumption, session history, model distribution, or activity patterns. Generates an interactive HTML dashboard with charts and tables, auto-opens in browser. Also triggers on "how much have I used Claude", "show my usage", "token usage", "session stats", "usage report", "usage dashboard". Do NOT use for API billing or cost estimation — token counts are not costs.
+---
+
+# Claude Code Usage Dashboard
+
+## Overview
+
+Generate an interactive HTML dashboard from Claude Code's local session data. The dashboard shows daily activity, model distribution, project breakdown, hourly patterns, and session details — with live filtering and sortable tables.
+
+**Core principles:**
+1. **Script-first.** A Python script aggregates all data and produces the HTML. Claude never parses raw JSONL files.
+2. **Browser-native.** The output is a self-contained HTML file with Chart.js charts and client-side filtering. No server needed.
+3. **Read-only.** The script only reads from `~/.claude/`. It writes one temp HTML file and opens the browser.
+
+## Workflow (MANDATORY)
+
+### Step 1: Parse Arguments
+
+Map the user's request to CLI flags:
+
+| User says | Flags |
+|-----------|-------|
+| `/usage-stats` (no args) | `--range 14d` |
+| "last week" | `--range week` |
+| "last month" | `--range month` |
+| "last 30 days" | `--range 30d` |
+| "all time" / "everything" | `--range all` |
+| "March 1 to March 10" | `--start 2026-03-01 --end 2026-03-10` |
+
+Convert relative dates to absolute `YYYY-MM-DD` format. If the user gives a vague range, default to `--range 14d`.
+
+### Step 2: Run the Dashboard Generator
+
+Execute via Bash:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/generate_dashboard.py" <flags>
+```
+
+The script:
+- Reads `~/.claude/stats-cache.json` for pre-computed daily data
+- Scans `~/.claude/projects/**/*.jsonl` for recent session data
+- Merges both sources into a complete dataset
+- Injects the data into an HTML template
+- Writes to `/tmp/claude-usage-YYYY-MM-DD.html`
+- Opens it in the default browser
+
+If the script exits with an error, show the stderr output and stop. Do not attempt manual data parsing.
+
+If the user specifies `--range all`, warn them it may take 10-30 seconds for large histories before running.
+
+### Step 3: Summarize in Conversation
+
+After the dashboard opens, provide a brief text summary (3-5 bullets) so the user gets immediate context without switching to the browser:
+
+- Total messages, sessions, and output tokens for the period
+- Busiest and quietest days
+- Model split (which model dominated)
+- Any notable trend (ramp-up, decline, model shift)
+
+Read the script's stdout (it prints a JSON summary) to get these numbers. Format large token counts readably: "10.7M output tokens", "2.5B cache-read tokens".
+
+### Step 4: Offer Follow-Up
+
+End with: "The dashboard is open in your browser. Want a different date range, or should I dig into a specific pattern?"
+
+The user can:
+- Ask for a different range → rerun the script
+- Ask about specific stats → answer from the data already shown
+- Ask to save the report → the HTML file is already saved at the output path
+
+## Scope Controls
+
+| Resource | Access |
+|----------|--------|
+| `~/.claude/stats-cache.json` | Read |
+| `~/.claude/projects/**/*.jsonl` | Read (via script) |
+| `~/.claude/history.jsonl` | Read (via script) |
+| `/tmp/claude-usage-*.html` | Write (one file) |
+| Network | None (browser loads Chart.js from CDN) |
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Reading JSONL files directly in conversation | Always use the Python script. Some session files are 40+ MB. |
+| Reporting token counts as dollar costs | Token counts are not costs. Claude Code pricing varies by plan. Never estimate dollars. |
+| Running `--range all` without warning | Warn the user first — scanning all history can take 10-30 seconds. |
+| Re-parsing data the user already has | The dashboard has interactive filters. Point the user to the browser instead of re-running. |
+| Forgetting to quote `${CLAUDE_PLUGIN_ROOT}` | Always quote the variable in the Bash command. |

--- a/plugins/usage-stats/skills/usage-stats/SKILL.md
+++ b/plugins/usage-stats/skills/usage-stats/SKILL.md
@@ -60,7 +60,7 @@ After the dashboard opens, provide a brief text summary (3-5 bullets) so the use
 - Model split (which model dominated)
 - Any notable trend (ramp-up, decline, model shift)
 
-Read the script's stdout (it prints a JSON summary) to get these numbers. Format large token counts readably: "10.7M output tokens", "2.5B cache-read tokens".
+Read the script's **stdout** to get these numbers — it prints a single JSON line with fields: `totalMessages`, `totalSessions`, `totalOutputTokens`, `totalInputTokens`, `totalCacheReadTokens`, `busiestDay`, `quietestDay`, `topModel`, `daysActive`, `startDate`, `endDate`. Parse it and format large token counts readably: "10.7M output tokens", "2.5B cache-read tokens". (Diagnostic messages go to stderr; ignore those.)
 
 ### Step 4: Offer Follow-Up
 


### PR DESCRIPTION
## Summary

Adds a new `usage-stats` plugin that generates an interactive HTML dashboard from local Claude Code session data. Users invoke `/usage-stats` (optionally with a date range) and get a self-contained dashboard auto-opened in their browser — no server, no network calls.

## Changes

- **`plugins/usage-stats/`** — new plugin with:
  - `scripts/generate_dashboard.py` — parses `~/.claude/stats-cache.json` and session JSONLs, injects into Chart.js HTML template, writes to `/tmp`, opens browser, prints a JSON summary to stdout
  - `assets/dashboard.html` — self-contained template with daily activity heatmap, token usage charts, model distribution, project breakdown, hourly patterns, and sortable session table
  - `skills/usage-stats/SKILL.md` — skill definition: argument mapping, workflow, scope controls, common mistakes
  - `skills/usage-stats/README.md` — user-facing docs with example output
- **`.claude-plugin/marketplace.json`** — registers `usage-stats` v0.1.0 under `productivity` category
- **`README.md`** — adds `usage-stats` row to the Skills table

## Test Plan

- [x] Local JSON manifest validation passes (`python3 -c "import json; json.load(...)"`)
- [x] Version alignment check passes (marketplace.json v0.1.0 == plugin.json v0.1.0)
- [ ] CI checks pass
- [ ] Manual: `/plugin install usage-stats@harness-kit` then `/usage-stats` generates dashboard

## Notes

- The script is intentionally read-only against `~/.claude/` — only writes one HTML file to `/tmp`
- Token counts are surfaced as-is; the skill explicitly guards against reporting them as dollar costs
- `plugins/cloudflare-deploy/` and several `.png` screenshot files are on this branch but not included — separate work for a follow-up PR