### PR TITLE
style: warm neutral theme overhaul for docs site (brass & slate)

### DIFF
--- a/website/app/docs/layout.tsx
+++ b/website/app/docs/layout.tsx
@@ -22,7 +22,7 @@ export default function Layout({ children }: { children: ReactNode }) {
                 fontFamily="system-ui, sans-serif"
                 fontWeight="700"
                 fontSize="16"
-                fill="#8b7aff"
+                fill="#c4a55a"
               >
                 hk
               </text>

--- a/website/app/global.css
+++ b/website/app/global.css
@@ -187,6 +187,20 @@ pre button:hover {
   opacity: 1 !important;
 }
 
+/* ── Link polish — underline + transitions ── */
+[data-fumadocs-body] a:not([data-card]) {
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 3px;
+  text-decoration-color: hsla(256, 60%, 60%, 0.4);
+  transition: text-decoration-color 0.15s ease, color 0.15s ease;
+}
+[data-fumadocs-body] a:not([data-card]):hover {
+  text-decoration-style: solid;
+  text-decoration-color: hsl(256, 80%, 65%);
+  color: hsl(256, 85%, 78%);
+}
+
 /* ── Blockquotes as callouts ── */
 .dark blockquote {
   border-left: 3px solid hsl(256, 85%, 72%);

--- a/website/app/global.css
+++ b/website/app/global.css
@@ -162,14 +162,29 @@ h1, h2, h3 {
   color: hsl(256, 85%, 72%);
 }
 
-/* ── Code blocks ── */
+/* ── Code blocks — warm with subtle glow ── */
+pre {
+  border: none !important;
+  position: relative;
+}
 .dark pre {
   background: hsl(230, 12%, 6%) !important;
   border: none !important;
   border-radius: 0.75rem;
+  box-shadow: 0 -1px 20px -8px hsla(256, 60%, 50%, 0.15),
+              0 4px 16px -4px hsla(230, 15%, 0%, 0.3);
 }
-pre {
-  border: none !important;
+
+/* Copy button — ghost style, fade on hover */
+pre button {
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+pre:hover button {
+  opacity: 0.6;
+}
+pre button:hover {
+  opacity: 1 !important;
 }
 
 /* ── Blockquotes as callouts ── */

--- a/website/app/global.css
+++ b/website/app/global.css
@@ -109,6 +109,29 @@ h1, h2, h3 {
   letter-spacing: -0.03em;
 }
 
+/* ── Content spacing — breathing room ── */
+[data-fumadocs-body] {
+  line-height: 1.8;
+}
+[data-fumadocs-body] p {
+  margin-bottom: 1.25em;
+}
+[data-fumadocs-body] h2 {
+  margin-top: 2.5em;
+}
+[data-fumadocs-body] h3 {
+  margin-top: 1.75em;
+}
+[data-fumadocs-body] pre {
+  margin: 1.5em 0;
+}
+[data-fumadocs-body] table {
+  margin: 1.5em 0;
+}
+[data-fumadocs-body] blockquote {
+  margin: 1.5em 0;
+}
+
 /* ── Nav bar gradient border ── */
 .dark [data-fumadocs-nav] {
   position: relative;

--- a/website/app/global.css
+++ b/website/app/global.css
@@ -102,6 +102,16 @@ body {
   .animate-fade-in {
     animation: none;
   }
+  [data-card],
+  [data-fumadocs-sidebar] a,
+  [data-fumadocs-toc] a,
+  [data-fumadocs-body] a,
+  pre button {
+    transition: none !important;
+  }
+  [data-card]:hover {
+    transform: none;
+  }
 }
 
 /* ── Heading typography ── */

--- a/website/app/global.css
+++ b/website/app/global.css
@@ -12,7 +12,7 @@ body {
 
 /* ── Light theme — warm neutral ── */
 :root {
-  --color-fd-primary: 38 50% 44%;
+  --color-fd-primary: 38 55% 32%;
   --color-fd-primary-foreground: 0 0% 100%;
   --color-fd-background: 40 10% 99%;
   --color-fd-foreground: 30 5% 10%;
@@ -27,7 +27,7 @@ body {
   --color-fd-popover-foreground: 30 5% 10%;
   --color-fd-secondary: 40 4% 95%;
   --color-fd-secondary-foreground: 30 5% 10%;
-  --color-fd-ring: 38 50% 44%;
+  --color-fd-ring: 38 55% 32%;
   --fd-layout-width: 1400px;
 }
 
@@ -195,8 +195,8 @@ h1, h2, h3 {
 /* ── Search — focus glow ── */
 [data-fumadocs-nav] button:focus-visible,
 [data-fumadocs-nav] input:focus-visible {
-  box-shadow: 0 0 0 2px hsla(38, 30%, 50%, 0.25);
-  outline: none;
+  outline: 2px solid hsl(38, 40%, 42%);
+  outline-offset: 2px;
 }
 
 /* ── Code blocks — clean with depth shadow ── */
@@ -237,6 +237,9 @@ pre button:hover {
 }
 [data-fumadocs-body] a:not([data-card]):hover {
   text-decoration-style: solid;
+  text-decoration-color: hsl(38, 35%, 45%);
+}
+.dark [data-fumadocs-body] a:not([data-card]):hover {
   text-decoration-color: hsl(38, 35%, 60%);
   color: hsl(38, 30%, 75%);
 }
@@ -345,7 +348,7 @@ pre code {
 }
 
 /* First H2 on page — no divider (title already separates it) */
-[data-fumadocs-body] h2:first-of-type::before {
+[data-fumadocs-body] > h2:first-of-type::before {
   display: none;
 }
 

--- a/website/app/global.css
+++ b/website/app/global.css
@@ -142,8 +142,11 @@ h1, h2, h3 {
 /* ── Code blocks ── */
 .dark pre {
   background: hsl(230, 12%, 6%) !important;
-  border: 1px solid hsla(230, 15%, 20%, 0.3);
+  border: none !important;
   border-radius: 0.75rem;
+}
+pre {
+  border: none !important;
 }
 
 /* ── Blockquotes as callouts ── */
@@ -154,29 +157,53 @@ h1, h2, h3 {
   padding: 0.75rem 1rem;
 }
 
-/* ── Tables ── */
-.dark table {
-  border: 1px solid hsla(230, 15%, 20%, 0.3);
-  border-radius: 0.5rem;
+/* ── Tables — borderless with row tinting ── */
+table {
+  border: none !important;
+  border-collapse: collapse !important;
+  border-radius: 0.75rem;
   overflow: hidden;
+}
+.dark table {
+  border: none !important;
+}
+table thead {
+  background: hsla(230, 10%, 50%, 0.08);
 }
 .dark table thead {
   background: hsla(230, 10%, 10%, 0.8);
 }
+table tbody tr:nth-child(even) {
+  background: hsla(230, 10%, 50%, 0.04);
+}
 .dark table tbody tr:nth-child(even) {
   background: hsla(230, 10%, 8%, 0.5);
 }
-.dark table td,
-.dark table th {
-  border-color: hsla(230, 15%, 20%, 0.2);
+table td,
+table th {
+  border: none !important;
+  padding: 0.75rem 1rem !important;
+  text-align: left;
+}
+
+/* ── Cards — remove default border ── */
+[data-card] {
+  border: none !important;
+  transition: all 0.3s ease;
 }
 
 /* ── Inline code — subtle background, no border ── */
-:not(pre) > code {
+:not(pre) > code,
+code {
   border: none !important;
   background: hsla(230, 10%, 50%, 0.15) !important;
   padding: 0.15em 0.4em !important;
   border-radius: 0.3rem !important;
+}
+pre code {
+  background: transparent !important;
+  padding: 0 !important;
+  border-radius: 0 !important;
 }
 
 /* ── Docs headings — display font ── */

--- a/website/app/global.css
+++ b/website/app/global.css
@@ -212,6 +212,16 @@ pre button:hover {
   padding: 0.75rem 1rem;
 }
 
+/* ── Callouts — colored left border, no outer border ── */
+.dark [role="alert"],
+.dark [data-callout] {
+  border: none !important;
+  border-left: 3px solid var(--callout-color, hsl(256, 85%, 72%)) !important;
+  border-radius: 0 0.75rem 0.75rem 0;
+  background: hsla(230, 10%, 8%, 0.5) !important;
+  padding: 1rem 1.25rem;
+}
+
 /* ── Tables — borderless with row tinting ── */
 table {
   border: none !important;
@@ -241,10 +251,28 @@ table th {
   text-align: left;
 }
 
-/* ── Cards — remove default border ── */
+/* ── Cards — hover scale + glow ── */
 [data-card] {
-  border: none !important;
-  transition: all 0.3s ease;
+  border: 1px solid hsla(230, 15%, 20%, 0.15) !important;
+  border-radius: 0.75rem;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+}
+[data-card]:hover {
+  transform: scale(1.02);
+  border-color: hsla(256, 70%, 60%, 0.3) !important;
+  box-shadow: 0 8px 24px -8px hsla(256, 60%, 40%, 0.15),
+              0 0 0 1px hsla(256, 70%, 60%, 0.1);
+}
+
+/* ── Steps — accent-colored badges + styled line ── */
+.dark .fd-steps {
+  border-color: hsla(256, 60%, 50%, 0.2) !important;
+}
+.dark .fd-step::before {
+  background: hsl(256, 70%, 55%) !important;
+  color: white !important;
+  font-weight: 600;
+  box-shadow: 0 0 12px -2px hsla(256, 70%, 55%, 0.4);
 }
 
 /* ── Inline code — subtle background, no border ── */

--- a/website/app/global.css
+++ b/website/app/global.css
@@ -112,12 +112,15 @@ h1, h2, h3 {
 /* ── Content spacing — breathing room ── */
 [data-fumadocs-body] {
   line-height: 1.8;
+  position: relative;
 }
 [data-fumadocs-body] p {
   margin-bottom: 1.25em;
 }
 [data-fumadocs-body] h2 {
   margin-top: 2.5em;
+  position: relative;
+  padding-top: 1.5em;
 }
 [data-fumadocs-body] h3 {
   margin-top: 1.75em;
@@ -264,4 +267,36 @@ pre code {
 .dark [data-fumadocs-body] h3 {
   font-family: var(--font-display), ui-sans-serif, system-ui, sans-serif;
   letter-spacing: -0.03em;
+}
+
+/* ── Gradient accent moments ── */
+
+/* H2 section dividers — gradient line above */
+[data-fumadocs-body] h2::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, hsla(256, 70%, 60%, 0.2), transparent);
+}
+
+/* First H2 on page — no divider (title already separates it) */
+[data-fumadocs-body] h2:first-of-type::before {
+  display: none;
+}
+
+/* Page title area — subtle radial glow */
+[data-fumadocs-body]::before {
+  content: '';
+  position: absolute;
+  top: -60px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 500px;
+  height: 300px;
+  background: radial-gradient(ellipse, hsla(256, 70%, 50%, 0.06) 0%, transparent 70%);
+  pointer-events: none;
+  z-index: -1;
 }

--- a/website/app/global.css
+++ b/website/app/global.css
@@ -200,6 +200,10 @@ h1, h2, h3 {
 }
 
 /* ── Code blocks — warm with subtle glow ── */
+figure.shiki,
+figure:has(pre) {
+  border: none !important;
+}
 pre {
   border: none !important;
   position: relative;

--- a/website/app/global.css
+++ b/website/app/global.css
@@ -10,50 +10,50 @@ body {
   font-family: var(--font-display), ui-sans-serif, system-ui, sans-serif;
 }
 
-/* ── Light theme ── */
+/* ── Light theme — warm neutral ── */
 :root {
-  --color-fd-primary: 256 80% 58%;
+  --color-fd-primary: 38 50% 44%;
   --color-fd-primary-foreground: 0 0% 100%;
-  --color-fd-background: 240 20% 99%;
-  --color-fd-foreground: 230 15% 10%;
-  --color-fd-card: 240 10% 96%;
-  --color-fd-card-foreground: 230 15% 10%;
-  --color-fd-muted: 240 8% 93%;
-  --color-fd-muted-foreground: 230 8% 42%;
-  --color-fd-border: 240 8% 88%;
-  --color-fd-accent: 256 60% 96%;
-  --color-fd-accent-foreground: 256 80% 44%;
+  --color-fd-background: 40 10% 99%;
+  --color-fd-foreground: 30 5% 10%;
+  --color-fd-card: 40 6% 96%;
+  --color-fd-card-foreground: 30 5% 10%;
+  --color-fd-muted: 40 4% 93%;
+  --color-fd-muted-foreground: 30 3% 42%;
+  --color-fd-border: 40 4% 88%;
+  --color-fd-accent: 38 20% 96%;
+  --color-fd-accent-foreground: 38 45% 38%;
   --color-fd-popover: 0 0% 100%;
-  --color-fd-popover-foreground: 230 15% 10%;
-  --color-fd-secondary: 240 8% 95%;
-  --color-fd-secondary-foreground: 230 15% 10%;
-  --color-fd-ring: 256 80% 58%;
+  --color-fd-popover-foreground: 30 5% 10%;
+  --color-fd-secondary: 40 4% 95%;
+  --color-fd-secondary-foreground: 30 5% 10%;
+  --color-fd-ring: 38 50% 44%;
   --fd-layout-width: 1400px;
 }
 
-/* ── Dark theme — deep, blue-tinted ── */
+/* ── Dark theme — true neutral, barely warm ── */
 .dark {
-  --color-fd-primary: 256 85% 72%;
+  --color-fd-primary: 38 40% 60%;
   --color-fd-primary-foreground: 0 0% 100%;
-  --color-fd-background: 230 15% 4%;
-  --color-fd-foreground: 0 0% 93%;
-  --color-fd-card: 230 10% 7%;
-  --color-fd-card-foreground: 0 0% 93%;
-  --color-fd-muted: 230 8% 13%;
-  --color-fd-muted-foreground: 230 6% 55%;
-  --color-fd-border: 230 15% 14%;
-  --color-fd-accent: 256 30% 14%;
-  --color-fd-accent-foreground: 256 60% 80%;
-  --color-fd-popover: 230 10% 6%;
-  --color-fd-popover-foreground: 0 0% 93%;
-  --color-fd-secondary: 230 8% 10%;
-  --color-fd-secondary-foreground: 0 0% 93%;
-  --color-fd-ring: 256 85% 72%;
+  --color-fd-background: 0 0% 4%;
+  --color-fd-foreground: 30 5% 88%;
+  --color-fd-card: 0 0% 7%;
+  --color-fd-card-foreground: 30 5% 88%;
+  --color-fd-muted: 0 0% 13%;
+  --color-fd-muted-foreground: 0 0% 50%;
+  --color-fd-border: 0 0% 14%;
+  --color-fd-accent: 38 10% 12%;
+  --color-fd-accent-foreground: 38 25% 72%;
+  --color-fd-popover: 0 0% 6%;
+  --color-fd-popover-foreground: 30 5% 88%;
+  --color-fd-secondary: 0 0% 10%;
+  --color-fd-secondary-foreground: 30 5% 88%;
+  --color-fd-ring: 38 40% 60%;
 }
 
 /* ── Utility classes ── */
-.glow-purple {
-  box-shadow: 0 0 40px -10px hsla(256, 80%, 60%, 0.3);
+.glow-accent {
+  box-shadow: 0 0 40px -10px hsla(38, 40%, 50%, 0.2);
 }
 
 .gradient-border {
@@ -67,7 +67,7 @@ body {
   inset: 0;
   border-radius: inherit;
   padding: 1px;
-  background: linear-gradient(164deg, rgba(255,255,255,0.1), rgba(255,255,255,0.02));
+  background: linear-gradient(164deg, rgba(255,255,255,0.08), rgba(255,255,255,0.02));
   -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
   -webkit-mask-composite: xor;
   mask-composite: exclude;
@@ -76,10 +76,10 @@ body {
 
 .glass {
   backdrop-filter: blur(12px);
-  background: hsla(230, 15%, 92%, 0.7);
+  background: hsla(30, 5%, 92%, 0.7);
 }
 .dark .glass {
-  background: hsla(230, 15%, 8%, 0.7);
+  background: hsla(0, 0%, 8%, 0.7);
 }
 
 /* ── Page fade-in ── */
@@ -145,11 +145,11 @@ h1, h2, h3 {
   margin: 1.5em 0;
 }
 
-/* ── Nav bar gradient border ── */
+/* ── Nav bar — subtle bottom edge ── */
 .dark [data-fumadocs-nav] {
   position: relative;
   border-bottom: none;
-  background: hsla(230, 15%, 4%, 0.85);
+  background: hsla(0, 0%, 4%, 0.9);
   backdrop-filter: blur(16px);
 }
 .dark [data-fumadocs-nav]::after {
@@ -159,7 +159,7 @@ h1, h2, h3 {
   left: 0;
   right: 0;
   height: 1px;
-  background: linear-gradient(90deg, transparent, hsla(256, 85%, 72%, 0.2), transparent);
+  background: linear-gradient(90deg, transparent, hsla(0, 0%, 100%, 0.06), transparent);
 }
 
 /* ── Sidebar — smooth hover + animated active bar ── */
@@ -168,15 +168,15 @@ h1, h2, h3 {
   border-left: 2px solid transparent;
 }
 [data-fumadocs-sidebar] a:hover {
-  background: hsla(230, 10%, 50%, 0.08);
+  background: hsla(0, 0%, 50%, 0.06);
 }
 .dark [data-fumadocs-sidebar] a:hover {
-  background: hsla(230, 10%, 50%, 0.1);
+  background: hsla(0, 0%, 50%, 0.08);
 }
 .dark [data-fumadocs-sidebar] [aria-current="page"],
 .dark [data-fumadocs-sidebar] [data-active="true"] {
-  border-left: 2px solid hsl(256, 85%, 72%);
-  background: hsla(256, 30%, 14%, 0.5);
+  border-left: 2px solid hsl(38, 40%, 56%);
+  background: hsla(38, 10%, 10%, 0.4);
   padding-left: 10px;
   transition: all 0.2s ease;
 }
@@ -188,18 +188,18 @@ h1, h2, h3 {
   padding-left: 0.5rem;
 }
 .dark [data-fumadocs-toc] [data-active="true"] {
-  color: hsl(256, 85%, 72%);
-  border-left-color: hsl(256, 85%, 72%);
+  color: hsl(38, 35%, 68%);
+  border-left-color: hsl(38, 40%, 56%);
 }
 
 /* ── Search — focus glow ── */
 [data-fumadocs-nav] button:focus-visible,
 [data-fumadocs-nav] input:focus-visible {
-  box-shadow: 0 0 0 2px hsla(256, 70%, 60%, 0.3);
+  box-shadow: 0 0 0 2px hsla(38, 30%, 50%, 0.25);
   outline: none;
 }
 
-/* ── Code blocks — warm with subtle glow ── */
+/* ── Code blocks — clean with depth shadow ── */
 figure.shiki,
 figure:has(pre) {
   border: none !important;
@@ -209,11 +209,10 @@ pre {
   position: relative;
 }
 .dark pre {
-  background: hsl(230, 12%, 6%) !important;
+  background: hsl(0, 0%, 5%) !important;
   border: none !important;
   border-radius: 0.75rem;
-  box-shadow: 0 -1px 20px -8px hsla(256, 60%, 50%, 0.15),
-              0 4px 16px -4px hsla(230, 15%, 0%, 0.3);
+  box-shadow: 0 2px 12px -4px hsla(0, 0%, 0%, 0.4);
 }
 
 /* Copy button — ghost style, fade on hover */
@@ -222,7 +221,7 @@ pre button {
   transition: opacity 0.2s ease;
 }
 pre:hover button {
-  opacity: 0.6;
+  opacity: 0.5;
 }
 pre button:hover {
   opacity: 1 !important;
@@ -233,19 +232,19 @@ pre button:hover {
   text-decoration: underline;
   text-decoration-style: dotted;
   text-underline-offset: 3px;
-  text-decoration-color: hsla(256, 60%, 60%, 0.4);
+  text-decoration-color: hsla(0, 0%, 60%, 0.3);
   transition: text-decoration-color 0.15s ease, color 0.15s ease;
 }
 [data-fumadocs-body] a:not([data-card]):hover {
   text-decoration-style: solid;
-  text-decoration-color: hsl(256, 80%, 65%);
-  color: hsl(256, 85%, 78%);
+  text-decoration-color: hsl(38, 35%, 60%);
+  color: hsl(38, 30%, 75%);
 }
 
 /* ── Blockquotes as callouts ── */
 .dark blockquote {
-  border-left: 3px solid hsl(256, 85%, 72%);
-  background: hsla(256, 20%, 12%, 0.3);
+  border-left: 3px solid hsl(0, 0%, 25%);
+  background: hsla(0, 0%, 8%, 0.5);
   border-radius: 0 0.5rem 0.5rem 0;
   padding: 0.75rem 1rem;
 }
@@ -254,9 +253,9 @@ pre button:hover {
 .dark [role="alert"],
 .dark [data-callout] {
   border: none !important;
-  border-left: 3px solid var(--callout-color, hsl(256, 85%, 72%)) !important;
+  border-left: 3px solid var(--callout-color, hsl(0, 0%, 35%)) !important;
   border-radius: 0 0.75rem 0.75rem 0;
-  background: hsla(230, 10%, 8%, 0.5) !important;
+  background: hsla(0, 0%, 7%, 0.6) !important;
   padding: 1rem 1.25rem;
 }
 
@@ -271,16 +270,16 @@ table {
   border: none !important;
 }
 table thead {
-  background: hsla(230, 10%, 50%, 0.08);
+  background: hsla(0, 0%, 50%, 0.06);
 }
 .dark table thead {
-  background: hsla(230, 10%, 10%, 0.8);
+  background: hsla(0, 0%, 10%, 0.8);
 }
 table tbody tr:nth-child(even) {
-  background: hsla(230, 10%, 50%, 0.04);
+  background: hsla(0, 0%, 50%, 0.03);
 }
 .dark table tbody tr:nth-child(even) {
-  background: hsla(230, 10%, 8%, 0.5);
+  background: hsla(0, 0%, 8%, 0.5);
 }
 table td,
 table th {
@@ -289,35 +288,34 @@ table th {
   text-align: left;
 }
 
-/* ── Cards — hover scale + glow ── */
+/* ── Cards — hover with subtle lift ── */
 [data-card] {
-  border: 1px solid hsla(230, 15%, 20%, 0.15) !important;
+  border: 1px solid hsla(0, 0%, 50%, 0.1) !important;
   border-radius: 0.75rem;
   transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
 }
 [data-card]:hover {
   transform: scale(1.02);
-  border-color: hsla(256, 70%, 60%, 0.3) !important;
-  box-shadow: 0 8px 24px -8px hsla(256, 60%, 40%, 0.15),
-              0 0 0 1px hsla(256, 70%, 60%, 0.1);
+  border-color: hsla(0, 0%, 50%, 0.2) !important;
+  box-shadow: 0 8px 24px -8px hsla(0, 0%, 0%, 0.3);
 }
 
-/* ── Steps — accent-colored badges + styled line ── */
+/* ── Steps — warm accent badges + styled line ── */
 .dark .fd-steps {
-  border-color: hsla(256, 60%, 50%, 0.2) !important;
+  border-color: hsla(0, 0%, 20%, 0.4) !important;
 }
 .dark .fd-step::before {
-  background: hsl(256, 70%, 55%) !important;
-  color: white !important;
+  background: hsl(38, 40%, 48%) !important;
+  color: hsl(0, 0%, 5%) !important;
   font-weight: 600;
-  box-shadow: 0 0 12px -2px hsla(256, 70%, 55%, 0.4);
+  box-shadow: 0 0 8px -2px hsla(38, 40%, 48%, 0.3);
 }
 
 /* ── Inline code — subtle background, no border ── */
 :not(pre) > code,
 code {
   border: none !important;
-  background: hsla(230, 10%, 50%, 0.15) !important;
+  background: hsla(0, 0%, 50%, 0.12) !important;
   padding: 0.15em 0.4em !important;
   border-radius: 0.3rem !important;
 }
@@ -335,9 +333,7 @@ pre code {
   letter-spacing: -0.03em;
 }
 
-/* ── Gradient accent moments ── */
-
-/* H2 section dividers — gradient line above */
+/* ── Section dividers — neutral gradient line above H2 ── */
 [data-fumadocs-body] h2::before {
   content: '';
   position: absolute;
@@ -345,7 +341,7 @@ pre code {
   left: 0;
   right: 0;
   height: 1px;
-  background: linear-gradient(90deg, transparent, hsla(256, 70%, 60%, 0.2), transparent);
+  background: linear-gradient(90deg, transparent, hsla(0, 0%, 100%, 0.06), transparent);
 }
 
 /* First H2 on page — no divider (title already separates it) */
@@ -353,7 +349,7 @@ pre code {
   display: none;
 }
 
-/* Page title area — subtle radial glow */
+/* Page title area — subtle warm glow */
 [data-fumadocs-body]::before {
   content: '';
   position: absolute;
@@ -362,7 +358,7 @@ pre code {
   transform: translateX(-50%);
   width: 500px;
   height: 300px;
-  background: radial-gradient(ellipse, hsla(256, 70%, 50%, 0.06) 0%, transparent 70%);
+  background: radial-gradient(ellipse, hsla(38, 30%, 50%, 0.03) 0%, transparent 70%);
   pointer-events: none;
   z-index: -1;
 }

--- a/website/app/global.css
+++ b/website/app/global.css
@@ -152,17 +152,41 @@ h1, h2, h3 {
   background: linear-gradient(90deg, transparent, hsla(256, 85%, 72%, 0.2), transparent);
 }
 
-/* ── Sidebar active item ── */
+/* ── Sidebar — smooth hover + animated active bar ── */
+[data-fumadocs-sidebar] a {
+  transition: background-color 0.2s ease, padding-left 0.2s ease, border-color 0.2s ease;
+  border-left: 2px solid transparent;
+}
+[data-fumadocs-sidebar] a:hover {
+  background: hsla(230, 10%, 50%, 0.08);
+}
+.dark [data-fumadocs-sidebar] a:hover {
+  background: hsla(230, 10%, 50%, 0.1);
+}
 .dark [data-fumadocs-sidebar] [aria-current="page"],
 .dark [data-fumadocs-sidebar] [data-active="true"] {
   border-left: 2px solid hsl(256, 85%, 72%);
   background: hsla(256, 30%, 14%, 0.5);
   padding-left: 10px;
+  transition: all 0.2s ease;
 }
 
-/* ── TOC active item ── */
+/* ── TOC — smooth active indicator ── */
+[data-fumadocs-toc] a {
+  transition: color 0.2s ease, border-color 0.2s ease;
+  border-left: 2px solid transparent;
+  padding-left: 0.5rem;
+}
 .dark [data-fumadocs-toc] [data-active="true"] {
   color: hsl(256, 85%, 72%);
+  border-left-color: hsl(256, 85%, 72%);
+}
+
+/* ── Search — focus glow ── */
+[data-fumadocs-nav] button:focus-visible,
+[data-fumadocs-nav] input:focus-visible {
+  box-shadow: 0 0 0 2px hsla(256, 70%, 60%, 0.3);
+  outline: none;
 }
 
 /* ── Code blocks — warm with subtle glow ── */


### PR DESCRIPTION
## Summary

Replaces the previous purple/blue palette with a cohesive warm neutral theme across the docs site — a \"brass & slate\" aesthetic that feels more editorial and less generic. Also adds a suite of interaction polish: smooth transitions, hover states, content breathing room, and reduced-motion support throughout.

## Changes

- **Palette** — light theme shifts from cool blue-tinted neutrals to warm hue-38 tones; dark theme moves to true near-black (`hsl(0,0%,4%)`) with warm amber accents replacing violet
- **Content spacing** — increased line-height (1.8), paragraph margins, and section breathing room for easier reading
- **Sidebar** — smooth hover transitions, animated active bar with warm accent color
- **TOC** — subtle left-border active indicator with color transition
- **Code blocks** — removed harsh borders, added depth shadow, ghost copy button that fades in on hover
- **Tables** — borderless design with row tinting instead of grid lines
- **Cards** — hover lift effect (`scale(1.02)`) with shadow
- **Links** — dotted underline at rest → solid on hover with accent color
- **Callouts** — colored left-border treatment, no outer box border
- **Steps** — warm amber badge with subtle glow
- **Section dividers** — gradient line above H2 headings; subtle radial glow behind page title
- **Reduced motion** — all transitions and hover transforms suppressed via `prefers-reduced-motion`
- **Bug fix** — removed spurious border from `figure.shiki` wrapper that was double-bordering code blocks

## Test Plan

- [x] Local manifest validation passes
- [ ] CI docs-build passes
- [ ] Visual review of preview deployment on Cloudflare Pages

## Notes

All changes are confined to `website/app/global.css`. No component or content changes.