### PR TITLE
feat: Observatory — Claude Code usage dashboard

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -17,14 +17,15 @@
     "@harness-kit/shared": "workspace:*",
     "@harness-kit/ui": "workspace:*",
     "@supabase/supabase-js": "^2",
-    "react-markdown": "^9.0.1",
-    "remark-gfm": "^4.0.0",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-fs": "^2",
     "dompurify": "^3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^7.0.0"
+    "react-markdown": "^9.0.1",
+    "react-router-dom": "^7.0.0",
+    "recharts": "^3.8.0",
+    "remark-gfm": "^4.0.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1228,6 +1228,7 @@ dependencies = [
 name = "harness-kit-desktop"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "dirs 5.0.1",
  "serde",
  "serde_json",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -21,3 +21,4 @@ tauri-plugin-fs = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "5"
+chrono = { version = "0.4", default-features = false, features = ["std"] }

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -2,3 +2,4 @@ pub mod plugins;
 pub mod hooks;
 pub mod claude_md;
 pub mod settings;
+pub mod observatory;

--- a/apps/desktop/src-tauri/src/commands/observatory.rs
+++ b/apps/desktop/src-tauri/src/commands/observatory.rs
@@ -1,0 +1,232 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::io::BufRead;
+
+// ── Stats cache types ─────────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DailyActivity {
+    pub date: String,
+    pub message_count: Option<u64>,
+    pub session_count: Option<u64>,
+    pub tool_call_count: Option<u64>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DailyModelTokens {
+    pub date: String,
+    pub tokens_by_model: Option<HashMap<String, u64>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelUsageEntry {
+    pub input_tokens: Option<u64>,
+    pub output_tokens: Option<u64>,
+    pub cache_read_input_tokens: Option<u64>,
+    pub cache_creation_input_tokens: Option<u64>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct StatsCache {
+    pub last_computed_date: Option<String>,
+    pub daily_activity: Option<Vec<DailyActivity>>,
+    pub daily_model_tokens: Option<Vec<DailyModelTokens>>,
+    pub model_usage: Option<HashMap<String, ModelUsageEntry>>,
+    pub total_sessions: Option<u64>,
+    pub total_messages: Option<u64>,
+    pub hour_counts: Option<HashMap<String, u64>>,
+}
+
+// ── Session types ─────────────────────────────────────────────
+
+/// Built from history.jsonl grouping — not deserialized directly
+#[derive(Debug, Serialize, Clone)]
+pub struct SessionSummary {
+    pub session_id: String,
+    pub project: String,
+    pub project_short: String,
+    pub first_timestamp: i64,
+    pub last_timestamp: i64,
+    pub message_count: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionFacet {
+    pub session_id: String,
+    pub underlying_goal: Option<String>,
+    pub outcome: Option<String>,
+    pub claude_helpfulness: Option<String>,
+    pub session_type: Option<String>,
+    pub brief_summary: Option<String>,
+    pub friction_counts: Option<HashMap<String, u64>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ActiveSession {
+    pub pid: u64,
+    pub session_id: String,
+    pub cwd: String,
+    pub started_at: Option<i64>,
+}
+
+// ── Helpers ───────────────────────────────────────────────────
+
+fn claude_dir() -> Option<std::path::PathBuf> {
+    dirs::home_dir().map(|h| h.join(".claude"))
+}
+
+// ── Commands ──────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn read_stats_cache() -> Result<StatsCache, String> {
+    let path = claude_dir()
+        .ok_or_else(|| "Could not resolve home directory".to_string())?
+        .join("stats-cache.json");
+
+    if !path.exists() {
+        return Err("stats-cache.json not found".to_string());
+    }
+
+    let contents = std::fs::read_to_string(&path)
+        .map_err(|e| format!("Failed to read stats-cache.json: {}", e))?;
+
+    serde_json::from_str(&contents)
+        .map_err(|e| format!("Failed to parse stats-cache.json: {}", e))
+}
+
+#[tauri::command]
+pub fn list_sessions_summary() -> Result<Vec<SessionSummary>, String> {
+    let path = claude_dir()
+        .ok_or_else(|| "Could not resolve home directory".to_string())?
+        .join("history.jsonl");
+
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let file = std::fs::File::open(&path)
+        .map_err(|e| format!("Failed to open history.jsonl: {}", e))?;
+
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct HistoryEntry {
+        session_id: Option<String>,
+        timestamp: Option<i64>,
+        project: Option<String>,
+    }
+
+    // project, first_ts, last_ts, count
+    let mut sessions: HashMap<String, (String, i64, i64, u64)> = HashMap::new();
+
+    for line in std::io::BufReader::new(file).lines() {
+        let line = match line {
+            Ok(l) if !l.trim().is_empty() => l,
+            _ => continue,
+        };
+        let entry: HistoryEntry = match serde_json::from_str(&line) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let session_id = match entry.session_id {
+            Some(s) if !s.is_empty() => s,
+            _ => continue,
+        };
+        let timestamp = entry.timestamp.unwrap_or(0);
+        let project = entry.project.unwrap_or_default();
+
+        let rec = sessions
+            .entry(session_id)
+            .or_insert_with(|| (project.clone(), timestamp, timestamp, 0));
+
+        if timestamp < rec.1 {
+            rec.1 = timestamp;
+        }
+        if timestamp > rec.2 {
+            rec.2 = timestamp;
+        }
+        rec.3 += 1;
+        if !project.is_empty() {
+            rec.0 = project;
+        }
+    }
+
+    let mut result: Vec<SessionSummary> = sessions
+        .into_iter()
+        .map(|(session_id, (project, first, last, count))| {
+            let project_short = std::path::Path::new(&project)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or_else(|| project.as_str())
+                .to_string();
+            SessionSummary {
+                session_id,
+                project,
+                project_short,
+                first_timestamp: first,
+                last_timestamp: last,
+                message_count: count,
+            }
+        })
+        .collect();
+
+    result.sort_by(|a, b| b.first_timestamp.cmp(&a.first_timestamp));
+    Ok(result)
+}
+
+#[tauri::command]
+pub fn read_session_facet(session_id: String) -> Result<Option<SessionFacet>, String> {
+    let path = claude_dir()
+        .ok_or_else(|| "Could not resolve home directory".to_string())?
+        .join("usage-data")
+        .join("facets")
+        .join(format!("{}.json", session_id));
+
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let contents = std::fs::read_to_string(&path)
+        .map_err(|e| format!("Failed to read facet {}: {}", session_id, e))?;
+
+    serde_json::from_str::<SessionFacet>(&contents)
+        .map(Some)
+        .map_err(|e| format!("Failed to parse facet {}: {}", session_id, e))
+}
+
+#[tauri::command]
+pub fn list_active_sessions() -> Result<Vec<ActiveSession>, String> {
+    let dir = claude_dir()
+        .ok_or_else(|| "Could not resolve home directory".to_string())?
+        .join("sessions");
+
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let entries = std::fs::read_dir(&dir)
+        .map_err(|e| format!("Failed to read sessions directory: {}", e))?;
+
+    let mut result = Vec::new();
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let contents = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        if let Ok(session) = serde_json::from_str::<ActiveSession>(&contents) {
+            result.push(session);
+        }
+    }
+
+    Ok(result)
+}

--- a/apps/desktop/src-tauri/src/commands/observatory.rs
+++ b/apps/desktop/src-tauri/src/commands/observatory.rs
@@ -230,3 +230,77 @@ pub fn list_active_sessions() -> Result<Vec<ActiveSession>, String> {
 
     Ok(result)
 }
+
+/// Daily activity derived from history.jsonl — always fresh (not stale like stats-cache)
+#[derive(Debug, Serialize, Clone)]
+pub struct LiveDailyActivity {
+    pub date: String,
+    pub message_count: u64,
+    pub session_count: u64,
+}
+
+#[tauri::command]
+pub fn read_live_activity() -> Result<Vec<LiveDailyActivity>, String> {
+    let path = claude_dir()
+        .ok_or_else(|| "Could not resolve home directory".to_string())?
+        .join("history.jsonl");
+
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let file = std::fs::File::open(&path)
+        .map_err(|e| format!("Failed to open history.jsonl: {}", e))?;
+
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct HistoryEntry {
+        timestamp: Option<i64>,
+        session_id: Option<String>,
+    }
+
+    // date_str -> (message_count, HashSet<session_id>)
+    let mut buckets: HashMap<String, (u64, std::collections::HashSet<String>)> = HashMap::new();
+
+    for line in std::io::BufReader::new(file).lines() {
+        let line = match line {
+            Ok(l) if !l.trim().is_empty() => l,
+            _ => continue,
+        };
+        let entry: HistoryEntry = match serde_json::from_str(&line) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let ts_ms = match entry.timestamp {
+            Some(t) if t > 0 => t,
+            _ => continue,
+        };
+        // Convert ms timestamp to "YYYY-MM-DD"
+        let secs = ts_ms / 1000;
+        let date = chrono::DateTime::from_timestamp(secs, 0)
+            .map(|dt: chrono::DateTime<chrono::Utc>| dt.format("%Y-%m-%d").to_string())
+            .unwrap_or_default();
+        if date.is_empty() {
+            continue;
+        }
+        let bucket = buckets.entry(date).or_insert_with(|| (0, std::collections::HashSet::new()));
+        bucket.0 += 1;
+        if let Some(sid) = entry.session_id {
+            if !sid.is_empty() {
+                bucket.1.insert(sid);
+            }
+        }
+    }
+
+    let mut result: Vec<LiveDailyActivity> = buckets
+        .into_iter()
+        .map(|(date, (msg_count, sessions))| LiveDailyActivity {
+            date,
+            message_count: msg_count,
+            session_count: sessions.len() as u64,
+        })
+        .collect();
+
+    result.sort_by(|a, b| a.date.cmp(&b.date));
+    Ok(result)
+}

--- a/apps/desktop/src-tauri/src/commands/observatory.rs
+++ b/apps/desktop/src-tauri/src/commands/observatory.rs
@@ -46,6 +46,7 @@ pub struct StatsCache {
 
 /// Built from history.jsonl grouping — not deserialized directly
 #[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct SessionSummary {
     pub session_id: String,
     pub project: String,
@@ -55,8 +56,8 @@ pub struct SessionSummary {
     pub message_count: u64,
 }
 
+/// Facet JSON files on disk use snake_case — no rename needed
 #[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
 pub struct SessionFacet {
     pub session_id: String,
     pub underlying_goal: Option<String>,
@@ -182,6 +183,10 @@ pub fn list_sessions_summary() -> Result<Vec<SessionSummary>, String> {
 
 #[tauri::command]
 pub fn read_session_facet(session_id: String) -> Result<Option<SessionFacet>, String> {
+    if session_id.contains('/') || session_id.contains('\\') || session_id.contains("..") {
+        return Err("Invalid session ID".to_string());
+    }
+
     let path = claude_dir()
         .ok_or_else(|| "Could not resolve home directory".to_string())?
         .join("usage-data")

--- a/apps/desktop/src-tauri/src/commands/observatory.rs
+++ b/apps/desktop/src-tauri/src/commands/observatory.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::io::BufRead;
 
 // ── Stats cache types ─────────────────────────────────────────
@@ -233,6 +234,7 @@ pub fn list_active_sessions() -> Result<Vec<ActiveSession>, String> {
 
 /// Daily activity derived from history.jsonl — always fresh (not stale like stats-cache)
 #[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct LiveDailyActivity {
     pub date: String,
     pub message_count: u64,
@@ -260,7 +262,7 @@ pub fn read_live_activity() -> Result<Vec<LiveDailyActivity>, String> {
     }
 
     // date_str -> (message_count, HashSet<session_id>)
-    let mut buckets: HashMap<String, (u64, std::collections::HashSet<String>)> = HashMap::new();
+    let mut buckets: HashMap<String, (u64, HashSet<String>)> = HashMap::new();
 
     for line in std::io::BufReader::new(file).lines() {
         let line = match line {
@@ -277,13 +279,13 @@ pub fn read_live_activity() -> Result<Vec<LiveDailyActivity>, String> {
         };
         // Convert ms timestamp to "YYYY-MM-DD"
         let secs = ts_ms / 1000;
-        let date = chrono::DateTime::from_timestamp(secs, 0)
+        let date = chrono::DateTime::<chrono::Utc>::from_timestamp_secs(secs)
             .map(|dt: chrono::DateTime<chrono::Utc>| dt.format("%Y-%m-%d").to_string())
             .unwrap_or_default();
         if date.is_empty() {
             continue;
         }
-        let bucket = buckets.entry(date).or_insert_with(|| (0, std::collections::HashSet::new()));
+        let bucket = buckets.entry(date).or_insert_with(|| (0, HashSet::new()));
         bucket.0 += 1;
         if let Some(sid) = entry.session_id {
             if !sid.is_empty() {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -10,6 +10,10 @@ pub fn run() {
             commands::hooks::read_hooks,
             commands::claude_md::read_claude_md,
             commands::settings::list_claude_dir,
+            commands::observatory::read_stats_cache,
+            commands::observatory::list_sessions_summary,
+            commands::observatory::read_session_facet,
+            commands::observatory::list_active_sessions,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application")

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ pub fn run() {
             commands::observatory::list_sessions_summary,
             commands::observatory::read_session_facet,
             commands::observatory::list_active_sessions,
+            commands::observatory::read_live_activity,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application")

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -8,6 +8,8 @@ import ClaudeMdPage from "./pages/harness/ClaudeMdPage";
 import ComingSoonPage from "./pages/ComingSoonPage";
 import BrowsePage from "./pages/marketplace/BrowsePage";
 import PluginDetailPage from "./pages/marketplace/PluginDetailPage";
+import DashboardPage from "./pages/observatory/DashboardPage";
+import SessionsPage from "./pages/observatory/SessionsPage";
 
 export default function App() {
   return (
@@ -25,10 +27,8 @@ export default function App() {
           {/* Marketplace */}
           <Route path="marketplace" element={<BrowsePage />} />
           <Route path="marketplace/:slug" element={<PluginDetailPage />} />
-          <Route
-            path="observatory/*"
-            element={<ComingSoonPage title="Observatory" description="Visualize your Claude Code usage patterns and token metrics." />}
-          />
+          <Route path="observatory" element={<DashboardPage />} />
+          <Route path="observatory/sessions" element={<SessionsPage />} />
           <Route
             path="comparator/*"
             element={<ComingSoonPage title="Comparator" description="Run side-by-side comparisons of AI tools and models on real tasks." />}

--- a/apps/desktop/src/layouts/AppLayout.tsx
+++ b/apps/desktop/src/layouts/AppLayout.tsx
@@ -38,6 +38,10 @@ const NAV_SECTIONS: NavSection[] = [
     id: "observatory",
     label: "Observatory",
     path: "/observatory",
+    children: [
+      { label: "Dashboard", path: "/observatory" },
+      { label: "Sessions", path: "/observatory/sessions" },
+    ],
   },
   {
     id: "comparator",

--- a/apps/desktop/src/lib/__tests__/format.test.ts
+++ b/apps/desktop/src/lib/__tests__/format.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatNumber,
+  formatDuration,
+  formatDate,
+  formatHour,
+  shortModelName,
+  daysBetween,
+} from "../format";
+
+// ── formatNumber ──────────────────────────────────────────────
+
+describe("formatNumber", () => {
+  it("formats 1234 with comma separator", () => {
+    expect(formatNumber(1234)).toBe("1,234");
+  });
+
+  it("formats 0 as '0'", () => {
+    expect(formatNumber(0)).toBe("0");
+  });
+
+  it("formats 1000000 as '1,000,000'", () => {
+    expect(formatNumber(1_000_000)).toBe("1,000,000");
+  });
+
+  it("formats 408 without comma (3-digit number)", () => {
+    expect(formatNumber(408)).toBe("408");
+  });
+
+  it("formats 2814 with comma", () => {
+    expect(formatNumber(2814)).toBe("2,814");
+  });
+});
+
+// ── formatDuration ────────────────────────────────────────────
+
+describe("formatDuration", () => {
+  it("formats 42 minutes as '42m'", () => {
+    expect(formatDuration(42 * 60 * 1000)).toBe("42m");
+  });
+
+  it("formats 3 hours 42 minutes as '3h 42m'", () => {
+    expect(formatDuration(3 * 3_600_000 + 42 * 60_000)).toBe("3h 42m");
+  });
+
+  it("formats exactly 1 minute as '1m'", () => {
+    expect(formatDuration(60_000)).toBe("1m");
+  });
+
+  it("formats 0 ms as '0m'", () => {
+    expect(formatDuration(0)).toBe("0m");
+  });
+
+  it("formats hours with 0 leftover minutes correctly", () => {
+    expect(formatDuration(2 * 3_600_000)).toBe("2h 0m");
+  });
+
+  it("formats 1 hour 1 minute as '1h 1m'", () => {
+    expect(formatDuration(3_600_000 + 60_000)).toBe("1h 1m");
+  });
+});
+
+// ── formatDate ────────────────────────────────────────────────
+
+describe("formatDate", () => {
+  it("formats '2026-02-08' as 'Feb 8'", () => {
+    expect(formatDate("2026-02-08")).toBe("Feb 8");
+  });
+
+  it("formats '2026-01-01' as 'Jan 1'", () => {
+    expect(formatDate("2026-01-01")).toBe("Jan 1");
+  });
+
+  it("formats a December date correctly", () => {
+    expect(formatDate("2026-12-25")).toBe("Dec 25");
+  });
+
+  it("formats a double-digit day correctly", () => {
+    expect(formatDate("2026-03-15")).toBe("Mar 15");
+  });
+});
+
+// ── formatHour ────────────────────────────────────────────────
+
+describe("formatHour", () => {
+  it("formats 0 as '12am'", () => {
+    expect(formatHour(0)).toBe("12am");
+  });
+
+  it("formats 12 as '12pm'", () => {
+    expect(formatHour(12)).toBe("12pm");
+  });
+
+  it("formats 17 as '5pm'", () => {
+    expect(formatHour(17)).toBe("5pm");
+  });
+
+  it("formats 1 as '1am'", () => {
+    expect(formatHour(1)).toBe("1am");
+  });
+
+  it("formats 23 as '11pm'", () => {
+    expect(formatHour(23)).toBe("11pm");
+  });
+
+  it("formats 11 as '11am'", () => {
+    expect(formatHour(11)).toBe("11am");
+  });
+
+  it("formats 13 as '1pm'", () => {
+    expect(formatHour(13)).toBe("1pm");
+  });
+});
+
+// ── shortModelName ────────────────────────────────────────────
+
+describe("shortModelName", () => {
+  it("converts 'claude-sonnet-4-6' to 'Sonnet 4.6'", () => {
+    expect(shortModelName("claude-sonnet-4-6")).toBe("Sonnet 4.6");
+  });
+
+  it("converts 'claude-opus-4-6' to 'Opus 4.6'", () => {
+    expect(shortModelName("claude-opus-4-6")).toBe("Opus 4.6");
+  });
+
+  it("converts 'claude-haiku-4-5-20251001' to 'Haiku 4.5' (strips date suffix)", () => {
+    expect(shortModelName("claude-haiku-4-5-20251001")).toBe("Haiku 4.5");
+  });
+
+  it("passes through unknown model names unchanged", () => {
+    expect(shortModelName("unknown-model")).toBe("unknown-model");
+  });
+
+  it("passes through a string that looks like a model but has no version digits", () => {
+    expect(shortModelName("claude-sonnet")).toBe("claude-sonnet");
+  });
+});
+
+// ── daysBetween ───────────────────────────────────────────────
+
+describe("daysBetween", () => {
+  it("returns 0 when date string and now are the same day", () => {
+    expect(daysBetween("2026-03-15", new Date("2026-03-15T12:00:00"))).toBe(0);
+  });
+
+  it("returns 3 when date is 3 days before now", () => {
+    expect(daysBetween("2026-03-12", new Date("2026-03-15T12:00:00"))).toBe(3);
+  });
+
+  it("returns 7 for a week difference", () => {
+    expect(daysBetween("2026-01-01", new Date("2026-01-08T12:00:00"))).toBe(7);
+  });
+
+  it("returns 0 when now is just a few hours after midnight of the date", () => {
+    // midnight + 6 hours is still the same calendar day (less than 24h)
+    expect(daysBetween("2026-03-15", new Date("2026-03-15T06:00:00"))).toBe(0);
+  });
+
+  it("returns 1 for yesterday", () => {
+    expect(daysBetween("2026-03-14", new Date("2026-03-15T12:00:00"))).toBe(1);
+  });
+});

--- a/apps/desktop/src/lib/__tests__/format.test.ts
+++ b/apps/desktop/src/lib/__tests__/format.test.ts
@@ -3,6 +3,7 @@ import {
   formatNumber,
   formatDuration,
   formatDate,
+  formatTimestamp,
   formatHour,
   shortModelName,
   daysBetween,
@@ -158,5 +159,27 @@ describe("daysBetween", () => {
 
   it("returns 1 for yesterday", () => {
     expect(daysBetween("2026-03-14", new Date("2026-03-15T12:00:00"))).toBe(1);
+  });
+});
+
+// ── formatTimestamp ────────────────────────────────────────────
+
+describe("formatTimestamp", () => {
+  it("formats a Unix ms timestamp to a readable date string", () => {
+    const result = formatTimestamp(1741824600000);
+    // Month and year should appear regardless of timezone
+    expect(result).toMatch(/Mar/);
+    expect(result).toMatch(/20(25|26)/);
+  });
+
+  it("includes time component", () => {
+    const result = formatTimestamp(1741824600000);
+    expect(result).toMatch(/\d{1,2}:\d{2}/);
+  });
+
+  it("returns a non-empty string for epoch", () => {
+    const result = formatTimestamp(0);
+    expect(result.length).toBeGreaterThan(0);
+    expect(result).toMatch(/\d{4}/); // contains a year
   });
 });

--- a/apps/desktop/src/lib/format.ts
+++ b/apps/desktop/src/lib/format.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared formatting utilities for Observatory and other pages.
+ */
+
+export function formatNumber(n: number): string {
+  return n.toLocaleString();
+}
+
+/** Format milliseconds as "3h 42m" or "42m" */
+export function formatDuration(ms: number): string {
+  const totalMinutes = Math.floor(ms / 60_000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}
+
+/** "2026-02-08" → "Feb 8" */
+export function formatDate(dateStr: string): string {
+  const date = new Date(dateStr + "T00:00:00");
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+/** Unix ms timestamp → "Feb 8, 2026, 6:50 PM" */
+export function formatTimestamp(ms: number): string {
+  const date = new Date(ms);
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+/** 0 → "12am", 12 → "12pm", 17 → "5pm" */
+export function formatHour(hour: number): string {
+  if (hour === 0) return "12am";
+  if (hour === 12) return "12pm";
+  if (hour < 12) return `${hour}am`;
+  return `${hour - 12}pm`;
+}
+
+/**
+ * "claude-sonnet-4-6" → "Sonnet 4.6"
+ * "claude-opus-4-6" → "Opus 4.6"
+ * "claude-haiku-4-5-20251001" → "Haiku 4.5"
+ * Passes through unknown model names unchanged.
+ */
+export function shortModelName(model: string): string {
+  const match = model.match(/^claude-(opus|sonnet|haiku)-(\d+)-(\d+)/i);
+  if (match) {
+    const name = match[1].charAt(0).toUpperCase() + match[1].slice(1);
+    return `${name} ${match[2]}.${match[3]}`;
+  }
+  return model;
+}
+
+/** Number of whole days between a date string and now (or provided Date) */
+export function daysBetween(dateStr: string, now: Date = new Date()): number {
+  const date = new Date(dateStr + "T00:00:00");
+  return Math.floor((now.getTime() - date.getTime()) / (1_000 * 60 * 60 * 24));
+}

--- a/apps/desktop/src/lib/tauri.ts
+++ b/apps/desktop/src/lib/tauri.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import type { InstalledPlugin, KnownMarketplace, HooksConfig, StatsCache, SessionSummary, SessionFacet, ActiveSession } from "@harness-kit/shared";
+import type { InstalledPlugin, KnownMarketplace, HooksConfig, StatsCache, SessionSummary, SessionFacet, ActiveSession, LiveDailyActivity } from "@harness-kit/shared";
 
 // ── Plugin commands ──────────────────────────────────────────
 
@@ -45,4 +45,8 @@ export async function readSessionFacet(sessionId: string): Promise<SessionFacet 
 
 export async function listActiveSessions(): Promise<ActiveSession[]> {
   return invoke<ActiveSession[]>("list_active_sessions");
+}
+
+export async function readLiveActivity(): Promise<LiveDailyActivity[]> {
+  return invoke<LiveDailyActivity[]>("read_live_activity");
 }

--- a/apps/desktop/src/lib/tauri.ts
+++ b/apps/desktop/src/lib/tauri.ts
@@ -43,6 +43,7 @@ export async function readSessionFacet(sessionId: string): Promise<SessionFacet 
   return invoke<SessionFacet | null>("read_session_facet", { sessionId });
 }
 
+/** Reserved for future "active sessions" indicator in the Observatory sidebar */
 export async function listActiveSessions(): Promise<ActiveSession[]> {
   return invoke<ActiveSession[]>("list_active_sessions");
 }

--- a/apps/desktop/src/lib/tauri.ts
+++ b/apps/desktop/src/lib/tauri.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import type { InstalledPlugin, KnownMarketplace, HooksConfig } from "@harness-kit/shared";
+import type { InstalledPlugin, KnownMarketplace, HooksConfig, StatsCache, SessionSummary, SessionFacet, ActiveSession } from "@harness-kit/shared";
 
 // ── Plugin commands ──────────────────────────────────────────
 
@@ -27,4 +27,22 @@ export async function readClaudeMd(path: string): Promise<string> {
 
 export async function listClaudeDir(): Promise<string[]> {
   return invoke<string[]>("list_claude_dir");
+}
+
+// ── Observatory commands ──────────────────────────────────────
+
+export async function readStatsCache(): Promise<StatsCache> {
+  return invoke<StatsCache>("read_stats_cache");
+}
+
+export async function listSessionsSummary(): Promise<SessionSummary[]> {
+  return invoke<SessionSummary[]>("list_sessions_summary");
+}
+
+export async function readSessionFacet(sessionId: string): Promise<SessionFacet | null> {
+  return invoke<SessionFacet | null>("read_session_facet", { sessionId });
+}
+
+export async function listActiveSessions(): Promise<ActiveSession[]> {
+  return invoke<ActiveSession[]>("list_active_sessions");
 }

--- a/apps/desktop/src/pages/observatory/DashboardPage.tsx
+++ b/apps/desktop/src/pages/observatory/DashboardPage.tsx
@@ -619,14 +619,7 @@ export default function DashboardPage() {
 
       {/* Hourly distribution */}
       <div style={{ marginBottom: "12px" }}>
-        <ChartCard
-          title="Activity by Hour of Day"
-          chartId="hourly"
-          override={chartOverrides["hourly"]}
-          onOverride={(r) => setChartOverride("hourly", r)}
-          onClearOverride={() => clearOverride("hourly")}
-          globalRange={globalRange}
-        >
+        <ChartCard title="Activity by Hour of Day">
           {hourlyChartData.some((d) => d.count > 0) ? (
             <ResponsiveContainer width="100%" height={160}>
               <BarChart data={hourlyChartData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>

--- a/apps/desktop/src/pages/observatory/DashboardPage.tsx
+++ b/apps/desktop/src/pages/observatory/DashboardPage.tsx
@@ -115,13 +115,16 @@ function Pill({ label, active, onClick }: { label: string; active: boolean; onCl
 // ── Global date control ──────────────────────────────────────
 
 function GlobalDateControl({
-  range, onChange, hasOverrides, onResetOverrides,
+  range, onChange, hasOverrides, onResetOverrides, idPrefix,
 }: {
   range: DateRange;
   onChange: (r: DateRange) => void;
   hasOverrides: boolean;
   onResetOverrides: () => void;
+  idPrefix?: string;
 }) {
+  const startId = idPrefix ? `${idPrefix}-start` : "range-start";
+  const endId = idPrefix ? `${idPrefix}-end` : "range-end";
   const presets: Preset[] = ["1d", "7d", "30d", "1y", "all"];
 
   function selectPreset(p: Preset) {
@@ -144,9 +147,9 @@ function GlobalDateControl({
         />
       ))}
       <div style={{ display: "flex", alignItems: "center", gap: "4px", marginLeft: "4px" }}>
-        <label htmlFor="range-start" style={{ fontSize: "10px", color: "var(--fg-subtle)" }}>Start date</label>
+        <label htmlFor={startId} style={{ fontSize: "10px", color: "var(--fg-subtle)" }}>Start date</label>
         <input
-          id="range-start"
+          id={startId}
           type="date"
           value={range.start}
           onChange={(e) => handleCustomDate("start", e.target.value)}
@@ -159,9 +162,9 @@ function GlobalDateControl({
             color: "var(--fg-base)",
           }}
         />
-        <label htmlFor="range-end" style={{ fontSize: "10px", color: "var(--fg-subtle)" }}>End date</label>
+        <label htmlFor={endId} style={{ fontSize: "10px", color: "var(--fg-subtle)" }}>End date</label>
         <input
-          id="range-end"
+          id={endId}
           type="date"
           value={range.end}
           onChange={(e) => handleCustomDate("end", e.target.value)}
@@ -246,6 +249,7 @@ function ChartCard({
             onChange={(r) => { onOverride(r); setShowPicker(false); }}
             hasOverrides={false}
             onResetOverrides={() => {}}
+            idPrefix={chartId}
           />
         </div>
       )}
@@ -322,13 +326,16 @@ export default function DashboardPage() {
   const cacheHitRate = useMemo(() => {
     if (!data?.modelUsage) return null;
     let totalCacheRead = 0;
+    let totalCacheCreate = 0;
     let totalInput = 0;
     for (const usage of Object.values(data.modelUsage)) {
       totalCacheRead += usage.cacheReadInputTokens ?? 0;
+      totalCacheCreate += usage.cacheCreationInputTokens ?? 0;
       totalInput += usage.inputTokens ?? 0;
     }
-    if (totalInput === 0) return null;
-    return Math.round((totalCacheRead / totalInput) * 100);
+    const total = totalInput + totalCacheRead + totalCacheCreate;
+    if (total === 0) return null;
+    return Math.round((totalCacheRead / total) * 100);
   }, [data]);
 
   const activityChartData = useMemo(() =>

--- a/apps/desktop/src/pages/observatory/DashboardPage.tsx
+++ b/apps/desktop/src/pages/observatory/DashboardPage.tsx
@@ -56,7 +56,16 @@ function filterByRange<T extends { date: string }>(items: T[], range: DateRange)
 // ── Hooks ────────────────────────────────────────────────────
 
 function useReducedMotion() {
-  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  const [reduced, setReduced] = useState(() =>
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+  );
+  useEffect(() => {
+    const mql = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const handler = (e: MediaQueryListEvent) => setReduced(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, []);
+  return reduced;
 }
 
 function getAccentColor() {

--- a/apps/desktop/src/pages/observatory/DashboardPage.tsx
+++ b/apps/desktop/src/pages/observatory/DashboardPage.tsx
@@ -6,9 +6,9 @@ import {
   CartesianGrid, Tooltip,
   ResponsiveContainer,
 } from "recharts";
-import { readStatsCache } from "../../lib/tauri";
-import { formatNumber, formatDate, formatHour, shortModelName, daysBetween } from "../../lib/format";
-import type { StatsCache, DailyActivity } from "@harness-kit/shared";
+import { readStatsCache, readLiveActivity } from "../../lib/tauri";
+import { formatNumber, formatDate, formatHour, shortModelName } from "../../lib/format";
+import type { StatsCache, LiveDailyActivity } from "@harness-kit/shared";
 
 // ── Date range types ─────────────────────────────────────────
 
@@ -133,7 +133,7 @@ function GlobalDateControl({
   }
 
   function handleCustomDate(field: "start" | "end", value: string) {
-    onChange({ preset: "custom", ...range, [field]: value });
+    onChange({ ...range, preset: "custom", [field]: value });
   }
 
   return (
@@ -275,16 +275,16 @@ const axisStyle = { fontSize: 10, fill: "var(--fg-subtle)" };
 
 export default function DashboardPage() {
   const [data, setData] = useState<StatsCache | null>(null);
+  // liveActivity will be consumed by activity charts (Task 6)
+  // @ts-expect-error liveActivity unused until Task 6 wires it to charts
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [liveActivity, setLiveActivity] = useState<LiveDailyActivity[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [globalRange, setGlobalRange] = useState<DateRange>(defaultRange);
   const [chartOverrides, setChartOverrides] = useState<Record<string, DateRange | null>>({});
   const [accentColor, setAccentColor] = useState(getAccentColor);
   const reducedMotion = useReducedMotion();
-
-  function rangeForChart(chartId: string): DateRange {
-    return chartOverrides[chartId] ?? globalRange;
-  }
 
   function setChartOverride(chartId: string, range: DateRange) {
     setChartOverrides((prev) => ({ ...prev, [chartId]: range }));
@@ -297,8 +297,10 @@ export default function DashboardPage() {
   const hasOverrides = Object.values(chartOverrides).some(Boolean);
 
   useEffect(() => {
-    readStatsCache()
-      .then(setData)
+    Promise.all([
+      readStatsCache().then(setData),
+      readLiveActivity().then(setLiveActivity),
+    ])
       .catch((e) => setError(String(e)))
       .finally(() => setLoading(false));
   }, []);
@@ -307,11 +309,6 @@ export default function DashboardPage() {
   useEffect(() => {
     setAccentColor(getAccentColor());
   }, []);
-
-  const isStale = useMemo(() => {
-    if (!data?.lastComputedDate) return false;
-    return daysBetween(data.lastComputedDate) > 3;
-  }, [data]);
 
   const filteredActivity = useMemo(() =>
     filterByRange(data?.dailyActivity ?? [], globalRange),
@@ -323,19 +320,20 @@ export default function DashboardPage() {
     return data.dailyActivity.reduce((sum, d) => sum + (d.toolCallCount ?? 0), 0);
   }, [data]);
 
-  const cacheHitRate = useMemo(() => {
-    if (!data?.modelUsage) return null;
-    let totalCacheRead = 0;
-    let totalCacheCreate = 0;
-    let totalInput = 0;
-    for (const usage of Object.values(data.modelUsage)) {
-      totalCacheRead += usage.cacheReadInputTokens ?? 0;
-      totalCacheCreate += usage.cacheCreationInputTokens ?? 0;
-      totalInput += usage.inputTokens ?? 0;
+  const { totalOutputTokens, cacheHitRate } = useMemo(() => {
+    if (!data?.modelUsage) return { totalOutputTokens: 0, cacheHitRate: null };
+    let outTokens = 0, cacheRead = 0, input = 0, cacheCreate = 0;
+    for (const m of Object.values(data.modelUsage)) {
+      outTokens += m.outputTokens ?? 0;
+      cacheRead += m.cacheReadInputTokens ?? 0;
+      input += m.inputTokens ?? 0;
+      cacheCreate += m.cacheCreationInputTokens ?? 0;
     }
-    const total = totalInput + totalCacheRead + totalCacheCreate;
-    if (total === 0) return null;
-    return Math.round((totalCacheRead / total) * 100);
+    const total = input + cacheRead + cacheCreate;
+    return {
+      totalOutputTokens: outTokens,
+      cacheHitRate: total > 0 ? Math.round((cacheRead / total) * 100) : null,
+    };
   }, [data]);
 
   const activityChartData = useMemo(() =>
@@ -362,17 +360,6 @@ export default function DashboardPage() {
       hour: formatHour(i),
       count: data.hourCounts?.[String(i)] ?? 0,
     }));
-  }, [data]);
-
-  const modelCount = useMemo(() => {
-    if (!data?.modelUsage) return 0;
-    return Object.keys(data.modelUsage).length;
-  }, [data]);
-
-  const firstSessionDate = useMemo(() => {
-    if (!data?.dailyActivity?.length) return "—";
-    const dates = data.dailyActivity.map((d) => d.date).sort();
-    return formatDate(dates[0]);
   }, [data]);
 
   if (loading) {
@@ -409,24 +396,18 @@ export default function DashboardPage() {
     <div style={{ padding: "20px 24px" }}>
       {/* Header */}
       <div style={{ marginBottom: "16px" }}>
-        <h1 style={{ fontSize: "17px", fontWeight: 600, letterSpacing: "-0.3px", color: "var(--fg-base)", margin: 0 }}>
+        <h1 style={{ fontSize: "17px", fontWeight: 600, letterSpacing: "-0.3px", color: "var(--fg-base)", margin: 0, display: "inline" }}>
           Observatory
         </h1>
+        {data?.lastComputedDate && (
+          <span style={{ fontSize: "10px", color: "var(--fg-subtle)", marginLeft: "8px" }}>
+            last updated {formatDate(data.lastComputedDate)}
+          </span>
+        )}
         <p style={{ fontSize: "12px", color: "var(--fg-muted)", margin: "3px 0 0" }}>
           Claude Code usage patterns and activity trends
         </p>
       </div>
-
-      {/* Last updated / stale indicator */}
-      {data?.lastComputedDate && (
-        <div style={{
-          fontSize: "11px",
-          color: "var(--fg-subtle)",
-          marginBottom: "16px",
-        }}>
-          Last updated {isStale ? `${daysBetween(data.lastComputedDate)} days ago` : formatDate(data.lastComputedDate)}
-        </div>
-      )}
 
       {/* Global date range control */}
       <GlobalDateControl
@@ -440,12 +421,21 @@ export default function DashboardPage() {
       <div style={{ display: "flex", gap: "10px", marginBottom: "16px" }}>
         <StatCard label="Total Sessions" value={formatNumber(data?.totalSessions ?? 0)} />
         <StatCard label="Total Messages" value={formatNumber(data?.totalMessages ?? 0)} />
-        <StatCard label="Models Used" value={String(modelCount)} />
         <StatCard label="Tool Calls" value={formatNumber(totalToolCalls)} />
-        {cacheHitRate !== null && (
-          <StatCard label="Cache Hit Rate" value={`${cacheHitRate}%`} />
-        )}
-        <StatCard label="First Session" value={firstSessionDate} />
+        <StatCard label="Output Tokens" value={
+          totalOutputTokens >= 1_000_000
+            ? `${(totalOutputTokens / 1_000_000).toFixed(1)}M`
+            : formatNumber(totalOutputTokens)
+        } />
+        <StatCard
+          label="Cache Hit Rate"
+          value={cacheHitRate !== null ? `${cacheHitRate}%` : "\u2014"}
+          sub="cache read / total input"
+        />
+        <StatCard
+          label="Time Saved"
+          value="\u2014"
+        />
       </div>
 
       {/* Activity chart */}

--- a/apps/desktop/src/pages/observatory/DashboardPage.tsx
+++ b/apps/desktop/src/pages/observatory/DashboardPage.tsx
@@ -10,7 +10,48 @@ import { readStatsCache } from "../../lib/tauri";
 import { formatNumber, formatDate, formatHour, shortModelName, daysBetween } from "../../lib/format";
 import type { StatsCache, DailyActivity } from "@harness-kit/shared";
 
-type TimeRange = "30d" | "90d" | "all";
+// ── Date range types ─────────────────────────────────────────
+
+type Preset = "1d" | "7d" | "30d" | "1y" | "all";
+
+interface DateRange {
+  preset: Preset | "custom";
+  start: string; // "YYYY-MM-DD"
+  end: string;   // "YYYY-MM-DD"
+}
+
+function presetToDates(preset: Preset): { start: string; end: string } {
+  const now = new Date();
+  const today = now.toISOString().slice(0, 10);
+  const daysAgo = (n: number) => {
+    const d = new Date(now);
+    d.setDate(d.getDate() - n);
+    return d.toISOString().slice(0, 10);
+  };
+  if (preset === "1d") return { start: daysAgo(1), end: today };
+  if (preset === "7d") return { start: daysAgo(7), end: today };
+  if (preset === "30d") return { start: daysAgo(30), end: today };
+  if (preset === "1y") return { start: daysAgo(365), end: today };
+  return { start: "", end: "" }; // "all"
+}
+
+function defaultRange(): DateRange {
+  const { start, end } = presetToDates("30d");
+  return { preset: "30d", start, end };
+}
+
+// ── Generic date filter ──────────────────────────────────────
+
+function filterByRange<T extends { date: string }>(items: T[], range: DateRange): T[] {
+  if (range.preset === "all" || (!range.start && !range.end)) return items;
+  return items.filter((d) => {
+    if (range.start && d.date < range.start) return false;
+    if (range.end && d.date > range.end) return false;
+    return true;
+  });
+}
+
+// ── Hooks ────────────────────────────────────────────────────
 
 function useReducedMotion() {
   return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
@@ -71,9 +112,105 @@ function Pill({ label, active, onClick }: { label: string; active: boolean; onCl
   );
 }
 
+// ── Global date control ──────────────────────────────────────
+
+function GlobalDateControl({
+  range, onChange, hasOverrides, onResetOverrides,
+}: {
+  range: DateRange;
+  onChange: (r: DateRange) => void;
+  hasOverrides: boolean;
+  onResetOverrides: () => void;
+}) {
+  const presets: Preset[] = ["1d", "7d", "30d", "1y", "all"];
+
+  function selectPreset(p: Preset) {
+    const dates = presetToDates(p);
+    onChange({ preset: p, ...dates });
+  }
+
+  function handleCustomDate(field: "start" | "end", value: string) {
+    onChange({ preset: "custom", ...range, [field]: value });
+  }
+
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: "8px", flexWrap: "wrap", marginBottom: "16px" }}>
+      {presets.map((p) => (
+        <Pill
+          key={p}
+          label={p === "all" ? "All" : p}
+          active={range.preset === p}
+          onClick={() => selectPreset(p)}
+        />
+      ))}
+      <div style={{ display: "flex", alignItems: "center", gap: "4px", marginLeft: "4px" }}>
+        <label htmlFor="range-start" style={{ fontSize: "10px", color: "var(--fg-subtle)" }}>Start date</label>
+        <input
+          id="range-start"
+          type="date"
+          value={range.start}
+          onChange={(e) => handleCustomDate("start", e.target.value)}
+          style={{
+            fontSize: "11px",
+            padding: "2px 6px",
+            borderRadius: "5px",
+            border: "1px solid var(--border-base)",
+            background: "var(--bg-surface)",
+            color: "var(--fg-base)",
+          }}
+        />
+        <label htmlFor="range-end" style={{ fontSize: "10px", color: "var(--fg-subtle)" }}>End date</label>
+        <input
+          id="range-end"
+          type="date"
+          value={range.end}
+          onChange={(e) => handleCustomDate("end", e.target.value)}
+          style={{
+            fontSize: "11px",
+            padding: "2px 6px",
+            borderRadius: "5px",
+            border: "1px solid var(--border-base)",
+            background: "var(--bg-surface)",
+            color: "var(--fg-base)",
+          }}
+        />
+      </div>
+      {hasOverrides && (
+        <button
+          onClick={onResetOverrides}
+          style={{
+            fontSize: "10px",
+            padding: "2px 8px",
+            borderRadius: "5px",
+            border: "1px solid var(--border-base)",
+            background: "var(--bg-base)",
+            color: "var(--fg-muted)",
+            cursor: "pointer",
+            marginLeft: "4px",
+          }}
+        >
+          Reset overrides
+        </button>
+      )}
+    </div>
+  );
+}
+
 // ── Chart card wrapper ────────────────────────────────────────
 
-function ChartCard({ title, children }: { title: string; children: React.ReactNode }) {
+function ChartCard({
+  title, children, chartId, override, onOverride, onClearOverride, globalRange,
+}: {
+  title: string;
+  children: React.ReactNode;
+  chartId?: string;
+  override?: DateRange | null;
+  onOverride?: (r: DateRange) => void;
+  onClearOverride?: () => void;
+  globalRange?: DateRange;
+}) {
+  const [showPicker, setShowPicker] = useState(false);
+
   return (
     <div style={{
       background: "var(--bg-surface)",
@@ -81,9 +218,37 @@ function ChartCard({ title, children }: { title: string; children: React.ReactNo
       borderRadius: "8px",
       padding: "14px 16px",
     }}>
-      <p style={{ fontSize: "11px", fontWeight: 600, color: "var(--fg-muted)", margin: "0 0 10px", textTransform: "uppercase", letterSpacing: "0.05em" }}>
-        {title}
-      </p>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "10px" }}>
+        <p style={{ fontSize: "11px", fontWeight: 600, color: "var(--fg-muted)", margin: 0, textTransform: "uppercase", letterSpacing: "0.05em" }}>
+          {title}
+        </p>
+        {chartId && (
+          <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+            {override && (
+              <button onClick={onClearOverride} style={{ fontSize: "9px", color: "var(--accent-text)", border: "none", background: "none", cursor: "pointer", padding: "1px 4px" }}>
+                ×reset
+              </button>
+            )}
+            <button
+              onClick={() => setShowPicker((s) => !s)}
+              style={{ fontSize: "9px", color: override ? "var(--accent-text)" : "var(--fg-subtle)", border: "none", background: "none", cursor: "pointer", padding: "1px 4px" }}
+              title="Override date range for this chart"
+            >
+              {override ? `${override.preset !== "custom" ? override.preset : `${override.start}–${override.end}`}` : "range"}
+            </button>
+          </div>
+        )}
+      </div>
+      {showPicker && chartId && globalRange && onOverride && (
+        <div style={{ marginBottom: "8px" }}>
+          <GlobalDateControl
+            range={override ?? globalRange}
+            onChange={(r) => { onOverride(r); setShowPicker(false); }}
+            hasOverrides={false}
+            onResetOverrides={() => {}}
+          />
+        </div>
+      )}
       {children}
     </div>
   );
@@ -108,9 +273,24 @@ export default function DashboardPage() {
   const [data, setData] = useState<StatsCache | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [range, setRange] = useState<TimeRange>("30d");
+  const [globalRange, setGlobalRange] = useState<DateRange>(defaultRange);
+  const [chartOverrides, setChartOverrides] = useState<Record<string, DateRange | null>>({});
   const [accentColor, setAccentColor] = useState(getAccentColor);
   const reducedMotion = useReducedMotion();
+
+  function rangeForChart(chartId: string): DateRange {
+    return chartOverrides[chartId] ?? globalRange;
+  }
+
+  function setChartOverride(chartId: string, range: DateRange) {
+    setChartOverrides((prev) => ({ ...prev, [chartId]: range }));
+  }
+
+  function clearOverride(chartId: string) {
+    setChartOverrides((prev) => ({ ...prev, [chartId]: null }));
+  }
+
+  const hasOverrides = Object.values(chartOverrides).some(Boolean);
 
   useEffect(() => {
     readStatsCache()
@@ -129,14 +309,27 @@ export default function DashboardPage() {
     return daysBetween(data.lastComputedDate) > 3;
   }, [data]);
 
-  const filteredActivity = useMemo((): DailyActivity[] => {
-    if (!data?.dailyActivity) return [];
-    const all = data.dailyActivity;
-    if (range === "all") return all;
-    const cutoff = range === "30d" ? 30 : 90;
-    const threshold = Date.now() - cutoff * 24 * 60 * 60 * 1000;
-    return all.filter((d) => new Date(d.date + "T00:00:00").getTime() >= threshold);
-  }, [data, range]);
+  const filteredActivity = useMemo(() =>
+    filterByRange(data?.dailyActivity ?? [], globalRange),
+    [data, globalRange]
+  );
+
+  const totalToolCalls = useMemo(() => {
+    if (!data?.dailyActivity) return 0;
+    return data.dailyActivity.reduce((sum, d) => sum + (d.toolCallCount ?? 0), 0);
+  }, [data]);
+
+  const cacheHitRate = useMemo(() => {
+    if (!data?.modelUsage) return null;
+    let totalCacheRead = 0;
+    let totalInput = 0;
+    for (const usage of Object.values(data.modelUsage)) {
+      totalCacheRead += usage.cacheReadInputTokens ?? 0;
+      totalInput += usage.inputTokens ?? 0;
+    }
+    if (totalInput === 0) return null;
+    return Math.round((totalCacheRead / totalInput) * 100);
+  }, [data]);
 
   const activityChartData = useMemo(() =>
     filteredActivity.map((d) => ({
@@ -217,37 +410,47 @@ export default function DashboardPage() {
         </p>
       </div>
 
-      {/* Stale warning */}
-      {isStale && data?.lastComputedDate && (
+      {/* Last updated / stale indicator */}
+      {data?.lastComputedDate && (
         <div style={{
-          background: "rgba(217, 119, 6, 0.1)",
-          border: "1px solid rgba(217, 119, 6, 0.3)",
-          borderRadius: "6px",
-          padding: "7px 12px",
           fontSize: "11px",
-          color: "var(--warning)",
+          color: "var(--fg-subtle)",
           marginBottom: "16px",
         }}>
-          Stats cache last updated {daysBetween(data.lastComputedDate)} days ago — data may be incomplete.
+          Last updated {isStale ? `${daysBetween(data.lastComputedDate)} days ago` : formatDate(data.lastComputedDate)}
         </div>
       )}
+
+      {/* Global date range control */}
+      <GlobalDateControl
+        range={globalRange}
+        onChange={(r) => { setGlobalRange(r); setChartOverrides({}); }}
+        hasOverrides={hasOverrides}
+        onResetOverrides={() => setChartOverrides({})}
+      />
 
       {/* Stats bar */}
       <div style={{ display: "flex", gap: "10px", marginBottom: "16px" }}>
         <StatCard label="Total Sessions" value={formatNumber(data?.totalSessions ?? 0)} />
         <StatCard label="Total Messages" value={formatNumber(data?.totalMessages ?? 0)} />
         <StatCard label="Models Used" value={String(modelCount)} />
+        <StatCard label="Tool Calls" value={formatNumber(totalToolCalls)} />
+        {cacheHitRate !== null && (
+          <StatCard label="Cache Hit Rate" value={`${cacheHitRate}%`} />
+        )}
         <StatCard label="First Session" value={firstSessionDate} />
       </div>
 
       {/* Activity chart */}
       <div style={{ marginBottom: "16px" }}>
-        <ChartCard title="Daily Activity">
-          <div style={{ display: "flex", gap: "6px", marginBottom: "10px" }}>
-            {(["30d", "90d", "all"] as TimeRange[]).map((r) => (
-              <Pill key={r} label={r === "all" ? "All" : r} active={range === r} onClick={() => setRange(r)} />
-            ))}
-          </div>
+        <ChartCard
+          title="Daily Activity"
+          chartId="activity"
+          override={chartOverrides["activity"]}
+          onOverride={(r) => setChartOverride("activity", r)}
+          onClearOverride={() => clearOverride("activity")}
+          globalRange={globalRange}
+        >
           {activityChartData.length > 0 ? (
             <ResponsiveContainer width="100%" height={140}>
               <AreaChart data={activityChartData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
@@ -283,7 +486,14 @@ export default function DashboardPage() {
       {/* Model breakdown + hourly distribution */}
       <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "12px" }}>
         {/* Model breakdown — horizontal bar chart */}
-        <ChartCard title="Output Tokens by Model">
+        <ChartCard
+          title="Output Tokens by Model"
+          chartId="model-tokens"
+          override={chartOverrides["model-tokens"]}
+          onOverride={(r) => setChartOverride("model-tokens", r)}
+          onClearOverride={() => clearOverride("model-tokens")}
+          globalRange={globalRange}
+        >
           {modelChartData.length > 0 ? (
             <ResponsiveContainer width="100%" height={160}>
               <BarChart data={modelChartData} layout="vertical" margin={{ top: 4, right: 8, left: 0, bottom: 0 }}>
@@ -300,7 +510,14 @@ export default function DashboardPage() {
         </ChartCard>
 
         {/* Hourly distribution */}
-        <ChartCard title="Activity by Hour of Day">
+        <ChartCard
+          title="Activity by Hour of Day"
+          chartId="hourly"
+          override={chartOverrides["hourly"]}
+          onOverride={(r) => setChartOverride("hourly", r)}
+          onClearOverride={() => clearOverride("hourly")}
+          globalRange={globalRange}
+        >
           {hourlyChartData.some((d) => d.count > 0) ? (
             <ResponsiveContainer width="100%" height={160}>
               <BarChart data={hourlyChartData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>

--- a/apps/desktop/src/pages/observatory/DashboardPage.tsx
+++ b/apps/desktop/src/pages/observatory/DashboardPage.tsx
@@ -3,12 +3,14 @@ import {
   AreaChart, Area,
   BarChart, Bar,
   XAxis, YAxis,
-  CartesianGrid, Tooltip,
+  CartesianGrid, Tooltip, Legend,
   ResponsiveContainer,
 } from "recharts";
 import { readStatsCache, readLiveActivity } from "../../lib/tauri";
 import { formatNumber, formatDate, formatHour, shortModelName } from "../../lib/format";
 import type { StatsCache, LiveDailyActivity } from "@harness-kit/shared";
+
+const MODEL_COLORS = ["#5b50e8", "#0d9488", "#ea580c", "#16a34a", "#2563eb", "#e11d48"];
 
 // ── Date range types ─────────────────────────────────────────
 
@@ -361,15 +363,47 @@ export default function DashboardPage() {
     };
   }, [data]);
 
-  const modelChartData = useMemo(() => {
+  const { dailyTokensChartData, allModelNames } = useMemo(() => {
+    if (!data?.dailyModelTokens?.length) return { dailyTokensChartData: [], allModelNames: [] };
+
+    const modelSet = new Set<string>();
+    data.dailyModelTokens.forEach((d) => {
+      Object.keys(d.tokensByModel ?? {}).forEach((m) => modelSet.add(m));
+    });
+    const models = Array.from(modelSet);
+
+    const filtered = filterByRange(data.dailyModelTokens, rangeForChart("dailyTokens"));
+    const chartData = filtered.map((d) => {
+      const row: Record<string, unknown> = { date: formatDate(d.date) };
+      models.forEach((m) => {
+        row[shortModelName(m)] = d.tokensByModel?.[m] ?? 0;
+      });
+      return row;
+    });
+
+    return {
+      dailyTokensChartData: chartData,
+      allModelNames: models.map(shortModelName),
+    };
+  }, [data, globalRange, chartOverrides]);
+
+  const tokenTypeData = useMemo(() => {
     if (!data?.modelUsage) return [];
-    return Object.entries(data.modelUsage)
-      .map(([model, usage]) => ({
-        name: shortModelName(model),
-        tokens: (usage.outputTokens ?? 0),
-      }))
-      .sort((a, b) => b.tokens - a.tokens);
+    return Object.entries(data.modelUsage).map(([model, usage]) => ({
+      name: shortModelName(model),
+      Input: usage.inputTokens ?? 0,
+      Output: usage.outputTokens ?? 0,
+      "Cache Read": usage.cacheReadInputTokens ?? 0,
+      "Cache Create": usage.cacheCreationInputTokens ?? 0,
+    })).sort((a, b) => (b.Output) - (a.Output));
   }, [data]);
+
+  const TOKEN_TYPE_COLORS: Record<string, string> = {
+    Input: "var(--fg-subtle)",
+    Output: accentColor,
+    "Cache Read": "#0d9488",
+    "Cache Create": "#636366",
+  };
 
   const hourlyChartData = useMemo(() => {
     if (!data?.hourCounts) return [];
@@ -530,33 +564,61 @@ export default function DashboardPage() {
         </ChartCard>
       </div>
 
-      {/* Model breakdown + hourly distribution */}
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "12px" }}>
-        {/* Model breakdown — horizontal bar chart */}
-        <ChartCard
-          title="Output Tokens by Model"
-          chartId="model-tokens"
-          override={chartOverrides["model-tokens"]}
-          onOverride={(r) => setChartOverride("model-tokens", r)}
-          onClearOverride={() => clearOverride("model-tokens")}
-          globalRange={globalRange}
-        >
-          {modelChartData.length > 0 ? (
-            <ResponsiveContainer width="100%" height={160}>
-              <BarChart data={modelChartData} layout="vertical" margin={{ top: 4, right: 8, left: 0, bottom: 0 }}>
-                <XAxis type="number" tick={axisStyle} tickLine={false} axisLine={false} tickFormatter={(v) => v >= 1_000_000 ? `${(v/1_000_000).toFixed(1)}M` : v >= 1000 ? `${(v/1000).toFixed(0)}k` : String(v)} />
-                <YAxis type="category" dataKey="name" tick={axisStyle} tickLine={false} axisLine={false} width={70} />
+      {/* Daily tokens by model — stacked area */}
+      {dailyTokensChartData.length > 0 && (
+        <div style={{ marginBottom: "12px" }}>
+          <ChartCard title="Daily Tokens by Model" chartId="dailyTokens"
+            override={chartOverrides["dailyTokens"]} globalRange={globalRange}
+            onOverride={(r) => setChartOverride("dailyTokens", r)}
+            onClearOverride={() => clearOverride("dailyTokens")}
+          >
+            <ResponsiveContainer width="100%" height={150}>
+              <AreaChart data={dailyTokensChartData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--border-base)" vertical={false} />
+                <XAxis dataKey="date" tick={axisStyle} tickLine={false} axisLine={false} interval="preserveStartEnd" />
+                <YAxis tick={axisStyle} tickLine={false} axisLine={false}
+                  tickFormatter={(v: number) => v >= 1_000_000 ? `${(v/1_000_000).toFixed(1)}M` : v >= 1000 ? `${(v/1000).toFixed(0)}k` : String(v)} />
                 {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-                <Tooltip contentStyle={tooltipStyle} formatter={((v: any) => formatNumber(v)) as any} />
-                <Bar dataKey="tokens" fill={accentColor} radius={[0, 3, 3, 0]} isAnimationActive={!reducedMotion} />
+                <Tooltip contentStyle={tooltipStyle} formatter={((v: number) => formatNumber(v)) as any} />
+                <Legend wrapperStyle={{ fontSize: "10px" }} />
+                {allModelNames.map((name, i) => (
+                  <Area key={name} type="monotone" dataKey={name} stackId="a"
+                    stroke={MODEL_COLORS[i % MODEL_COLORS.length]}
+                    fill={MODEL_COLORS[i % MODEL_COLORS.length]}
+                    fillOpacity={0.5} strokeWidth={1}
+                    isAnimationActive={!reducedMotion} />
+                ))}
+              </AreaChart>
+            </ResponsiveContainer>
+          </ChartCard>
+        </div>
+      )}
+
+      {/* Token type breakdown — stacked horizontal bars (no range filter — totals only) */}
+      {tokenTypeData.length > 0 && (
+        <div style={{ marginBottom: "12px" }}>
+          <ChartCard title="Token Type Breakdown by Model">
+            <ResponsiveContainer width="100%" height={Math.max(120, tokenTypeData.length * 36)}>
+              <BarChart data={tokenTypeData} layout="vertical" margin={{ top: 4, right: 8, left: 0, bottom: 0 }}>
+                <XAxis type="number" tick={axisStyle} tickLine={false} axisLine={false}
+                  tickFormatter={(v: number) => v >= 1_000_000 ? `${(v/1_000_000).toFixed(1)}M` : v >= 1000 ? `${(v/1000).toFixed(0)}k` : String(v)} />
+                <YAxis type="category" dataKey="name" tick={axisStyle} tickLine={false} axisLine={false} width={80} />
+                {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+                <Tooltip contentStyle={tooltipStyle} formatter={((v: number) => formatNumber(v)) as any} />
+                <Legend wrapperStyle={{ fontSize: "10px" }} />
+                {(["Input", "Output", "Cache Read", "Cache Create"] as const).map((type) => (
+                  <Bar key={type} dataKey={type} stackId="a"
+                    fill={TOKEN_TYPE_COLORS[type]}
+                    isAnimationActive={!reducedMotion} />
+                ))}
               </BarChart>
             </ResponsiveContainer>
-          ) : (
-            <p style={{ fontSize: "12px", color: "var(--fg-subtle)", textAlign: "center", padding: "20px 0" }}>No model data.</p>
-          )}
-        </ChartCard>
+          </ChartCard>
+        </div>
+      )}
 
-        {/* Hourly distribution */}
+      {/* Hourly distribution */}
+      <div style={{ marginBottom: "12px" }}>
         <ChartCard
           title="Activity by Hour of Day"
           chartId="hourly"

--- a/apps/desktop/src/pages/observatory/DashboardPage.tsx
+++ b/apps/desktop/src/pages/observatory/DashboardPage.tsx
@@ -313,17 +313,17 @@ export default function DashboardPage() {
     setAccentColor(getAccentColor());
   }, []);
 
-  const filteredLiveActivity = useMemo(() =>
+  const filteredMessagesActivity = useMemo(() =>
     filterByRange(liveActivity, rangeForChart("messages")),
     [liveActivity, globalRange, chartOverrides]
   );
 
   const activityChartData = useMemo(() =>
-    filteredLiveActivity.map((d) => ({
+    filteredMessagesActivity.map((d) => ({
       date: formatDate(d.date),
       messages: d.messageCount,
     })),
-    [filteredLiveActivity]
+    [filteredMessagesActivity]
   );
 
   const sessionsChartData = useMemo(() => {
@@ -469,7 +469,7 @@ export default function DashboardPage() {
       />
 
       {/* Stats bar */}
-      <div style={{ display: "flex", gap: "10px", marginBottom: "16px" }}>
+      <div style={{ display: "flex", gap: "10px", marginBottom: "16px", flexWrap: "wrap" }}>
         <StatCard label="Total Sessions" value={formatNumber(data?.totalSessions ?? 0)} />
         <StatCard label="Total Messages" value={formatNumber(data?.totalMessages ?? 0)} />
         <StatCard label="Tool Calls" value={formatNumber(totalToolCalls)} />

--- a/apps/desktop/src/pages/observatory/DashboardPage.tsx
+++ b/apps/desktop/src/pages/observatory/DashboardPage.tsx
@@ -275,9 +275,6 @@ const axisStyle = { fontSize: 10, fill: "var(--fg-subtle)" };
 
 export default function DashboardPage() {
   const [data, setData] = useState<StatsCache | null>(null);
-  // liveActivity will be consumed by activity charts (Task 6)
-  // @ts-expect-error liveActivity unused until Task 6 wires it to charts
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [liveActivity, setLiveActivity] = useState<LiveDailyActivity[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -296,6 +293,10 @@ export default function DashboardPage() {
 
   const hasOverrides = Object.values(chartOverrides).some(Boolean);
 
+  function rangeForChart(chartId: string): DateRange {
+    return chartOverrides[chartId] ?? globalRange;
+  }
+
   useEffect(() => {
     Promise.all([
       readStatsCache().then(setData),
@@ -310,10 +311,34 @@ export default function DashboardPage() {
     setAccentColor(getAccentColor());
   }, []);
 
-  const filteredActivity = useMemo(() =>
-    filterByRange(data?.dailyActivity ?? [], globalRange),
-    [data, globalRange]
+  const filteredLiveActivity = useMemo(() =>
+    filterByRange(liveActivity, rangeForChart("messages")),
+    [liveActivity, globalRange, chartOverrides]
   );
+
+  const activityChartData = useMemo(() =>
+    filteredLiveActivity.map((d) => ({
+      date: formatDate(d.date),
+      messages: d.messageCount,
+    })),
+    [filteredLiveActivity]
+  );
+
+  const sessionsChartData = useMemo(() => {
+    const filtered = filterByRange(liveActivity, rangeForChart("sessions"));
+    return filtered.map((d) => ({
+      date: formatDate(d.date),
+      sessions: d.sessionCount,
+    }));
+  }, [liveActivity, globalRange, chartOverrides]);
+
+  const toolCallsChartData = useMemo(() => {
+    const filtered = filterByRange(data?.dailyActivity ?? [], rangeForChart("toolCalls"));
+    return filtered.map((d) => ({
+      date: formatDate(d.date),
+      toolCalls: d.toolCallCount ?? 0,
+    }));
+  }, [data, globalRange, chartOverrides]);
 
   const totalToolCalls = useMemo(() => {
     if (!data?.dailyActivity) return 0;
@@ -335,14 +360,6 @@ export default function DashboardPage() {
       cacheHitRate: total > 0 ? Math.round((cacheRead / total) * 100) : null,
     };
   }, [data]);
-
-  const activityChartData = useMemo(() =>
-    filteredActivity.map((d) => ({
-      date: formatDate(d.date),
-      messages: d.messageCount ?? 0,
-    })),
-    [filteredActivity]
-  );
 
   const modelChartData = useMemo(() => {
     if (!data?.modelUsage) return [];
@@ -438,45 +455,78 @@ export default function DashboardPage() {
         />
       </div>
 
-      {/* Activity chart */}
-      <div style={{ marginBottom: "16px" }}>
-        <ChartCard
-          title="Daily Activity"
-          chartId="activity"
-          override={chartOverrides["activity"]}
-          onOverride={(r) => setChartOverride("activity", r)}
-          onClearOverride={() => clearOverride("activity")}
-          globalRange={globalRange}
+      {/* Messages chart — full width */}
+      <div style={{ marginBottom: "12px" }}>
+        <ChartCard title="Messages per Day" chartId="messages"
+          override={chartOverrides["messages"]} globalRange={globalRange}
+          onOverride={(r) => setChartOverride("messages", r)}
+          onClearOverride={() => clearOverride("messages")}
         >
-          {activityChartData.length > 0 ? (
-            <ResponsiveContainer width="100%" height={140}>
-              <AreaChart data={activityChartData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
-                <defs>
-                  <linearGradient id="activityGrad" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="5%" stopColor={accentColor} stopOpacity={0.25} />
-                    <stop offset="95%" stopColor={accentColor} stopOpacity={0.02} />
-                  </linearGradient>
-                </defs>
-                <CartesianGrid strokeDasharray="3 3" stroke="var(--border-base)" vertical={false} />
-                <XAxis dataKey="date" tick={axisStyle} tickLine={false} axisLine={false} interval="preserveStartEnd" />
-                <YAxis tick={axisStyle} tickLine={false} axisLine={false} />
-                <Tooltip contentStyle={tooltipStyle} cursor={{ stroke: "var(--border-strong)", strokeWidth: 1 }} />
-                <Area
-                  type="monotone"
-                  dataKey="messages"
-                  stroke={accentColor}
-                  strokeWidth={1.5}
-                  fill="url(#activityGrad)"
-                  dot={false}
-                  isAnimationActive={!reducedMotion}
-                />
-              </AreaChart>
-            </ResponsiveContainer>
-          ) : (
-            <p style={{ fontSize: "12px", color: "var(--fg-subtle)", textAlign: "center", padding: "20px 0" }}>
-              No activity data in this range.
-            </p>
-          )}
+          <ResponsiveContainer width="100%" height={130}>
+            <AreaChart data={activityChartData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
+              <defs>
+                <linearGradient id="msgGrad" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor={accentColor} stopOpacity={0.25} />
+                  <stop offset="95%" stopColor={accentColor} stopOpacity={0.02} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--border-base)" vertical={false} />
+              <XAxis dataKey="date" tick={axisStyle} tickLine={false} axisLine={false} interval="preserveStartEnd" />
+              <YAxis tick={axisStyle} tickLine={false} axisLine={false} />
+              <Tooltip contentStyle={tooltipStyle} />
+              <Area type="monotone" dataKey="messages" stroke={accentColor} strokeWidth={1.5}
+                fill="url(#msgGrad)" dot={false} isAnimationActive={!reducedMotion} />
+            </AreaChart>
+          </ResponsiveContainer>
+        </ChartCard>
+      </div>
+
+      {/* Sessions + Tool Calls — side by side */}
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "12px", marginBottom: "12px" }}>
+        <ChartCard title="Sessions per Day" chartId="sessions"
+          override={chartOverrides["sessions"]} globalRange={globalRange}
+          onOverride={(r) => setChartOverride("sessions", r)}
+          onClearOverride={() => clearOverride("sessions")}
+        >
+          <ResponsiveContainer width="100%" height={120}>
+            <AreaChart data={sessionsChartData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
+              <defs>
+                <linearGradient id="sessGrad" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor={accentColor} stopOpacity={0.2} />
+                  <stop offset="95%" stopColor={accentColor} stopOpacity={0.01} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--border-base)" vertical={false} />
+              <XAxis dataKey="date" tick={axisStyle} tickLine={false} axisLine={false} interval="preserveStartEnd" />
+              <YAxis tick={axisStyle} tickLine={false} axisLine={false} />
+              <Tooltip contentStyle={tooltipStyle} />
+              <Area type="monotone" dataKey="sessions" stroke={accentColor} strokeWidth={1.5}
+                fill="url(#sessGrad)" dot={false} isAnimationActive={!reducedMotion} />
+            </AreaChart>
+          </ResponsiveContainer>
+        </ChartCard>
+
+        <ChartCard title="Tool Calls per Day" chartId="toolCalls"
+          override={chartOverrides["toolCalls"]} globalRange={globalRange}
+          onOverride={(r) => setChartOverride("toolCalls", r)}
+          onClearOverride={() => clearOverride("toolCalls")}
+        >
+          <ResponsiveContainer width="100%" height={120}>
+            <AreaChart data={toolCallsChartData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
+              <defs>
+                <linearGradient id="tcGrad" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor={accentColor} stopOpacity={0.2} />
+                  <stop offset="95%" stopColor={accentColor} stopOpacity={0.01} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--border-base)" vertical={false} />
+              <XAxis dataKey="date" tick={axisStyle} tickLine={false} axisLine={false} interval="preserveStartEnd" />
+              <YAxis tick={axisStyle} tickLine={false} axisLine={false} />
+              <Tooltip contentStyle={tooltipStyle} />
+              <Area type="monotone" dataKey="toolCalls" stroke={accentColor} strokeWidth={1.5}
+                fill="url(#tcGrad)" dot={false} isAnimationActive={!reducedMotion} />
+            </AreaChart>
+          </ResponsiveContainer>
         </ChartCard>
       </div>
 

--- a/apps/desktop/src/pages/observatory/DashboardPage.tsx
+++ b/apps/desktop/src/pages/observatory/DashboardPage.tsx
@@ -1,0 +1,321 @@
+import { useEffect, useState, useMemo } from "react";
+import {
+  AreaChart, Area,
+  BarChart, Bar,
+  XAxis, YAxis,
+  CartesianGrid, Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { readStatsCache } from "../../lib/tauri";
+import { formatNumber, formatDate, formatHour, shortModelName, daysBetween } from "../../lib/format";
+import type { StatsCache, DailyActivity } from "@harness-kit/shared";
+
+type TimeRange = "30d" | "90d" | "all";
+
+function useReducedMotion() {
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+function getAccentColor() {
+  return getComputedStyle(document.documentElement).getPropertyValue("--accent").trim() || "#5b50e8";
+}
+
+// ── Stat card ────────────────────────────────────────────────
+
+function StatCard({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div style={{
+      flex: 1,
+      minWidth: 0,
+      background: "var(--bg-surface)",
+      border: "1px solid var(--border-base)",
+      borderRadius: "8px",
+      padding: "12px 16px",
+    }}>
+      <div style={{ fontSize: "20px", fontWeight: 600, letterSpacing: "-0.5px", color: "var(--fg-base)", lineHeight: 1.1 }}>
+        {value}
+      </div>
+      <div style={{ fontSize: "10px", fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--fg-subtle)", marginTop: "4px" }}>
+        {label}
+      </div>
+      {sub && (
+        <div style={{ fontSize: "10px", color: "var(--fg-subtle)", marginTop: "2px" }}>
+          {sub}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Pill button ───────────────────────────────────────────────
+
+function Pill({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      aria-pressed={active}
+      style={{
+        fontSize: "11px",
+        fontWeight: active ? 600 : 400,
+        padding: "3px 10px",
+        borderRadius: "12px",
+        border: "1px solid",
+        borderColor: active ? "var(--accent)" : "var(--border-base)",
+        background: active ? "var(--accent-light)" : "transparent",
+        color: active ? "var(--accent-text)" : "var(--fg-muted)",
+        cursor: "pointer",
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+// ── Chart card wrapper ────────────────────────────────────────
+
+function ChartCard({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div style={{
+      background: "var(--bg-surface)",
+      border: "1px solid var(--border-base)",
+      borderRadius: "8px",
+      padding: "14px 16px",
+    }}>
+      <p style={{ fontSize: "11px", fontWeight: 600, color: "var(--fg-muted)", margin: "0 0 10px", textTransform: "uppercase", letterSpacing: "0.05em" }}>
+        {title}
+      </p>
+      {children}
+    </div>
+  );
+}
+
+// ── Custom tooltip style ──────────────────────────────────────
+
+const tooltipStyle = {
+  background: "var(--bg-elevated)",
+  border: "1px solid var(--border-base)",
+  borderRadius: "6px",
+  fontSize: "11px",
+  color: "var(--fg-base)",
+  padding: "6px 10px",
+};
+
+const axisStyle = { fontSize: 10, fill: "var(--fg-subtle)" };
+
+// ── Main component ────────────────────────────────────────────
+
+export default function DashboardPage() {
+  const [data, setData] = useState<StatsCache | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [range, setRange] = useState<TimeRange>("30d");
+  const [accentColor, setAccentColor] = useState(getAccentColor);
+  const reducedMotion = useReducedMotion();
+
+  useEffect(() => {
+    readStatsCache()
+      .then(setData)
+      .catch((e) => setError(String(e)))
+      .finally(() => setLoading(false));
+  }, []);
+
+  // Re-read accent on mount to pick up dynamic theme
+  useEffect(() => {
+    setAccentColor(getAccentColor());
+  }, []);
+
+  const isStale = useMemo(() => {
+    if (!data?.lastComputedDate) return false;
+    return daysBetween(data.lastComputedDate) > 3;
+  }, [data]);
+
+  const filteredActivity = useMemo((): DailyActivity[] => {
+    if (!data?.dailyActivity) return [];
+    const all = data.dailyActivity;
+    if (range === "all") return all;
+    const cutoff = range === "30d" ? 30 : 90;
+    const threshold = Date.now() - cutoff * 24 * 60 * 60 * 1000;
+    return all.filter((d) => new Date(d.date + "T00:00:00").getTime() >= threshold);
+  }, [data, range]);
+
+  const activityChartData = useMemo(() =>
+    filteredActivity.map((d) => ({
+      date: formatDate(d.date),
+      messages: d.messageCount ?? 0,
+    })),
+    [filteredActivity]
+  );
+
+  const modelChartData = useMemo(() => {
+    if (!data?.modelUsage) return [];
+    return Object.entries(data.modelUsage)
+      .map(([model, usage]) => ({
+        name: shortModelName(model),
+        tokens: (usage.outputTokens ?? 0),
+      }))
+      .sort((a, b) => b.tokens - a.tokens);
+  }, [data]);
+
+  const hourlyChartData = useMemo(() => {
+    if (!data?.hourCounts) return [];
+    return Array.from({ length: 24 }, (_, i) => ({
+      hour: formatHour(i),
+      count: data.hourCounts?.[String(i)] ?? 0,
+    }));
+  }, [data]);
+
+  const modelCount = useMemo(() => {
+    if (!data?.modelUsage) return 0;
+    return Object.keys(data.modelUsage).length;
+  }, [data]);
+
+  const firstSessionDate = useMemo(() => {
+    if (!data?.dailyActivity?.length) return "—";
+    const dates = data.dailyActivity.map((d) => d.date).sort();
+    return formatDate(dates[0]);
+  }, [data]);
+
+  if (loading) {
+    return (
+      <div style={{ padding: "20px 24px" }}>
+        <p style={{ fontSize: "13px", color: "var(--fg-subtle)" }}>Loading…</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div style={{ padding: "20px 24px" }}>
+        <div style={{ marginBottom: "16px" }}>
+          <h1 style={{ fontSize: "17px", fontWeight: 600, letterSpacing: "-0.3px", color: "var(--fg-base)", margin: 0 }}>
+            Observatory
+          </h1>
+        </div>
+        <div style={{
+          background: "var(--bg-surface)",
+          border: "1px solid var(--border-base)",
+          borderRadius: "8px",
+          padding: "10px 14px",
+          fontSize: "13px",
+          color: "var(--danger)",
+        }}>
+          {error}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: "20px 24px" }}>
+      {/* Header */}
+      <div style={{ marginBottom: "16px" }}>
+        <h1 style={{ fontSize: "17px", fontWeight: 600, letterSpacing: "-0.3px", color: "var(--fg-base)", margin: 0 }}>
+          Observatory
+        </h1>
+        <p style={{ fontSize: "12px", color: "var(--fg-muted)", margin: "3px 0 0" }}>
+          Claude Code usage patterns and activity trends
+        </p>
+      </div>
+
+      {/* Stale warning */}
+      {isStale && data?.lastComputedDate && (
+        <div style={{
+          background: "rgba(217, 119, 6, 0.1)",
+          border: "1px solid rgba(217, 119, 6, 0.3)",
+          borderRadius: "6px",
+          padding: "7px 12px",
+          fontSize: "11px",
+          color: "var(--warning)",
+          marginBottom: "16px",
+        }}>
+          Stats cache last updated {daysBetween(data.lastComputedDate)} days ago — data may be incomplete.
+        </div>
+      )}
+
+      {/* Stats bar */}
+      <div style={{ display: "flex", gap: "10px", marginBottom: "16px" }}>
+        <StatCard label="Total Sessions" value={formatNumber(data?.totalSessions ?? 0)} />
+        <StatCard label="Total Messages" value={formatNumber(data?.totalMessages ?? 0)} />
+        <StatCard label="Models Used" value={String(modelCount)} />
+        <StatCard label="First Session" value={firstSessionDate} />
+      </div>
+
+      {/* Activity chart */}
+      <div style={{ marginBottom: "16px" }}>
+        <ChartCard title="Daily Activity">
+          <div style={{ display: "flex", gap: "6px", marginBottom: "10px" }}>
+            {(["30d", "90d", "all"] as TimeRange[]).map((r) => (
+              <Pill key={r} label={r === "all" ? "All" : r} active={range === r} onClick={() => setRange(r)} />
+            ))}
+          </div>
+          {activityChartData.length > 0 ? (
+            <ResponsiveContainer width="100%" height={140}>
+              <AreaChart data={activityChartData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
+                <defs>
+                  <linearGradient id="activityGrad" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor={accentColor} stopOpacity={0.25} />
+                    <stop offset="95%" stopColor={accentColor} stopOpacity={0.02} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--border-base)" vertical={false} />
+                <XAxis dataKey="date" tick={axisStyle} tickLine={false} axisLine={false} interval="preserveStartEnd" />
+                <YAxis tick={axisStyle} tickLine={false} axisLine={false} />
+                <Tooltip contentStyle={tooltipStyle} cursor={{ stroke: "var(--border-strong)", strokeWidth: 1 }} />
+                <Area
+                  type="monotone"
+                  dataKey="messages"
+                  stroke={accentColor}
+                  strokeWidth={1.5}
+                  fill="url(#activityGrad)"
+                  dot={false}
+                  isAnimationActive={!reducedMotion}
+                />
+              </AreaChart>
+            </ResponsiveContainer>
+          ) : (
+            <p style={{ fontSize: "12px", color: "var(--fg-subtle)", textAlign: "center", padding: "20px 0" }}>
+              No activity data in this range.
+            </p>
+          )}
+        </ChartCard>
+      </div>
+
+      {/* Model breakdown + hourly distribution */}
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "12px" }}>
+        {/* Model breakdown — horizontal bar chart */}
+        <ChartCard title="Output Tokens by Model">
+          {modelChartData.length > 0 ? (
+            <ResponsiveContainer width="100%" height={160}>
+              <BarChart data={modelChartData} layout="vertical" margin={{ top: 4, right: 8, left: 0, bottom: 0 }}>
+                <XAxis type="number" tick={axisStyle} tickLine={false} axisLine={false} tickFormatter={(v) => v >= 1_000_000 ? `${(v/1_000_000).toFixed(1)}M` : v >= 1000 ? `${(v/1000).toFixed(0)}k` : String(v)} />
+                <YAxis type="category" dataKey="name" tick={axisStyle} tickLine={false} axisLine={false} width={70} />
+                {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+                <Tooltip contentStyle={tooltipStyle} formatter={((v: any) => formatNumber(v)) as any} />
+                <Bar dataKey="tokens" fill={accentColor} radius={[0, 3, 3, 0]} isAnimationActive={!reducedMotion} />
+              </BarChart>
+            </ResponsiveContainer>
+          ) : (
+            <p style={{ fontSize: "12px", color: "var(--fg-subtle)", textAlign: "center", padding: "20px 0" }}>No model data.</p>
+          )}
+        </ChartCard>
+
+        {/* Hourly distribution */}
+        <ChartCard title="Activity by Hour of Day">
+          {hourlyChartData.some((d) => d.count > 0) ? (
+            <ResponsiveContainer width="100%" height={160}>
+              <BarChart data={hourlyChartData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--border-base)" vertical={false} />
+                <XAxis dataKey="hour" tick={axisStyle} tickLine={false} axisLine={false} interval={3} />
+                <YAxis tick={axisStyle} tickLine={false} axisLine={false} />
+                <Tooltip contentStyle={tooltipStyle} />
+                <Bar dataKey="count" fill={accentColor} radius={[2, 2, 0, 0]} isAnimationActive={!reducedMotion} />
+              </BarChart>
+            </ResponsiveContainer>
+          ) : (
+            <p style={{ fontSize: "12px", color: "var(--fg-subtle)", textAlign: "center", padding: "20px 0" }}>No hourly data.</p>
+          )}
+        </ChartCard>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/pages/observatory/SessionsPage.tsx
+++ b/apps/desktop/src/pages/observatory/SessionsPage.tsx
@@ -168,7 +168,7 @@ export default function SessionsPage() {
       .finally(() => setFacetLoading(false));
   }
 
-  const projectCount = new Set(sessions.map((s) => s.project_short).filter(Boolean)).size;
+  const projectCount = new Set(sessions.map((s) => s.projectShort).filter(Boolean)).size;
 
   return (
     <div style={{ padding: "20px 24px" }}>
@@ -219,14 +219,14 @@ export default function SessionsPage() {
       {!loading && !error && sessions.length > 0 && (
         <div className="row-list">
           {sessions.map((session) => {
-            const isExpanded = expandedId === session.session_id;
-            const duration = session.last_timestamp - session.first_timestamp;
+            const isExpanded = expandedId === session.sessionId;
+            const duration = session.lastTimestamp - session.firstTimestamp;
 
             return (
-              <div key={session.session_id}>
+              <div key={session.sessionId}>
                 <button
                   className="row-list-item"
-                  onClick={() => handleRowClick(session.session_id)}
+                  onClick={() => handleRowClick(session.sessionId)}
                   style={{
                     width: "100%",
                     justifyContent: "space-between",
@@ -239,19 +239,19 @@ export default function SessionsPage() {
                   {/* Left: timestamp */}
                   <div style={{ minWidth: "160px" }}>
                     <span style={{ fontSize: "12px", color: "var(--fg-muted)", fontVariantNumeric: "tabular-nums" }}>
-                      {formatTimestamp(session.first_timestamp)}
+                      {formatTimestamp(session.firstTimestamp)}
                     </span>
                   </div>
 
                   {/* Middle: project */}
                   <div style={{ flex: 1, padding: "0 12px" }}>
-                    {session.project_short && <ProjectPill name={session.project_short} />}
+                    {session.projectShort && <ProjectPill name={session.projectShort} />}
                   </div>
 
                   {/* Right: count + duration */}
                   <div style={{ display: "flex", gap: "10px", alignItems: "center", flexShrink: 0 }}>
                     <span style={{ fontSize: "11px", color: "var(--fg-subtle)" }}>
-                      {formatNumber(session.message_count)} msgs
+                      {formatNumber(session.messageCount)} msgs
                     </span>
                     {duration > 60_000 && (
                       <span style={{ fontSize: "11px", color: "var(--fg-subtle)" }}>

--- a/apps/desktop/src/pages/observatory/SessionsPage.tsx
+++ b/apps/desktop/src/pages/observatory/SessionsPage.tsx
@@ -1,0 +1,282 @@
+import { useEffect, useState } from "react";
+import { listSessionsSummary, readSessionFacet } from "../../lib/tauri";
+import { formatTimestamp, formatDuration, formatNumber } from "../../lib/format";
+import type { SessionSummary, SessionFacet } from "@harness-kit/shared";
+
+// ── Outcome badge ──────────────────────────────────────────────
+
+const OUTCOME_COLORS: Record<string, { bg: string; color: string }> = {
+  fully_achieved:    { bg: "rgba(22,163,74,0.12)",  color: "#16a34a" },
+  mostly_achieved:   { bg: "rgba(13,148,136,0.12)", color: "#0f766e" },
+  partially_achieved: { bg: "rgba(217,119,6,0.12)",  color: "#d97706" },
+  not_achieved:      { bg: "rgba(220,38,38,0.12)",  color: "#dc2626" },
+};
+
+function OutcomeBadge({ outcome }: { outcome: string }) {
+  const style = OUTCOME_COLORS[outcome] ?? { bg: "var(--bg-base)", color: "var(--fg-subtle)" };
+  const label = outcome.replace(/_/g, " ");
+  return (
+    <span style={{
+      fontSize: "10px",
+      fontWeight: 500,
+      padding: "1px 7px",
+      borderRadius: "10px",
+      background: style.bg,
+      color: style.color,
+      textTransform: "capitalize",
+    }}>
+      {label}
+    </span>
+  );
+}
+
+// ── Helpfulness badge ──────────────────────────────────────────
+
+function HelpfulnessBadge({ value }: { value: string }) {
+  const label = value.replace(/_/g, " ");
+  return (
+    <span style={{
+      fontSize: "10px",
+      fontWeight: 400,
+      padding: "1px 7px",
+      borderRadius: "10px",
+      border: "1px solid var(--border-base)",
+      color: "var(--fg-subtle)",
+      textTransform: "capitalize",
+    }}>
+      {label}
+    </span>
+  );
+}
+
+// ── Project pill ───────────────────────────────────────────────
+
+function ProjectPill({ name }: { name: string }) {
+  return (
+    <span style={{
+      fontSize: "10px",
+      fontWeight: 400,
+      padding: "2px 7px",
+      borderRadius: "10px",
+      border: "1px solid var(--border-base)",
+      color: "var(--fg-muted)",
+      background: "var(--bg-base)",
+      maxWidth: "160px",
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+      whiteSpace: "nowrap",
+      display: "inline-block",
+    }}>
+      {name}
+    </span>
+  );
+}
+
+// ── Facet detail panel ─────────────────────────────────────────
+
+function FacetDetail({ facet, loading }: { facet: SessionFacet | null; loading: boolean }) {
+  if (loading) {
+    return (
+      <div style={{ padding: "10px 14px 12px 28px", borderTop: "1px solid var(--separator)" }}>
+        <p style={{ fontSize: "11px", color: "var(--fg-subtle)", margin: 0 }}>Loading insights…</p>
+      </div>
+    );
+  }
+
+  if (!facet) {
+    return (
+      <div style={{ padding: "10px 14px 12px 28px", borderTop: "1px solid var(--separator)" }}>
+        <p style={{ fontSize: "11px", color: "var(--fg-subtle)", margin: 0 }}>No insights available for this session.</p>
+      </div>
+    );
+  }
+
+  const hasFriction = facet.friction_counts && Object.keys(facet.friction_counts).length > 0;
+
+  return (
+    <div style={{ padding: "10px 14px 12px 28px", borderTop: "1px solid var(--separator)", background: "var(--bg-base)" }}>
+      {facet.brief_summary && (
+        <p style={{ fontSize: "12px", color: "var(--fg-muted)", margin: "0 0 8px", lineHeight: 1.5 }}>
+          {facet.brief_summary}
+        </p>
+      )}
+
+      <div style={{ display: "flex", gap: "8px", flexWrap: "wrap", alignItems: "center", marginBottom: facet.underlying_goal ? "8px" : 0 }}>
+        {facet.outcome && <OutcomeBadge outcome={facet.outcome} />}
+        {facet.claude_helpfulness && <HelpfulnessBadge value={facet.claude_helpfulness} />}
+        {facet.session_type && (
+          <span style={{ fontSize: "10px", color: "var(--fg-subtle)", textTransform: "capitalize" }}>
+            {facet.session_type.replace(/_/g, " ")}
+          </span>
+        )}
+      </div>
+
+      {facet.underlying_goal && (
+        <p style={{ fontSize: "11px", color: "var(--fg-subtle)", margin: "0 0 6px" }}>
+          <span style={{ fontWeight: 500, color: "var(--fg-muted)" }}>Goal:</span> {facet.underlying_goal}
+        </p>
+      )}
+
+      {hasFriction && (
+        <div style={{ display: "flex", gap: "4px", flexWrap: "wrap" }}>
+          {Object.entries(facet.friction_counts!).map(([type, count]) => (
+            <span key={type} style={{
+              fontSize: "10px",
+              padding: "1px 6px",
+              borderRadius: "4px",
+              background: "rgba(220,38,38,0.08)",
+              color: "var(--danger)",
+            }}>
+              {type.replace(/_/g, " ")} ×{count}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Main component ─────────────────────────────────────────────
+
+export default function SessionsPage() {
+  const [sessions, setSessions] = useState<SessionSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [facet, setFacet] = useState<SessionFacet | null>(null);
+  const [facetLoading, setFacetLoading] = useState(false);
+
+  useEffect(() => {
+    listSessionsSummary()
+      .then(setSessions)
+      .catch((e) => setError(String(e)))
+      .finally(() => setLoading(false));
+  }, []);
+
+  function handleRowClick(sessionId: string) {
+    if (expandedId === sessionId) {
+      setExpandedId(null);
+      setFacet(null);
+      return;
+    }
+    setExpandedId(sessionId);
+    setFacet(null);
+    setFacetLoading(true);
+    readSessionFacet(sessionId)
+      .then(setFacet)
+      .catch(() => setFacet(null))
+      .finally(() => setFacetLoading(false));
+  }
+
+  const projectCount = new Set(sessions.map((s) => s.project_short).filter(Boolean)).size;
+
+  return (
+    <div style={{ padding: "20px 24px" }}>
+      {/* Header */}
+      <div style={{ marginBottom: "16px" }}>
+        <h1 style={{ fontSize: "17px", fontWeight: 600, letterSpacing: "-0.3px", color: "var(--fg-base)", margin: 0 }}>
+          Sessions
+        </h1>
+        {!loading && !error && (
+          <p style={{ fontSize: "12px", color: "var(--fg-muted)", margin: "3px 0 0" }}>
+            {formatNumber(sessions.length)} {sessions.length === 1 ? "session" : "sessions"} across {projectCount} {projectCount === 1 ? "project" : "projects"}
+          </p>
+        )}
+      </div>
+
+      {loading && (
+        <p style={{ fontSize: "13px", color: "var(--fg-subtle)" }}>Loading…</p>
+      )}
+
+      {error && (
+        <div style={{
+          background: "var(--bg-surface)",
+          border: "1px solid var(--border-base)",
+          borderRadius: "8px",
+          padding: "10px 14px",
+          fontSize: "13px",
+          color: "var(--danger)",
+        }}>
+          {error}
+        </div>
+      )}
+
+      {!loading && !error && sessions.length === 0 && (
+        <div style={{
+          background: "var(--bg-surface)",
+          border: "1px solid var(--border-base)",
+          borderRadius: "8px",
+          padding: "32px 16px",
+          textAlign: "center",
+        }}>
+          <p style={{ fontSize: "13px", color: "var(--fg-muted)", margin: 0 }}>No sessions found.</p>
+          <p style={{ fontSize: "11px", color: "var(--fg-subtle)", margin: "4px 0 0" }}>
+            Sessions are read from <code style={{ fontFamily: "ui-monospace, monospace", fontSize: "10px" }}>~/.claude/history.jsonl</code>
+          </p>
+        </div>
+      )}
+
+      {!loading && !error && sessions.length > 0 && (
+        <div className="row-list">
+          {sessions.map((session) => {
+            const isExpanded = expandedId === session.session_id;
+            const duration = session.last_timestamp - session.first_timestamp;
+
+            return (
+              <div key={session.session_id}>
+                <button
+                  className="row-list-item"
+                  onClick={() => handleRowClick(session.session_id)}
+                  style={{
+                    width: "100%",
+                    justifyContent: "space-between",
+                    background: isExpanded ? "var(--hover-bg)" : undefined,
+                    cursor: "pointer",
+                    border: "none",
+                    textAlign: "left",
+                  }}
+                >
+                  {/* Left: timestamp */}
+                  <div style={{ minWidth: "160px" }}>
+                    <span style={{ fontSize: "12px", color: "var(--fg-muted)", fontVariantNumeric: "tabular-nums" }}>
+                      {formatTimestamp(session.first_timestamp)}
+                    </span>
+                  </div>
+
+                  {/* Middle: project */}
+                  <div style={{ flex: 1, padding: "0 12px" }}>
+                    {session.project_short && <ProjectPill name={session.project_short} />}
+                  </div>
+
+                  {/* Right: count + duration */}
+                  <div style={{ display: "flex", gap: "10px", alignItems: "center", flexShrink: 0 }}>
+                    <span style={{ fontSize: "11px", color: "var(--fg-subtle)" }}>
+                      {formatNumber(session.message_count)} msgs
+                    </span>
+                    {duration > 60_000 && (
+                      <span style={{ fontSize: "11px", color: "var(--fg-subtle)" }}>
+                        {formatDuration(duration)}
+                      </span>
+                    )}
+                    <svg
+                      width="10" height="10"
+                      viewBox="0 0 10 10"
+                      fill="none"
+                      style={{ color: "var(--fg-subtle)", transform: isExpanded ? "rotate(180deg)" : "rotate(0deg)", transition: "transform 0.15s" }}
+                    >
+                      <path d="M2 3.5L5 6.5L8 3.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                  </div>
+                </button>
+
+                {isExpanded && (
+                  <FacetDetail facet={facet} loading={facetLoading} />
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/pages/observatory/__tests__/DashboardPage.test.tsx
+++ b/apps/desktop/src/pages/observatory/__tests__/DashboardPage.test.tsx
@@ -173,7 +173,8 @@ describe("DashboardPage — charts", () => {
     await waitFor(() =>
       expect(screen.queryByText("Loading…")).not.toBeInTheDocument(),
     );
-    expect(screen.getByTestId("area-chart")).toBeInTheDocument();
+    const areaCharts = screen.getAllByTestId("area-chart");
+    expect(areaCharts.length).toBe(3);
   });
 
   it("renders bar charts after load", async () => {

--- a/apps/desktop/src/pages/observatory/__tests__/DashboardPage.test.tsx
+++ b/apps/desktop/src/pages/observatory/__tests__/DashboardPage.test.tsx
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { StatsCache } from "@harness-kit/shared";
+import DashboardPage from "../DashboardPage";
+
+// ── Recharts mock ─────────────────────────────────────────────
+// jsdom cannot render SVG/canvas; mock all recharts components as simple divs.
+// The factory must not reference any variables declared outside it (Vitest hoisting).
+
+vi.mock("recharts", () => ({
+  AreaChart: ({ children }: { children: React.ReactNode }) => <div data-testid="area-chart">{children}</div>,
+  Area: () => null,
+  BarChart: ({ children }: { children: React.ReactNode }) => <div data-testid="bar-chart">{children}</div>,
+  Bar: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+// ── Tauri mock ────────────────────────────────────────────────
+// Variable name starts with "mock" — required for Vitest hoisting to work inside
+// the vi.mock factory (factory runs before module-scope let/const declarations).
+
+let mockReadStatsCache: () => Promise<unknown>;
+
+vi.mock("../../../lib/tauri", () => ({
+  get readStatsCache() { return mockReadStatsCache; },
+}));
+
+// ── Fixtures ──────────────────────────────────────────────────
+
+const mockStats: StatsCache = {
+  lastComputedDate: "2026-03-15",
+  totalSessions: 408,
+  totalMessages: 2814,
+  dailyActivity: [
+    { date: "2026-03-14", messageCount: 45, sessionCount: 3, toolCallCount: 120 },
+    { date: "2026-03-15", messageCount: 30, sessionCount: 2, toolCallCount: 80 },
+  ],
+  modelUsage: {
+    "claude-sonnet-4-6": { inputTokens: 1000, outputTokens: 2000, cacheReadInputTokens: 500, cacheCreationInputTokens: 200 },
+    "claude-opus-4-6": { inputTokens: 500, outputTokens: 1000, cacheReadInputTokens: 200, cacheCreationInputTokens: 100 },
+  },
+  hourCounts: { "9": 50, "10": 80, "14": 60 },
+};
+
+// 5 days before 2026-03-15 → stale (> 3 days)
+const staleStats: StatsCache = {
+  ...mockStats,
+  lastComputedDate: "2026-03-10",
+};
+
+// ── Helpers ───────────────────────────────────────────────────
+
+function renderDashboard() {
+  return render(
+    <MemoryRouter>
+      <DashboardPage />
+    </MemoryRouter>,
+  );
+}
+
+// ── Setup ─────────────────────────────────────────────────────
+
+beforeEach(() => {
+  // window.matchMedia is not available in jsdom; provide a stub.
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      media: "",
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }),
+  });
+});
+
+// ── Tests ─────────────────────────────────────────────────────
+
+describe("DashboardPage — loading state", () => {
+  it("shows 'Loading…' before data arrives", () => {
+    // never-resolving promise keeps the loading state active
+    mockReadStatsCache = () => new Promise(() => {});
+    renderDashboard();
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
+  });
+
+  it("hides 'Loading…' after data loads", async () => {
+    mockReadStatsCache = () => Promise.resolve(mockStats);
+    renderDashboard();
+    await waitFor(() =>
+      expect(screen.queryByText("Loading…")).not.toBeInTheDocument(),
+    );
+  });
+});
+
+describe("DashboardPage — stats bar", () => {
+  beforeEach(() => {
+    mockReadStatsCache = () => Promise.resolve(mockStats);
+  });
+
+  it("shows 408 total sessions", async () => {
+    renderDashboard();
+    // 408 has no comma — just assert the raw number is present
+    expect(await screen.findByText(/^408$/)).toBeInTheDocument();
+  });
+
+  it("shows 2,814 total messages (locale-formatted)", async () => {
+    renderDashboard();
+    expect(await screen.findByText("2,814")).toBeInTheDocument();
+  });
+
+  it("shows 2 models used", async () => {
+    renderDashboard();
+    // The Models Used stat card renders the count as a plain string
+    expect(await screen.findByText("2")).toBeInTheDocument();
+  });
+});
+
+describe("DashboardPage — error state", () => {
+  it("shows the error message when readStatsCache rejects", async () => {
+    mockReadStatsCache = () => Promise.reject(new Error("Failed to read stats"));
+    renderDashboard();
+    expect(await screen.findByText(/Failed to read stats/)).toBeInTheDocument();
+  });
+
+  it("does not show loading spinner after error", async () => {
+    mockReadStatsCache = () => Promise.reject(new Error("Error"));
+    renderDashboard();
+    await screen.findByText(/Error/);
+    expect(screen.queryByText("Loading…")).not.toBeInTheDocument();
+  });
+});
+
+describe("DashboardPage — stale warning", () => {
+  it("shows stale warning when lastComputedDate is 5 days old", async () => {
+    mockReadStatsCache = () => Promise.resolve(staleStats);
+    renderDashboard();
+    expect(await screen.findByText(/days ago/)).toBeInTheDocument();
+  });
+
+  it("does NOT show stale warning when lastComputedDate is today", async () => {
+    mockReadStatsCache = () => Promise.resolve(mockStats);
+    renderDashboard();
+    await waitFor(() =>
+      expect(screen.queryByText("Loading…")).not.toBeInTheDocument(),
+    );
+    expect(screen.queryByText(/days ago/)).not.toBeInTheDocument();
+  });
+});
+
+describe("DashboardPage — charts", () => {
+  beforeEach(() => {
+    mockReadStatsCache = () => Promise.resolve(mockStats);
+  });
+
+  it("renders the activity area chart after load", async () => {
+    renderDashboard();
+    await waitFor(() =>
+      expect(screen.queryByText("Loading…")).not.toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("area-chart")).toBeInTheDocument();
+  });
+
+  it("renders bar charts after load", async () => {
+    renderDashboard();
+    await waitFor(() =>
+      expect(screen.queryByText("Loading…")).not.toBeInTheDocument(),
+    );
+    const barCharts = screen.getAllByTestId("bar-chart");
+    expect(barCharts.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/apps/desktop/src/pages/observatory/__tests__/DashboardPage.test.tsx
+++ b/apps/desktop/src/pages/observatory/__tests__/DashboardPage.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import type { StatsCache } from "@harness-kit/shared";
+import type { StatsCache, LiveDailyActivity } from "@harness-kit/shared";
 import DashboardPage from "../DashboardPage";
 
 // ── Recharts mock ─────────────────────────────────────────────
@@ -25,9 +25,11 @@ vi.mock("recharts", () => ({
 // the vi.mock factory (factory runs before module-scope let/const declarations).
 
 let mockReadStatsCache: () => Promise<unknown>;
+let mockReadLiveActivity: () => Promise<unknown>;
 
 vi.mock("../../../lib/tauri", () => ({
   get readStatsCache() { return mockReadStatsCache; },
+  get readLiveActivity() { return mockReadLiveActivity; },
 }));
 
 // ── Fixtures ──────────────────────────────────────────────────
@@ -52,6 +54,11 @@ const staleStats: StatsCache = {
   ...mockStats,
   lastComputedDate: "2026-03-10",
 };
+
+const mockLiveActivity: LiveDailyActivity[] = [
+  { date: "2026-03-14", messageCount: 45, sessionCount: 3 },
+  { date: "2026-03-15", messageCount: 30, sessionCount: 2 },
+];
 
 // ── Helpers ───────────────────────────────────────────────────
 
@@ -80,6 +87,9 @@ beforeEach(() => {
       dispatchEvent: vi.fn(),
     }),
   });
+
+  mockReadStatsCache = vi.fn().mockResolvedValue(mockStats);
+  mockReadLiveActivity = vi.fn().mockResolvedValue(mockLiveActivity);
 });
 
 // ── Tests ─────────────────────────────────────────────────────
@@ -176,5 +186,54 @@ describe("DashboardPage — charts", () => {
     );
     const barCharts = screen.getAllByTestId("bar-chart");
     expect(barCharts.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("stats bar — new cards", () => {
+  it("shows tool call total", async () => {
+    renderDashboard();
+    // mockStats dailyActivity has toolCallCount: 120 + 80 = 200
+    expect(await screen.findByText("200")).toBeInTheDocument();
+  });
+
+  it("shows cache hit rate", async () => {
+    renderDashboard();
+    // For mockStats with 2 models totaling some cache/input tokens, a % should appear
+    expect(await screen.findByText(/cache hit/i)).toBeInTheDocument();
+  });
+});
+
+describe("date range control", () => {
+  it("renders preset pills", async () => {
+    renderDashboard();
+    await screen.findByText("200"); // wait for load
+    expect(screen.getByRole("button", { name: "1d" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "7d" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "30d" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "1y" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "All" })).toBeInTheDocument();
+  });
+
+  it("renders custom date inputs", async () => {
+    renderDashboard();
+    await screen.findByText("200");
+    expect(screen.getByLabelText(/start date/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/end date/i)).toBeInTheDocument();
+  });
+
+  it("30d pill is active by default", async () => {
+    renderDashboard();
+    await screen.findByText("200");
+    expect(screen.getByRole("button", { name: "30d" })).toHaveAttribute("aria-pressed", "true");
+  });
+});
+
+describe("stale warning replaced by refresh UI", () => {
+  it("shows last-updated label not a warning banner when stale", async () => {
+    mockReadStatsCache = vi.fn().mockResolvedValue(staleStats);
+    renderDashboard();
+    await screen.findByText(/last updated/i);
+    // No orange warning banner text
+    expect(screen.queryByText(/data may be incomplete/i)).not.toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/pages/observatory/__tests__/DashboardPage.test.tsx
+++ b/apps/desktop/src/pages/observatory/__tests__/DashboardPage.test.tsx
@@ -17,6 +17,7 @@ vi.mock("recharts", () => ({
   YAxis: () => null,
   CartesianGrid: () => null,
   Tooltip: () => null,
+  Legend: () => null,
   ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
 

--- a/apps/desktop/src/pages/observatory/__tests__/DashboardPage.test.tsx
+++ b/apps/desktop/src/pages/observatory/__tests__/DashboardPage.test.tsx
@@ -127,10 +127,10 @@ describe("DashboardPage — stats bar", () => {
     expect(await screen.findByText("2,814")).toBeInTheDocument();
   });
 
-  it("shows 2 models used", async () => {
+  it("shows output tokens total", async () => {
     renderDashboard();
-    // The Models Used stat card renders the count as a plain string
-    expect(await screen.findByText("2")).toBeInTheDocument();
+    // mockStats modelUsage: 2000 + 1000 = 3,000 output tokens
+    expect(await screen.findByText("3,000")).toBeInTheDocument();
   });
 });
 
@@ -150,19 +150,16 @@ describe("DashboardPage — error state", () => {
 });
 
 describe("DashboardPage — stale warning", () => {
-  it("shows stale warning when lastComputedDate is 5 days old", async () => {
+  it("shows last-updated label when lastComputedDate is 5 days old", async () => {
     mockReadStatsCache = () => Promise.resolve(staleStats);
     renderDashboard();
-    expect(await screen.findByText(/days ago/)).toBeInTheDocument();
+    expect(await screen.findByText(/last updated/i)).toBeInTheDocument();
   });
 
-  it("does NOT show stale warning when lastComputedDate is today", async () => {
+  it("shows last-updated label when lastComputedDate is today", async () => {
     mockReadStatsCache = () => Promise.resolve(mockStats);
     renderDashboard();
-    await waitFor(() =>
-      expect(screen.queryByText("Loading…")).not.toBeInTheDocument(),
-    );
-    expect(screen.queryByText(/days ago/)).not.toBeInTheDocument();
+    expect(await screen.findByText(/last updated/i)).toBeInTheDocument();
   });
 });
 

--- a/apps/desktop/src/pages/observatory/__tests__/SessionsPage.test.tsx
+++ b/apps/desktop/src/pages/observatory/__tests__/SessionsPage.test.tsx
@@ -20,20 +20,20 @@ vi.mock("../../../lib/tauri", () => ({
 
 const mockSessions: SessionSummary[] = [
   {
-    session_id: "sess-1",
+    sessionId: "sess-1",
     project: "/Users/john/repos/my-project",
-    project_short: "my-project",
-    first_timestamp: 1741824600000,  // 2026-03-13 06:50 UTC
-    last_timestamp: 1741824600000 + 2 * 3_600_000 + 15 * 60_000,
-    message_count: 142,
+    projectShort: "my-project",
+    firstTimestamp: 1741824600000,  // 2026-03-13 06:50 UTC
+    lastTimestamp: 1741824600000 + 2 * 3_600_000 + 15 * 60_000,
+    messageCount: 142,
   },
   {
-    session_id: "sess-2",
+    sessionId: "sess-2",
     project: "/Users/john/repos/other-app",
-    project_short: "other-app",
-    first_timestamp: 1741738200000,
-    last_timestamp: 1741738200000 + 45 * 60_000,
-    message_count: 23,
+    projectShort: "other-app",
+    firstTimestamp: 1741738200000,
+    lastTimestamp: 1741738200000 + 45 * 60_000,
+    messageCount: 23,
   },
 ];
 

--- a/apps/desktop/src/pages/observatory/__tests__/SessionsPage.test.tsx
+++ b/apps/desktop/src/pages/observatory/__tests__/SessionsPage.test.tsx
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { SessionSummary, SessionFacet } from "@harness-kit/shared";
+import SessionsPage from "../SessionsPage";
+
+// ── Tauri mock ────────────────────────────────────────────────
+// Variable names must start with "mock" for Vitest hoisting to allow
+// access inside the vi.mock factory.
+
+let mockListSessionsSummary: () => Promise<unknown>;
+let mockReadSessionFacet: (sessionId: string) => Promise<unknown>;
+
+vi.mock("../../../lib/tauri", () => ({
+  get listSessionsSummary() { return mockListSessionsSummary; },
+  get readSessionFacet() { return mockReadSessionFacet; },
+}));
+
+// ── Fixtures ──────────────────────────────────────────────────
+
+const mockSessions: SessionSummary[] = [
+  {
+    session_id: "sess-1",
+    project: "/Users/john/repos/my-project",
+    project_short: "my-project",
+    first_timestamp: 1741824600000,  // 2026-03-13 06:50 UTC
+    last_timestamp: 1741824600000 + 2 * 3_600_000 + 15 * 60_000,
+    message_count: 142,
+  },
+  {
+    session_id: "sess-2",
+    project: "/Users/john/repos/other-app",
+    project_short: "other-app",
+    first_timestamp: 1741738200000,
+    last_timestamp: 1741738200000 + 45 * 60_000,
+    message_count: 23,
+  },
+];
+
+const mockFacet: SessionFacet = {
+  session_id: "sess-1",
+  underlying_goal: "Add Observatory dashboard",
+  outcome: "fully_achieved",
+  claude_helpfulness: "very_helpful",
+  session_type: "feature_development",
+  brief_summary: "Built the Observatory feature with charts.",
+  friction_counts: null,
+};
+
+// ── Render helper ─────────────────────────────────────────────
+
+function renderSessions() {
+  return render(
+    <MemoryRouter>
+      <SessionsPage />
+    </MemoryRouter>,
+  );
+}
+
+// ── Setup ─────────────────────────────────────────────────────
+
+beforeEach(() => {
+  // Default: facet returns null unless overridden per test
+  mockReadSessionFacet = () => Promise.resolve(null);
+});
+
+// ── Tests ─────────────────────────────────────────────────────
+
+describe("SessionsPage — loading state", () => {
+  it("shows 'Loading…' before data arrives", () => {
+    mockListSessionsSummary = () => new Promise(() => {});
+    renderSessions();
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
+  });
+
+  it("hides 'Loading…' after data loads", async () => {
+    mockListSessionsSummary = () => Promise.resolve(mockSessions);
+    renderSessions();
+    await waitFor(() =>
+      expect(screen.queryByText("Loading…")).not.toBeInTheDocument(),
+    );
+  });
+});
+
+describe("SessionsPage — session list", () => {
+  beforeEach(() => {
+    mockListSessionsSummary = () => Promise.resolve(mockSessions);
+  });
+
+  it("renders both sessions after load", async () => {
+    renderSessions();
+    expect(await screen.findByText("my-project")).toBeInTheDocument();
+    expect(screen.getByText("other-app")).toBeInTheDocument();
+  });
+
+  it("shows correct message count for first session", async () => {
+    renderSessions();
+    expect(await screen.findByText("142 msgs")).toBeInTheDocument();
+  });
+
+  it("shows message count for second session", async () => {
+    renderSessions();
+    expect(await screen.findByText("23 msgs")).toBeInTheDocument();
+  });
+});
+
+describe("SessionsPage — empty state", () => {
+  it("shows 'No sessions found.' when list is empty", async () => {
+    mockListSessionsSummary = () => Promise.resolve([]);
+    renderSessions();
+    expect(await screen.findByText("No sessions found.")).toBeInTheDocument();
+  });
+});
+
+describe("SessionsPage — session count header", () => {
+  it("shows '2 sessions across 2 projects'", async () => {
+    mockListSessionsSummary = () => Promise.resolve(mockSessions);
+    renderSessions();
+    expect(
+      await screen.findByText("2 sessions across 2 projects"),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("SessionsPage — row click / facet", () => {
+  beforeEach(() => {
+    mockListSessionsSummary = () => Promise.resolve(mockSessions);
+  });
+
+  it("calls readSessionFacet with the correct session ID on row click", async () => {
+    const readFacetSpy = vi.fn().mockResolvedValue(null);
+    mockReadSessionFacet = readFacetSpy;
+
+    renderSessions();
+    const projectPill = await screen.findByText("my-project");
+    // The pill is inside a <button>; click the ancestor button
+    const rowButton = projectPill.closest("button")!;
+    fireEvent.click(rowButton);
+
+    await waitFor(() => {
+      expect(readFacetSpy).toHaveBeenCalledWith("sess-1");
+    });
+  });
+
+  it("shows 'fully achieved' outcome badge after clicking row and facet loads", async () => {
+    mockReadSessionFacet = () => Promise.resolve(mockFacet);
+
+    renderSessions();
+    const projectPill = await screen.findByText("my-project");
+    const rowButton = projectPill.closest("button")!;
+    fireEvent.click(rowButton);
+
+    expect(await screen.findByText("fully achieved")).toBeInTheDocument();
+  });
+
+  it("shows 'No insights available' when facet is null", async () => {
+    mockReadSessionFacet = () => Promise.resolve(null);
+
+    renderSessions();
+    const projectPill = await screen.findByText("my-project");
+    const rowButton = projectPill.closest("button")!;
+    fireEvent.click(rowButton);
+
+    expect(
+      await screen.findByText("No insights available for this session."),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("SessionsPage — error state", () => {
+  it("shows error message when listSessionsSummary rejects", async () => {
+    mockListSessionsSummary = () => Promise.reject(new Error("Failed to list sessions"));
+    renderSessions();
+    expect(await screen.findByText(/Failed to list sessions/)).toBeInTheDocument();
+  });
+
+  it("does not show loading spinner after error", async () => {
+    mockListSessionsSummary = () => Promise.reject(new Error("Error"));
+    renderSessions();
+    await screen.findByText(/Error/);
+    expect(screen.queryByText("Loading…")).not.toBeInTheDocument();
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -20,4 +20,11 @@ export type {
   KnownMarketplace,
   HookCommand,
   HooksConfig,
+  StatsCache,
+  DailyActivity,
+  DailyModelTokens,
+  ModelUsageEntry,
+  SessionSummary,
+  SessionFacet,
+  ActiveSession,
 } from "./types.js";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -27,4 +27,5 @@ export type {
   SessionSummary,
   SessionFacet,
   ActiveSession,
+  LiveDailyActivity,
 } from "./types.js";

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -237,3 +237,9 @@ export interface ActiveSession {
   cwd: string;
   startedAt: number;
 }
+
+export interface LiveDailyActivity {
+  date: string;
+  messageCount: number;
+  sessionCount: number;
+}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -185,21 +185,21 @@ export interface MarketplaceManifest {
 
 export interface DailyActivity {
   date: string;
-  messageCount: number;
-  sessionCount: number;
-  toolCallCount: number;
+  messageCount?: number;
+  sessionCount?: number;
+  toolCallCount?: number;
 }
 
 export interface DailyModelTokens {
   date: string;
-  tokensByModel: Record<string, number>;
+  tokensByModel?: Record<string, number>;
 }
 
 export interface ModelUsageEntry {
-  inputTokens: number;
-  outputTokens: number;
-  cacheReadInputTokens: number;
-  cacheCreationInputTokens: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheReadInputTokens?: number;
+  cacheCreationInputTokens?: number;
 }
 
 export interface StatsCache {
@@ -213,12 +213,12 @@ export interface StatsCache {
 }
 
 export interface SessionSummary {
-  session_id: string;
+  sessionId: string;
   project: string;
-  project_short: string;
-  first_timestamp: number;
-  last_timestamp: number;
-  message_count: number;
+  projectShort: string;
+  firstTimestamp: number;
+  lastTimestamp: number;
+  messageCount: number;
 }
 
 export interface SessionFacet {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -180,3 +180,60 @@ export interface MarketplaceManifest {
   categories: MarketplaceCategory[];
   plugins: MarketplacePlugin[];
 }
+
+// ── Observatory types ─────────────────────────────────────────
+
+export interface DailyActivity {
+  date: string;
+  messageCount: number;
+  sessionCount: number;
+  toolCallCount: number;
+}
+
+export interface DailyModelTokens {
+  date: string;
+  tokensByModel: Record<string, number>;
+}
+
+export interface ModelUsageEntry {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadInputTokens: number;
+  cacheCreationInputTokens: number;
+}
+
+export interface StatsCache {
+  lastComputedDate?: string;
+  dailyActivity?: DailyActivity[];
+  dailyModelTokens?: DailyModelTokens[];
+  modelUsage?: Record<string, ModelUsageEntry>;
+  totalSessions?: number;
+  totalMessages?: number;
+  hourCounts?: Record<string, number>;
+}
+
+export interface SessionSummary {
+  session_id: string;
+  project: string;
+  project_short: string;
+  first_timestamp: number;
+  last_timestamp: number;
+  message_count: number;
+}
+
+export interface SessionFacet {
+  session_id: string;
+  underlying_goal: string | null;
+  outcome: string | null;
+  claude_helpfulness: string | null;
+  session_type: string | null;
+  brief_summary: string | null;
+  friction_counts: Record<string, number> | null;
+}
+
+export interface ActiveSession {
+  pid: number;
+  sessionId: string;
+  cwd: string;
+  startedAt: number;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       react-router-dom:
         specifier: ^7.0.0
         version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      recharts:
+        specifier: ^3.8.0
+        version: 3.8.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@17.0.2)(react@19.2.4)(redux@5.0.1)
       remark-gfm:
         specifier: ^4.0.0
         version: 4.0.1
@@ -478,13 +481,8 @@ packages:
     peerDependencies:
       '@csstools/css-tokenizer': ^4.0.0
 
-  '@csstools/css-syntax-patches-for-csstree@1.1.1':
-    resolution: {integrity: sha512-BvqN0AMWNAnLk9G8jnUT77D+mUbY/H2b3uDTvg2isJkHaOufUE2R3AOwxWo7VBQKT1lOdwdvorddo2B/lk64+w==}
-    peerDependencies:
-      css-tree: ^3.2.1
-    peerDependenciesMeta:
-      css-tree:
-        optional: true
+  '@csstools/css-syntax-patches-for-csstree@1.1.0':
+    resolution: {integrity: sha512-H4tuz2nhWgNKLt1inYpoVCfbJbMwX/lQKp3g69rrrIMIYlFD9+zTykOKhNR8uGrAmbS/kT9n6hTFkmDkxLgeTA==}
 
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
@@ -1600,6 +1598,17 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@reduxjs/toolkit@2.11.2':
+    resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -1770,6 +1779,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@supabase/auth-js@2.99.1':
     resolution: {integrity: sha512-x7lKKTvKjABJt/FYcRSPiTT01Xhm2FF8RhfL8+RHMkmlwmRQ88/lREupIHKwFPW0W6pTCJqkZb7Yhpw/EZ+fNw==}
@@ -2030,6 +2042,33 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -2110,6 +2149,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -2276,8 +2318,8 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  baseline-browser-mapping@2.10.8:
-    resolution: {integrity: sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==}
+  baseline-browser-mapping@2.10.7:
+    resolution: {integrity: sha512-1ghYO3HnxGec0TCGBXiDLVns4eCSx4zJpxnHrlqFQajmhfKMQBzUGDdkMK7fUW7PTHTeLf+j87aTuKuuwWzMGw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -2462,6 +2504,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -2482,6 +2568,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
@@ -2567,6 +2656,9 @@ packages:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.45.1:
+    resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
+
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
 
@@ -2621,6 +2713,9 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
@@ -2843,8 +2938,8 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
-  hono@4.12.7:
-    resolution: {integrity: sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==}
+  hono@4.12.8:
+    resolution: {integrity: sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@6.0.0:
@@ -2889,6 +2984,12 @@ packages:
     engines: {node: '>=16.x'}
     hasBin: true
 
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.1.4:
+    resolution: {integrity: sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==}
+
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
@@ -2898,6 +2999,10 @@ packages:
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
@@ -3555,6 +3660,18 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
@@ -3614,6 +3731,14 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  recharts@3.8.0:
+    resolution: {integrity: sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   recma-build-jsx@1.0.0:
     resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
 
@@ -3631,6 +3756,14 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   regex-recursion@6.0.2:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
@@ -3665,6 +3798,9 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -3857,6 +3993,9 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -3965,8 +4104,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.24.3:
-    resolution: {integrity: sha512-eJdUmK/Wrx2d+mnWWmwwLRyA7OQCkLap60sk3dOK4ViZR7DKwwptwuIvFBg2HaiP9ESaEdhtpSymQPvytpmkCA==}
+  undici@7.24.2:
+    resolution: {integrity: sha512-P9J1HWYV/ajFr8uCqk5QixwiRKmB1wOamgS0e+o2Z4A44Ej2+thFVRLG/eA7qprx88XXhnV5Bl8LHXTURpzB3Q==}
     engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
@@ -4020,6 +4159,11 @@ packages:
       '@types/react':
         optional: true
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -4036,6 +4180,9 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -4387,9 +4534,7 @@ snapshots:
     dependencies:
       '@csstools/css-tokenizer': 4.0.0
 
-  '@csstools/css-syntax-patches-for-csstree@1.1.1(css-tree@3.2.1)':
-    optionalDependencies:
-      css-tree: 3.2.1
+  '@csstools/css-syntax-patches-for-csstree@1.1.0': {}
 
   '@csstools/css-tokenizer@4.0.0': {}
 
@@ -4602,9 +4747,9 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@hono/node-server@1.19.11(hono@4.12.7)':
+  '@hono/node-server@1.19.11(hono@4.12.8)':
     dependencies:
-      hono: 4.12.7
+      hono: 4.12.8
 
   '@img/colour@1.1.0':
     optional: true
@@ -4879,7 +5024,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.11(hono@4.12.7)
+      '@hono/node-server': 1.19.11(hono@4.12.8)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -4889,7 +5034,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.1(express@5.2.1)
-      hono: 4.12.7
+      hono: 4.12.8
       jose: 6.2.1
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -5283,6 +5428,18 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.4
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 19.2.4
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
@@ -5408,6 +5565,8 @@ snapshots:
   '@shikijs/vscode-textmate@10.0.2': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@supabase/auth-js@2.99.1':
     dependencies:
@@ -5651,6 +5810,30 @@ snapshots:
     dependencies:
       '@types/node': 22.19.15
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
@@ -5738,6 +5921,8 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@types/ws@8.18.1':
     dependencies:
@@ -5928,7 +6113,7 @@ snapshots:
 
   bail@2.0.2: {}
 
-  baseline-browser-mapping@2.10.8: {}
+  baseline-browser-mapping@2.10.7: {}
 
   bidi-js@1.0.3:
     dependencies:
@@ -5967,7 +6152,7 @@ snapshots:
 
   browserslist@4.28.1:
     dependencies:
-      baseline-browser-mapping: 2.10.8
+      baseline-browser-mapping: 2.10.7
       caniuse-lite: 1.0.30001778
       electron-to-chromium: 1.5.313
       node-releases: 2.0.36
@@ -6095,11 +6280,49 @@ snapshots:
   cssstyle@6.2.0:
     dependencies:
       '@asamuzakjp/css-color': 5.0.1
-      '@csstools/css-syntax-patches-for-csstree': 1.1.1(css-tree@3.2.1)
+      '@csstools/css-syntax-patches-for-csstree': 1.1.0
       css-tree: 3.2.1
       lru-cache: 11.2.6
 
   csstype@3.2.3: {}
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
 
   data-urls@7.0.0:
     dependencies:
@@ -6115,6 +6338,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   decimal.js@10.6.0: {}
 
@@ -6178,6 +6403,8 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  es-toolkit@1.45.1: {}
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -6295,6 +6522,8 @@ snapshots:
       '@types/estree': 1.0.8
 
   etag@1.8.1: {}
+
+  eventemitter3@5.0.4: {}
 
   eventsource-parser@3.0.6: {}
 
@@ -6633,7 +6862,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
-  hono@4.12.7: {}
+  hono@4.12.8: {}
 
   html-encoding-sniffer@6.0.0:
     dependencies:
@@ -6681,11 +6910,17 @@ snapshots:
 
   image-size@2.0.2: {}
 
+  immer@10.2.0: {}
+
+  immer@11.1.4: {}
+
   indent-string@4.0.0: {}
 
   inherits@2.0.4: {}
 
   inline-style-parser@0.2.7: {}
+
+  internmap@2.0.3: {}
 
   ip-address@10.1.0: {}
 
@@ -6758,7 +6993,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.24.3
+      undici: 7.24.2
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -7560,6 +7795,15 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
+  react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      redux: 5.0.1
+
   react-refresh@0.17.0: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.4):
@@ -7607,6 +7851,26 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  recharts@3.8.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@17.0.2)(react@19.2.4)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.45.1
+      eventemitter3: 5.0.4
+      immer: 10.2.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-is: 17.0.2
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.4)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
   recma-build-jsx@1.0.0:
     dependencies:
       '@types/estree': 1.0.8
@@ -7640,6 +7904,12 @@ snapshots:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
 
   regex-recursion@6.0.2:
     dependencies:
@@ -7710,6 +7980,8 @@ snapshots:
       - supports-color
 
   require-from-string@2.0.2: {}
+
+  reselect@5.1.1: {}
 
   resolve-from@5.0.0: {}
 
@@ -7991,6 +8263,8 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -8088,7 +8362,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.24.3: {}
+  undici@7.24.2: {}
 
   unified@11.0.5:
     dependencies:
@@ -8150,6 +8424,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  use-sync-external-store@1.6.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
@@ -8165,6 +8443,23 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite-node@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:


### PR DESCRIPTION
## Summary

- **Rust backend**: 4 new Tauri commands that read `~/.claude/stats-cache.json`, parse `history.jsonl` by session, read facet files, and enumerate active sessions
- **Dashboard page**: stats bar, daily activity area chart (30d/90d/All toggle), model token breakdown, hourly distribution — all using Recharts with CSS variable theming and reduced-motion support
- **Sessions page**: row list from `history.jsonl` with click-to-expand inline facet detail (goal, outcome badge, summary, friction counts)
- **Format utilities**: `formatNumber`, `formatDuration`, `formatDate`, `shortModelName`, `daysBetween` etc. in shared `lib/format.ts`
- **Types**: 7 Observatory interfaces added to `@harness-kit/shared`

## Test Plan

- [x] `cargo check` — Rust compiles cleanly
- [x] `pnpm test` — 143/143 tests pass (6 files: 3 new Observatory test files + 3 existing)
- [x] `tsc --noEmit` — no TypeScript errors
- [ ] `pnpm tauri dev` → Observatory → Dashboard loads with real data from `~/.claude/stats-cache.json`
- [ ] Time range toggle (30d/90d/All) filters activity chart
- [ ] Stale data warning appears when `lastComputedDate` is > 3 days old
- [ ] Observatory → Sessions shows session list from `history.jsonl`
- [ ] Clicking a session expands inline facet detail (or "No insights available" gracefully)
- [ ] Light/dark mode + accent color changes apply to charts

🤖 Generated with [Claude Code](https://claude.com/claude-code)