### PR TITLE
feat: @harness-kit/core library and CLI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -113,6 +113,30 @@ jobs:
               print('requires.env schema valid.')
           "
 
+  core-build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build core package
+        run: pnpm --filter @harness-kit/core build
+
+      - name: Run core tests
+        run: pnpm --filter @harness-kit/core test
+
+      - name: Build CLI package
+        run: pnpm --filter @harness-kit/cli build
+
   docs-build:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,9 @@ packages/shared/dist/
 apps/desktop/src-tauri/target/
 apps/desktop/dist/
 packages/ui/dist/
+
+# Core library
+packages/core/dist/
+
+# CLI
+apps/cli/dist/

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@harness-kit/cli",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "harness-kit": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch"
+  },
+  "dependencies": {
+    "@harness-kit/core": "workspace:*",
+    "commander": "^13",
+    "@inquirer/prompts": "^7",
+    "chalk": "^5"
+  },
+  "devDependencies": {
+    "tsup": "^8",
+    "typescript": "^5"
+  }
+}

--- a/apps/cli/src/commands/compile.ts
+++ b/apps/cli/src/commands/compile.ts
@@ -6,12 +6,13 @@ import {
   compile,
   detectPlatforms,
   findOrphanedMarkerBlocks,
+  getAllInstructionFilePaths,
   parseHarness,
   removeOrphanedBlocks,
   validateHarness,
 } from "@harness-kit/core";
 import { NodeFsProvider } from "@harness-kit/core/node";
-import type { TargetPlatform } from "@harness-kit/core";
+import type { OrphanedBlock, TargetPlatform } from "@harness-kit/core";
 import { formatCompileReport, formatDryRunFile } from "../formatters/report.js";
 import { formatValidationResult } from "../formatters/validation.js";
 
@@ -156,25 +157,22 @@ async function handleClean(
   targets: TargetPlatform[],
   fs: NodeFsProvider,
 ): Promise<void> {
-  // Files that could contain harness marker blocks
-  const filesToScan = [
-    "CLAUDE.md",
-    "AGENT.md",
-    "SOUL.md",
-    ".cursor/rules/harness.mdc",
-    ".cursor/rules/behavioral.mdc",
-    ".github/copilot-instructions.md",
-    ".github/instructions/behavioral.instructions.md",
-  ];
-
+  // Derive scannable files from the canonical slot mappings
+  const filesToScan = [...new Set(getAllInstructionFilePaths())];
   const cwd = fs.cwd();
-  const allOrphans: import("@harness-kit/core").OrphanedBlock[] = [];
+  const allOrphans: OrphanedBlock[] = [];
+  const contentCache = new Map<string, string>();
 
   for (const filePath of filesToScan) {
     const fullPath = fs.joinPath(cwd, filePath);
-    if (!(await fs.exists(fullPath))) continue;
+    let content: string;
+    try {
+      content = await fs.readFile(fullPath);
+    } catch {
+      continue; // File doesn't exist
+    }
 
-    const content = await fs.readFile(fullPath);
+    contentCache.set(filePath, content);
     const orphans = findOrphanedMarkerBlocks(content, harnessName, filePath);
     allOrphans.push(...orphans);
   }
@@ -201,8 +199,8 @@ async function handleClean(
     return;
   }
 
-  // Group orphans by file and remove
-  const byFile = new Map<string, import("@harness-kit/core").OrphanedBlock[]>();
+  // Group orphans by file and remove using cached content
+  const byFile = new Map<string, OrphanedBlock[]>();
   for (const orphan of allOrphans) {
     const existing = byFile.get(orphan.file) ?? [];
     existing.push(orphan);
@@ -211,7 +209,7 @@ async function handleClean(
 
   for (const [filePath, orphans] of byFile) {
     const fullPath = fs.joinPath(cwd, filePath);
-    const content = await fs.readFile(fullPath);
+    const content = contentCache.get(filePath)!;
     const cleaned = removeOrphanedBlocks(content, orphans);
     await fs.writeFile(fullPath, cleaned);
   }

--- a/apps/cli/src/commands/compile.ts
+++ b/apps/cli/src/commands/compile.ts
@@ -1,0 +1,220 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import chalk from "chalk";
+import { checkbox, confirm } from "@inquirer/prompts";
+import {
+  compile,
+  detectPlatforms,
+  findOrphanedMarkerBlocks,
+  parseHarness,
+  removeOrphanedBlocks,
+  validateHarness,
+} from "@harness-kit/core";
+import { NodeFsProvider } from "@harness-kit/core/node";
+import type { TargetPlatform } from "@harness-kit/core";
+import { formatCompileReport, formatDryRunFile } from "../formatters/report.js";
+import { formatValidationResult } from "../formatters/validation.js";
+
+interface CompileFlags {
+  target?: string;
+  dryRun?: boolean;
+  clean?: boolean;
+  verbose?: boolean;
+}
+
+const ALL_TARGETS: TargetPlatform[] = ["claude-code", "cursor", "copilot"];
+
+function parseTargets(targetStr: string): TargetPlatform[] {
+  if (targetStr === "all") return ALL_TARGETS;
+  return targetStr.split(",").map((t) => {
+    const trimmed = t.trim() as TargetPlatform;
+    if (!ALL_TARGETS.includes(trimmed)) {
+      console.error(`Unknown target: ${trimmed}. Valid targets: ${ALL_TARGETS.join(", ")}, all`);
+      process.exit(1);
+    }
+    return trimmed;
+  });
+}
+
+export async function compileCommand(
+  filePath: string | undefined,
+  flags: CompileFlags,
+): Promise<void> {
+  const resolved = resolve(filePath ?? "harness.yaml");
+  const fs = new NodeFsProvider();
+
+  // Read harness.yaml
+  let yamlString: string;
+  try {
+    yamlString = await readFile(resolved, "utf-8");
+  } catch {
+    console.error(
+      `No harness.yaml found at ${resolved}. Specify a path: harness-kit compile <path>`,
+    );
+    process.exit(1);
+  }
+
+  // Parse and validate
+  let config;
+  try {
+    ({ config } = parseHarness(yamlString));
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.error(msg);
+    process.exit(1);
+  }
+
+  const validation = validateHarness(config);
+  if (!validation.valid) {
+    console.error(formatValidationResult(validation, resolved));
+    process.exit(1);
+  }
+
+  if (validation.isLegacyFormat) {
+    console.error(
+      chalk.red("Error:") +
+        ' This harness.yaml uses the legacy format (version: 1 integer). It must use version: "1" (string) for compilation.',
+    );
+    process.exit(1);
+  }
+
+  // Determine targets
+  let targets: TargetPlatform[];
+  if (flags.target) {
+    targets = parseTargets(flags.target);
+  } else {
+    targets = await interactiveTargetSelection(fs);
+  }
+
+  if (targets.length === 0) {
+    console.log("No targets selected. Nothing to compile.");
+    return;
+  }
+
+  // Compile
+  const result = await compile(yamlString, targets, fs, {
+    dryRun: flags.dryRun,
+    clean: flags.clean,
+    verbose: flags.verbose,
+  });
+
+  // Dry-run: show file previews
+  if (flags.dryRun) {
+    for (const file of result.files) {
+      if (file.action !== "skip") {
+        console.log(formatDryRunFile(file.path, file.content));
+        console.log("");
+      }
+    }
+  }
+
+  // Print report
+  console.log(formatCompileReport(result, flags.dryRun ?? false));
+
+  // Handle --clean
+  if (flags.clean && !flags.dryRun) {
+    await handleClean(result.harnessName, targets, fs);
+  }
+}
+
+async function interactiveTargetSelection(
+  fs: NodeFsProvider,
+): Promise<TargetPlatform[]> {
+  const detected = await detectPlatforms(fs);
+
+  if (detected.length === 0) {
+    console.log(
+      "No AI tool config directories found. Which targets should I compile for?",
+    );
+    const selected = await checkbox<TargetPlatform>({
+      message: "Select targets:",
+      choices: ALL_TARGETS.map((t) => ({ name: t, value: t })),
+    });
+    return selected;
+  }
+
+  const choices = ALL_TARGETS.map((t) => {
+    const det = detected.find((d) => d.platform === t);
+    const found = det ? ` (found: ${det.indicators.join(", ")})` : " (not detected)";
+    return {
+      name: `${t}${found}`,
+      value: t,
+      checked: det ? !det.needsConfirmation : false,
+    };
+  });
+
+  const selected = await checkbox<TargetPlatform>({
+    message: "Detected targets. Confirm or adjust:",
+    choices,
+  });
+
+  return selected;
+}
+
+async function handleClean(
+  harnessName: string,
+  targets: TargetPlatform[],
+  fs: NodeFsProvider,
+): Promise<void> {
+  // Files that could contain harness marker blocks
+  const filesToScan = [
+    "CLAUDE.md",
+    "AGENT.md",
+    "SOUL.md",
+    ".cursor/rules/harness.mdc",
+    ".cursor/rules/behavioral.mdc",
+    ".github/copilot-instructions.md",
+    ".github/instructions/behavioral.instructions.md",
+  ];
+
+  const cwd = fs.cwd();
+  const allOrphans: import("@harness-kit/core").OrphanedBlock[] = [];
+
+  for (const filePath of filesToScan) {
+    const fullPath = fs.joinPath(cwd, filePath);
+    if (!(await fs.exists(fullPath))) continue;
+
+    const content = await fs.readFile(fullPath);
+    const orphans = findOrphanedMarkerBlocks(content, harnessName, filePath);
+    allOrphans.push(...orphans);
+  }
+
+  if (allOrphans.length === 0) {
+    console.log(chalk.dim("\nNo orphaned marker blocks found."));
+    return;
+  }
+
+  console.log(chalk.yellow(`\nFound ${allOrphans.length} orphaned marker block(s):\n`));
+  for (const orphan of allOrphans) {
+    console.log(
+      `  ${chalk.cyan(orphan.file)} lines ${orphan.startLine}-${orphan.endLine}: harness:${orphan.name}:${orphan.slot}`,
+    );
+  }
+
+  const proceed = await confirm({
+    message: `Remove these ${allOrphans.length} orphaned blocks?`,
+    default: false,
+  });
+
+  if (!proceed) {
+    console.log("Cleanup skipped.");
+    return;
+  }
+
+  // Group orphans by file and remove
+  const byFile = new Map<string, import("@harness-kit/core").OrphanedBlock[]>();
+  for (const orphan of allOrphans) {
+    const existing = byFile.get(orphan.file) ?? [];
+    existing.push(orphan);
+    byFile.set(orphan.file, existing);
+  }
+
+  for (const [filePath, orphans] of byFile) {
+    const fullPath = fs.joinPath(cwd, filePath);
+    const content = await fs.readFile(fullPath);
+    const cleaned = removeOrphanedBlocks(content, orphans);
+    await fs.writeFile(fullPath, cleaned);
+  }
+
+  console.log(chalk.green(`Removed ${allOrphans.length} orphaned block(s).`));
+}

--- a/apps/cli/src/commands/validate.ts
+++ b/apps/cli/src/commands/validate.ts
@@ -1,0 +1,34 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { parseHarness, validateHarness } from "@harness-kit/core";
+import { formatValidationResult } from "../formatters/validation.js";
+
+export async function validateCommand(filePath?: string): Promise<void> {
+  const resolved = resolve(filePath ?? "harness.yaml");
+
+  let yamlString: string;
+  try {
+    yamlString = await readFile(resolved, "utf-8");
+  } catch {
+    console.error(
+      `No harness.yaml found at ${resolved}. Specify a path: harness-kit validate <path>`,
+    );
+    process.exit(1);
+  }
+
+  // Parse YAML first
+  try {
+    parseHarness(yamlString);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.error(msg);
+    process.exit(1);
+  }
+
+  // Parse again for raw object (parseHarness returns typed, but we need raw for Ajv)
+  const { config } = parseHarness(yamlString);
+  const result = validateHarness(config);
+
+  console.log(formatValidationResult(result, resolved));
+  process.exit(result.valid ? 0 : 1);
+}

--- a/apps/cli/src/commands/validate.ts
+++ b/apps/cli/src/commands/validate.ts
@@ -16,17 +16,15 @@ export async function validateCommand(filePath?: string): Promise<void> {
     process.exit(1);
   }
 
-  // Parse YAML first
+  let config;
   try {
-    parseHarness(yamlString);
+    ({ config } = parseHarness(yamlString));
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     console.error(msg);
     process.exit(1);
   }
 
-  // Parse again for raw object (parseHarness returns typed, but we need raw for Ajv)
-  const { config } = parseHarness(yamlString);
   const result = validateHarness(config);
 
   console.log(formatValidationResult(result, resolved));

--- a/apps/cli/src/formatters/report.ts
+++ b/apps/cli/src/formatters/report.ts
@@ -1,0 +1,86 @@
+import chalk from "chalk";
+import type { CompileReport, CompileResult, TargetPlatform } from "@harness-kit/core";
+import { buildReport } from "@harness-kit/core";
+
+export function formatCompileReport(
+  result: CompileResult,
+  dryRun: boolean,
+): string {
+  const report = buildReport(result);
+  return formatReport(report, dryRun);
+}
+
+function formatReport(report: CompileReport, dryRun: boolean): string {
+  const lines: string[] = [];
+
+  if (dryRun) {
+    lines.push(chalk.yellow("[DRY RUN]") + " Preview — no files were written.\n");
+  }
+
+  lines.push(
+    `Compiled harness: ${chalk.bold(report.harnessName)}`,
+  );
+  lines.push(
+    `Targets: ${report.targets.map(formatTarget).join(", ")}\n`,
+  );
+
+  // Group entries by platform
+  let currentPlatform: TargetPlatform | null = null;
+
+  for (const entry of report.entries) {
+    if (entry.platform !== currentPlatform) {
+      currentPlatform = entry.platform;
+    }
+
+    const file = entry.file.padEnd(36);
+    const slot = entry.slot.padEnd(14);
+    const action = entry.action.padEnd(8);
+    const detail = entry.detail;
+
+    lines.push(`  ${chalk.white(file)} ${chalk.dim(slot)} ${action} ${detail}`);
+  }
+
+  if (report.skippedPlugins.length > 0) {
+    lines.push("");
+    lines.push("  Skipped plugins:");
+    for (const msg of report.skippedPlugins) {
+      lines.push(`    ${chalk.dim(msg)}`);
+    }
+  }
+
+  if (report.warnings.length > 0) {
+    lines.push("");
+    lines.push("  Warnings:");
+    for (const warning of report.warnings) {
+      lines.push(`    ${chalk.yellow(warning)}`);
+    }
+  }
+
+  if (dryRun) {
+    lines.push(
+      `\n${chalk.yellow("Dry run complete.")} No files were written. Remove --dry-run to apply.`,
+    );
+  }
+
+  return lines.join("\n");
+}
+
+function formatTarget(target: TargetPlatform): string {
+  switch (target) {
+    case "claude-code":
+      return chalk.blue("claude-code");
+    case "cursor":
+      return chalk.magenta("cursor");
+    case "copilot":
+      return chalk.green("copilot");
+  }
+}
+
+export function formatDryRunFile(path: string, content: string): string {
+  const lines: string[] = [];
+  lines.push(`${chalk.yellow("[DRY RUN]")} Would write: ${chalk.bold(path)}`);
+  lines.push(chalk.dim("─".repeat(40)));
+  lines.push(content.trimEnd());
+  lines.push(chalk.dim("─".repeat(40)));
+  return lines.join("\n");
+}

--- a/apps/cli/src/formatters/validation.ts
+++ b/apps/cli/src/formatters/validation.ts
@@ -1,0 +1,35 @@
+import chalk from "chalk";
+import type { ValidationResult } from "@harness-kit/core";
+
+export function formatValidationResult(
+  result: ValidationResult,
+  filePath: string,
+): string {
+  const lines: string[] = [];
+
+  if (result.valid) {
+    lines.push(
+      chalk.green(`PASS`) + ` ${filePath} is valid — passes Harness Protocol v1 schema validation.`,
+    );
+    if (result.isLegacyFormat) {
+      lines.push(
+        chalk.yellow("Note:") +
+          ' This is in the legacy format (version: 1 integer). Run /harness-export to regenerate in Harness Protocol v1 format (version: "1" string).',
+      );
+    }
+  } else {
+    lines.push(chalk.red(`FAIL`) + ` ${filePath} failed validation:\n`);
+
+    for (const err of result.errors) {
+      lines.push(`  ${chalk.cyan(err.path)}: ${err.message}`);
+      if (err.fix) {
+        lines.push(`    ${chalk.dim("Fix:")} ${err.fix}`);
+      }
+      lines.push("");
+    }
+
+    lines.push('Fix these issues and run "harness-kit validate" again to confirm.');
+  }
+
+  return lines.join("\n");
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,0 +1,52 @@
+import { Command } from "commander";
+import { validateCommand } from "./commands/validate.js";
+import { compileCommand } from "./commands/compile.js";
+
+const program = new Command();
+
+program
+  .name("harness-kit")
+  .description("Compile and validate harness.yaml configurations")
+  .version("0.1.0");
+
+program
+  .command("validate")
+  .description("Validate a harness.yaml against the Harness Protocol v1 schema")
+  .argument("[path]", "Path to harness.yaml", "harness.yaml")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  harness-kit validate                    Validate ./harness.yaml
+  harness-kit validate ~/dotfiles/harness.yaml   Validate a specific file`,
+  )
+  .action(async (path: string) => {
+    await validateCommand(path);
+  });
+
+program
+  .command("compile")
+  .description("Compile harness.yaml into native config files for AI coding tools")
+  .argument("[path]", "Path to harness.yaml", "harness.yaml")
+  .option(
+    "--target <targets>",
+    "Target platforms: claude-code, cursor, copilot (comma-separated), or all",
+  )
+  .option("--dry-run", "Preview output without writing files")
+  .option("--clean", "Remove orphaned marker blocks from previous compilations")
+  .option("--verbose", "Show skipped slots and extra detail")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  harness-kit compile                           Interactive platform detection
+  harness-kit compile --target all --dry-run    Preview output for all platforms
+  harness-kit compile --target claude-code      Compile for Claude Code only
+  harness-kit compile --target cursor,copilot   Compile for Cursor and Copilot
+  harness-kit compile --clean                   Compile and remove orphaned blocks`,
+  )
+  .action(async (path: string, flags) => {
+    await compileCommand(path, flags);
+  });
+
+program.parse();

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/apps/cli/tsup.config.ts
+++ b/apps/cli/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  clean: true,
+  sourcemap: true,
+  banner: {
+    js: "#!/usr/bin/env node",
+  },
+});

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -13,6 +13,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@harness-kit/core": "workspace:*",
     "@harness-kit/shared": "workspace:*",
     "@harness-kit/ui": "workspace:*",
     "@supabase/supabase-js": "^2",

--- a/apps/desktop/src-tauri/src/commands/hooks.rs
+++ b/apps/desktop/src-tauri/src/commands/hooks.rs
@@ -8,8 +8,21 @@ pub struct HookCommand {
     pub command: String,
 }
 
-// HooksConfig maps event name -> list of hook commands
 pub type HooksConfig = HashMap<String, Vec<HookCommand>>;
+
+// Actual shape inside each matcher's hooks array
+#[derive(Debug, Deserialize)]
+struct RawHookEntry {
+    #[serde(rename = "type")]
+    hook_type: String,
+    command: String,
+}
+
+// Actual shape: each event maps to a list of matchers, each with a hooks array
+#[derive(Debug, Deserialize)]
+struct RawHookMatcher {
+    hooks: Vec<RawHookEntry>,
+}
 
 fn claude_dir() -> Option<std::path::PathBuf> {
     dirs::home_dir().map(|h| h.join(".claude"))
@@ -36,6 +49,30 @@ pub fn read_hooks() -> Result<HooksConfig, String> {
         None => return Ok(HooksConfig::new()),
     };
 
-    serde_json::from_value::<HooksConfig>(hooks_val)
-        .map_err(|e| format!("Failed to parse hooks config: {}", e))
+    // Parse the actual nested format: { Event: [{ matcher?, hooks: [{type, command}] }] }
+    let raw: HashMap<String, Vec<RawHookMatcher>> = serde_json::from_value(hooks_val)
+        .map_err(|e| format!("Failed to parse hooks config: {}", e))?;
+
+    // Flatten each event's matchers into a single list of HookCommands
+    let result = raw
+        .into_iter()
+        .filter_map(|(event, matchers)| {
+            let commands: Vec<HookCommand> = matchers
+                .into_iter()
+                .flat_map(|m| {
+                    m.hooks.into_iter().map(|h| HookCommand {
+                        hook_type: h.hook_type,
+                        command: h.command,
+                    })
+                })
+                .collect();
+            if commands.is_empty() {
+                None
+            } else {
+                Some((event, commands))
+            }
+        })
+        .collect();
+
+    Ok(result)
 }

--- a/apps/desktop/src-tauri/src/commands/plugins.rs
+++ b/apps/desktop/src-tauri/src/commands/plugins.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct InstalledPlugin {
@@ -15,6 +16,22 @@ pub struct KnownMarketplace {
     pub name: String,
     pub url: String,
     pub description: Option<String>,
+}
+
+// Actual shape of each entry in the plugins map
+#[derive(Debug, Deserialize)]
+struct RawPluginRecord {
+    version: String,
+    #[serde(rename = "installedAt")]
+    installed_at: Option<String>,
+    #[serde(rename = "installPath")]
+    install_path: Option<String>,
+}
+
+// Actual shape of installed_plugins.json
+#[derive(Debug, Deserialize)]
+struct RawInstalledPlugins {
+    plugins: HashMap<String, Vec<RawPluginRecord>>,
 }
 
 fn claude_dir() -> Option<std::path::PathBuf> {
@@ -35,8 +52,31 @@ pub fn list_installed_plugins() -> Result<Vec<InstalledPlugin>, String> {
     let contents = std::fs::read_to_string(&path)
         .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
 
-    serde_json::from_str::<Vec<InstalledPlugin>>(&contents)
-        .map_err(|e| format!("Failed to parse installed_plugins.json: {}", e))
+    let raw: RawInstalledPlugins = serde_json::from_str(&contents)
+        .map_err(|e| format!("Failed to parse installed_plugins.json: {}", e))?;
+
+    let mut result: Vec<InstalledPlugin> = raw
+        .plugins
+        .into_iter()
+        .filter_map(|(key, records)| {
+            let record = records.into_iter().next()?;
+            let (name, marketplace) = match key.find('@') {
+                Some(idx) => (key[..idx].to_string(), Some(key[idx + 1..].to_string())),
+                None => (key, None),
+            };
+            Some(InstalledPlugin {
+                name,
+                version: record.version,
+                description: None,
+                marketplace,
+                source: record.install_path,
+                installed_at: record.installed_at,
+            })
+        })
+        .collect();
+
+    result.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(result)
 }
 
 #[tauri::command]

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -3,6 +3,7 @@ import AppLayout from "./layouts/AppLayout";
 import PluginsPage from "./pages/harness/PluginsPage";
 import HooksPage from "./pages/harness/HooksPage";
 import SettingsPage from "./pages/harness/SettingsPage";
+import FileViewerPage from "./pages/harness/FileViewerPage";
 import ClaudeMdPage from "./pages/harness/ClaudeMdPage";
 import ComingSoonPage from "./pages/ComingSoonPage";
 import BrowsePage from "./pages/marketplace/BrowsePage";
@@ -19,6 +20,7 @@ export default function App() {
           <Route path="harness/hooks" element={<HooksPage />} />
           <Route path="harness/claude-md" element={<ClaudeMdPage />} />
           <Route path="harness/settings" element={<SettingsPage />} />
+          <Route path="harness/settings/:filename" element={<FileViewerPage />} />
 
           {/* Marketplace */}
           <Route path="marketplace" element={<BrowsePage />} />

--- a/apps/desktop/src/components/MarkdownPanel.tsx
+++ b/apps/desktop/src/components/MarkdownPanel.tsx
@@ -1,0 +1,119 @@
+import { useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+interface MarkdownPanelProps {
+  content: string;
+  title?: string;
+  defaultView?: "preview" | "raw";
+  /** Fill all available height instead of intrinsic height */
+  fill?: boolean;
+}
+
+export default function MarkdownPanel({
+  content,
+  title,
+  defaultView = "preview",
+  fill = false,
+}: MarkdownPanelProps) {
+  const [view, setView] = useState<"preview" | "raw">(defaultView);
+
+  const tabBtn = (active: boolean): React.CSSProperties => ({
+    fontSize: "10px",
+    fontWeight: active ? 600 : 400,
+    padding: "3px 8px",
+    borderRadius: "4px",
+    border: "none",
+    background: active ? "var(--bg-elevated)" : "transparent",
+    color: active ? "var(--fg-base)" : "var(--fg-subtle)",
+    cursor: "pointer",
+    boxShadow: active ? "0 1px 2px rgba(0,0,0,0.08)" : "none",
+    transition: "all 0.1s",
+  });
+
+  return (
+    <section
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        flex: fill ? 1 : undefined,
+        marginBottom: fill ? 0 : "24px",
+        minHeight: 0,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: title ? "space-between" : "flex-end",
+          marginBottom: "8px",
+          flexShrink: 0,
+        }}
+      >
+        {title && (
+          <p
+            style={{
+              fontSize: "10px",
+              fontWeight: 600,
+              textTransform: "uppercase",
+              letterSpacing: "0.05em",
+              color: "var(--fg-subtle)",
+              margin: 0,
+            }}
+          >
+            {title}
+          </p>
+        )}
+        <div
+          style={{
+            display: "flex",
+            gap: "2px",
+            background: "var(--bg-base)",
+            border: "1px solid var(--border-base)",
+            borderRadius: "6px",
+            padding: "2px",
+          }}
+        >
+          <button onClick={() => setView("preview")} style={tabBtn(view === "preview")}>
+            Preview
+          </button>
+          <button onClick={() => setView("raw")} style={tabBtn(view === "raw")}>
+            Raw
+          </button>
+        </div>
+      </div>
+
+      <div
+        style={{
+          flex: fill ? 1 : undefined,
+          background: "var(--bg-surface)",
+          border: "1px solid var(--border-base)",
+          borderRadius: "8px",
+          padding: "14px 16px",
+          overflow: fill ? "auto" : undefined,
+          minHeight: 0,
+        }}
+      >
+        {view === "preview" ? (
+          <div className="markdown-body">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+          </div>
+        ) : (
+          <pre
+            style={{
+              margin: 0,
+              fontFamily: "ui-monospace, monospace",
+              fontSize: "11px",
+              lineHeight: "1.6",
+              color: "var(--fg-muted)",
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-word",
+            }}
+          >
+            {content}
+          </pre>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/desktop/src/layouts/AppLayout.tsx
+++ b/apps/desktop/src/layouts/AppLayout.tsx
@@ -1,6 +1,11 @@
 import { Outlet, NavLink, useLocation } from "react-router-dom";
-import { useEffect, useState } from "react";
-import { initTheme, toggleTheme, getTheme } from "../lib/theme";
+import { useEffect, useRef, useState } from "react";
+import {
+  initTheme, getTheme, setTheme,
+  getAccent, setAccent,
+  ACCENT_PRESETS,
+  type AccentName,
+} from "../lib/theme";
 
 type NavSection = {
   id: string;
@@ -18,7 +23,7 @@ const NAV_SECTIONS: NavSection[] = [
       { label: "Plugins", path: "/harness/plugins" },
       { label: "Hooks", path: "/harness/hooks" },
       { label: "CLAUDE.md", path: "/harness/claude-md" },
-      { label: "Settings", path: "/harness/settings" },
+      { label: "Config Files", path: "/harness/settings" },
     ],
   },
   {
@@ -44,14 +49,34 @@ const NAV_SECTIONS: NavSection[] = [
 export default function AppLayout() {
   const location = useLocation();
   const [theme, setThemeState] = useState(getTheme);
+  const [accent, setAccentState] = useState(getAccent);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const settingsRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     initTheme();
   }, []);
 
-  function handleToggleTheme() {
-    toggleTheme();
-    setThemeState(getTheme());
+  // Close settings panel on outside click
+  useEffect(() => {
+    if (!settingsOpen) return;
+    function onPointerDown(e: PointerEvent) {
+      if (settingsRef.current && !settingsRef.current.contains(e.target as Node)) {
+        setSettingsOpen(false);
+      }
+    }
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [settingsOpen]);
+
+  function handleSetTheme(t: "light" | "dark" | "system") {
+    setTheme(t);
+    setThemeState(t);
+  }
+
+  function handleSetAccent(name: AccentName) {
+    setAccent(name);
+    setAccentState(name);
   }
 
   function isActive(section: NavSection) {
@@ -70,24 +95,15 @@ export default function AppLayout() {
           width: "var(--sidebar-width)",
           background: "var(--bg-sidebar-solid)",
           borderRight: "1px solid var(--border-base)",
+          position: "relative",
         }}
       >
         {/* App name */}
         <div
           className="flex items-center px-4"
-          style={{
-            height: "44px",
-            borderBottom: "1px solid var(--separator)",
-          }}
+          style={{ height: "44px", borderBottom: "1px solid var(--separator)" }}
         >
-          <span
-            style={{
-              fontSize: "13px",
-              fontWeight: 600,
-              letterSpacing: "-0.1px",
-              color: "var(--fg-base)",
-            }}
-          >
+          <span style={{ fontSize: "13px", fontWeight: 600, letterSpacing: "-0.1px", color: "var(--fg-base)" }}>
             harness-kit
           </span>
         </div>
@@ -98,10 +114,7 @@ export default function AppLayout() {
             const active = isActive(section);
             return (
               <div key={section.id} className="mb-0.5">
-                <NavLink
-                  to={section.path}
-                  className={`sidebar-item${active ? " active" : ""}`}
-                >
+                <NavLink to={section.path} className={`sidebar-item${active ? " active" : ""}`}>
                   {section.label}
                 </NavLink>
 
@@ -125,26 +138,108 @@ export default function AppLayout() {
           })}
         </nav>
 
-        {/* Theme toggle */}
+        {/* Preferences panel (floats above gear button) */}
+        {settingsOpen && (
+          <div
+            ref={settingsRef}
+            style={{
+              position: "absolute",
+              bottom: "48px",
+              left: "8px",
+              right: "8px",
+              background: "var(--bg-elevated)",
+              border: "1px solid var(--border-base)",
+              borderRadius: "10px",
+              boxShadow: "0 8px 24px rgba(0,0,0,0.18)",
+              padding: "14px",
+              zIndex: 50,
+            }}
+          >
+            <p style={{ fontSize: "11px", fontWeight: 700, color: "var(--fg-base)", margin: "0 0 12px", letterSpacing: "-0.1px" }}>
+              Preferences
+            </p>
+
+            {/* Theme */}
+            <p style={{ fontSize: "10px", fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.05em", color: "var(--fg-subtle)", margin: "0 0 6px" }}>
+              Appearance
+            </p>
+            <div style={{ display: "flex", gap: "4px", marginBottom: "14px" }}>
+              {(["light", "system", "dark"] as const).map((t) => (
+                <button
+                  key={t}
+                  onClick={() => handleSetTheme(t)}
+                  style={{
+                    flex: 1,
+                    fontSize: "11px",
+                    padding: "5px 0",
+                    borderRadius: "5px",
+                    border: "1px solid",
+                    borderColor: theme === t ? "var(--accent)" : "var(--border-base)",
+                    background: theme === t ? "var(--accent-light)" : "transparent",
+                    color: theme === t ? "var(--accent-text)" : "var(--fg-muted)",
+                    cursor: "pointer",
+                    textTransform: "capitalize",
+                    fontWeight: theme === t ? 600 : 400,
+                  }}
+                >
+                  {t}
+                </button>
+              ))}
+            </div>
+
+            {/* Accent color */}
+            <p style={{ fontSize: "10px", fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.05em", color: "var(--fg-subtle)", margin: "0 0 6px" }}>
+              Accent Color
+            </p>
+            <div style={{ display: "flex", gap: "6px", flexWrap: "wrap" }}>
+              {(Object.entries(ACCENT_PRESETS) as [AccentName, typeof ACCENT_PRESETS[AccentName]][]).map(([name, preset]) => (
+                <button
+                  key={name}
+                  title={preset.label}
+                  onClick={() => handleSetAccent(name)}
+                  style={{
+                    width: "22px",
+                    height: "22px",
+                    borderRadius: "50%",
+                    background: preset.swatch,
+                    border: accent === name ? "2px solid var(--fg-base)" : "2px solid transparent",
+                    cursor: "pointer",
+                    outline: accent === name ? "2px solid var(--accent)" : "none",
+                    outlineOffset: "1px",
+                    padding: 0,
+                  }}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Bottom bar: gear button */}
         <div
-          className="px-3 py-3"
+          className="px-2 py-2"
           style={{ borderTop: "1px solid var(--separator)" }}
         >
           <button
-            onClick={handleToggleTheme}
-            className="flex items-center gap-2 w-full px-2 py-1.5 rounded text-xs transition-colors"
+            onClick={() => setSettingsOpen((o) => !o)}
             style={{
-              color: "var(--fg-subtle)",
-              background: "transparent",
+              display: "flex",
+              alignItems: "center",
+              gap: "6px",
+              width: "100%",
+              padding: "6px 8px",
+              borderRadius: "6px",
               border: "none",
+              background: settingsOpen ? "var(--accent-light)" : "transparent",
+              color: settingsOpen ? "var(--accent-text)" : "var(--fg-subtle)",
               cursor: "pointer",
               fontSize: "11px",
+              textAlign: "left",
             }}
           >
-            <span style={{ fontSize: "12px" }}>
-              {theme === "dark" ? "☀" : "◑"}
-            </span>
-            {theme === "dark" ? "Light mode" : "Dark mode"}
+            <svg width="13" height="13" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clipRule="evenodd" />
+            </svg>
+            Preferences
           </button>
         </div>
       </aside>

--- a/apps/desktop/src/lib/harness-fs.ts
+++ b/apps/desktop/src/lib/harness-fs.ts
@@ -49,6 +49,11 @@ export class TauriFsProvider implements FsProvider {
       .replace(/\/$/, "");
   }
 
+  dirname(path: string): string {
+    const lastSlash = path.lastIndexOf("/");
+    return lastSlash > 0 ? path.substring(0, lastSlash) : "/";
+  }
+
   async homedir(): Promise<string> {
     return homeDir();
   }

--- a/apps/desktop/src/lib/harness-fs.ts
+++ b/apps/desktop/src/lib/harness-fs.ts
@@ -7,6 +7,7 @@ import {
 } from "@tauri-apps/plugin-fs";
 import { join, homeDir } from "@tauri-apps/api/path";
 import type { FsProvider } from "@harness-kit/core";
+import { posixJoin, posixDirname } from "@harness-kit/core";
 
 /**
  * FsProvider implementation for Tauri desktop apps.
@@ -41,17 +42,11 @@ export class TauriFsProvider implements FsProvider {
   }
 
   joinPath(...segments: string[]): string {
-    // Tauri's join is async, but FsProvider.joinPath is sync.
-    // Use a simple POSIX join for paths — Tauri normalizes on the backend.
-    return segments
-      .join("/")
-      .replace(/\/+/g, "/")
-      .replace(/\/$/, "");
+    return posixJoin(...segments);
   }
 
   dirname(path: string): string {
-    const lastSlash = path.lastIndexOf("/");
-    return lastSlash > 0 ? path.substring(0, lastSlash) : "/";
+    return posixDirname(path);
   }
 
   async homedir(): Promise<string> {

--- a/apps/desktop/src/lib/harness-fs.ts
+++ b/apps/desktop/src/lib/harness-fs.ts
@@ -1,0 +1,59 @@
+import {
+  readTextFile,
+  writeTextFile,
+  exists,
+  mkdir,
+  readDir,
+} from "@tauri-apps/plugin-fs";
+import { join, homeDir } from "@tauri-apps/api/path";
+import type { FsProvider } from "@harness-kit/core";
+
+/**
+ * FsProvider implementation for Tauri desktop apps.
+ * Uses Tauri's FS plugin and path APIs — runs in the browser/webview context.
+ */
+export class TauriFsProvider implements FsProvider {
+  private _cwd: string;
+
+  constructor(cwd: string) {
+    this._cwd = cwd;
+  }
+
+  async readFile(path: string): Promise<string> {
+    return readTextFile(path);
+  }
+
+  async writeFile(path: string, content: string): Promise<void> {
+    await writeTextFile(path, content);
+  }
+
+  async exists(path: string): Promise<boolean> {
+    return exists(path);
+  }
+
+  async mkdir(path: string, options?: { recursive?: boolean }): Promise<void> {
+    await mkdir(path, { recursive: options?.recursive ?? false });
+  }
+
+  async readDir(path: string): Promise<string[]> {
+    const entries = await readDir(path);
+    return entries.map((e) => e.name).filter((n): n is string => n != null);
+  }
+
+  joinPath(...segments: string[]): string {
+    // Tauri's join is async, but FsProvider.joinPath is sync.
+    // Use a simple POSIX join for paths — Tauri normalizes on the backend.
+    return segments
+      .join("/")
+      .replace(/\/+/g, "/")
+      .replace(/\/$/, "");
+  }
+
+  async homedir(): Promise<string> {
+    return homeDir();
+  }
+
+  cwd(): string {
+    return this._cwd;
+  }
+}

--- a/apps/desktop/src/lib/theme.ts
+++ b/apps/desktop/src/lib/theme.ts
@@ -1,23 +1,22 @@
 type Theme = "light" | "dark" | "system";
 
 const STORAGE_KEY = "harness-kit-theme";
+const ACCENT_KEY = "harness-kit-accent";
 
 function getSystemTheme(): "light" | "dark" {
-  return window.matchMedia("(prefers-color-scheme: dark)").matches
-    ? "dark"
-    : "light";
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
 }
 
 function applyTheme(theme: Theme) {
   const resolved = theme === "system" ? getSystemTheme() : theme;
   document.documentElement.classList.toggle("dark", resolved === "dark");
+  applyAccent(getAccent(), resolved);
 }
 
 export function initTheme() {
   const stored = (localStorage.getItem(STORAGE_KEY) as Theme | null) ?? "system";
   applyTheme(stored);
 
-  // Listen for system preference changes
   window
     .matchMedia("(prefers-color-scheme: dark)")
     .addEventListener("change", () => {
@@ -39,4 +38,68 @@ export function toggleTheme() {
   const current = getTheme();
   const resolved = current === "system" ? getSystemTheme() : current;
   setTheme(resolved === "dark" ? "light" : "dark");
+}
+
+// ── Accent colors ─────────────────────────────────────────────
+
+export type AccentName = "purple" | "blue" | "teal" | "green" | "orange" | "rose";
+
+type AccentTokens = { accent: string; light: string; text: string };
+type AccentPreset = { dark: AccentTokens; light: AccentTokens; swatch: string; label: string };
+
+export const ACCENT_PRESETS: Record<AccentName, AccentPreset> = {
+  purple: {
+    swatch: "#7c3aed",
+    label: "Purple",
+    dark:  { accent: "#7c3aed", light: "rgba(124,58,237,0.15)",  text: "#a78bfa" },
+    light: { accent: "#7c3aed", light: "rgba(124,58,237,0.10)",  text: "#6d28d9" },
+  },
+  blue: {
+    swatch: "#2563eb",
+    label: "Blue",
+    dark:  { accent: "#2563eb", light: "rgba(37,99,235,0.15)",   text: "#60a5fa" },
+    light: { accent: "#2563eb", light: "rgba(37,99,235,0.10)",   text: "#1d4ed8" },
+  },
+  teal: {
+    swatch: "#0d9488",
+    label: "Teal",
+    dark:  { accent: "#0d9488", light: "rgba(13,148,136,0.15)",  text: "#2dd4bf" },
+    light: { accent: "#0d9488", light: "rgba(13,148,136,0.10)",  text: "#0f766e" },
+  },
+  green: {
+    swatch: "#16a34a",
+    label: "Green",
+    dark:  { accent: "#16a34a", light: "rgba(22,163,74,0.15)",   text: "#4ade80" },
+    light: { accent: "#16a34a", light: "rgba(22,163,74,0.10)",   text: "#15803d" },
+  },
+  orange: {
+    swatch: "#ea580c",
+    label: "Orange",
+    dark:  { accent: "#ea580c", light: "rgba(234,88,12,0.15)",   text: "#fb923c" },
+    light: { accent: "#ea580c", light: "rgba(234,88,12,0.10)",   text: "#c2410c" },
+  },
+  rose: {
+    swatch: "#e11d48",
+    label: "Rose",
+    dark:  { accent: "#e11d48", light: "rgba(225,29,72,0.15)",   text: "#fb7185" },
+    light: { accent: "#e11d48", light: "rgba(225,29,72,0.10)",   text: "#be123c" },
+  },
+};
+
+export function getAccent(): AccentName {
+  return (localStorage.getItem(ACCENT_KEY) as AccentName | null) ?? "purple";
+}
+
+export function setAccent(name: AccentName) {
+  localStorage.setItem(ACCENT_KEY, name);
+  const resolved = getTheme() === "system" ? getSystemTheme() : (getTheme() as "light" | "dark");
+  applyAccent(name, resolved);
+}
+
+function applyAccent(name: AccentName, theme: "light" | "dark") {
+  const tokens = ACCENT_PRESETS[name][theme];
+  const root = document.documentElement.style;
+  root.setProperty("--accent", tokens.accent);
+  root.setProperty("--accent-light", tokens.light);
+  root.setProperty("--accent-text", tokens.text);
 }

--- a/apps/desktop/src/pages/harness/ClaudeMdPage.tsx
+++ b/apps/desktop/src/pages/harness/ClaudeMdPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { readClaudeMd } from "../../lib/tauri";
+import MarkdownPanel from "../../components/MarkdownPanel";
 
 const CLAUDE_MD_PATHS = [
   { label: "Global", path: "~/.claude/CLAUDE.md" },
@@ -22,7 +23,7 @@ export default function ClaudeMdPage() {
 
   return (
     <div style={{ padding: "20px 24px", display: "flex", flexDirection: "column", height: "100%" }}>
-      <div style={{ marginBottom: "16px", display: "flex", alignItems: "flex-start", justifyContent: "space-between" }}>
+      <div style={{ marginBottom: "16px", display: "flex", alignItems: "flex-start", justifyContent: "space-between", flexShrink: 0 }}>
         <div>
           <h1 style={{ fontSize: "17px", fontWeight: 600, letterSpacing: "-0.3px", color: "var(--fg-base)", margin: 0 }}>
             CLAUDE.md
@@ -68,39 +69,7 @@ export default function ClaudeMdPage() {
       )}
 
       {!loading && !error && content !== null && (
-        <div style={{
-          flex: 1,
-          borderRadius: "8px",
-          border: "1px solid var(--border-base)",
-          background: "var(--bg-surface)",
-          overflow: "hidden",
-          display: "flex",
-          flexDirection: "column",
-        }}>
-          <div style={{
-            padding: "8px 14px",
-            borderBottom: "1px solid var(--separator)",
-            background: "var(--bg-elevated)",
-          }}>
-            <span style={{ fontSize: "11px", fontFamily: "ui-monospace, monospace", color: "var(--fg-subtle)" }}>
-              {selectedPath}
-            </span>
-          </div>
-          <pre style={{
-            flex: 1,
-            padding: "14px",
-            margin: 0,
-            fontFamily: "ui-monospace, monospace",
-            fontSize: "12px",
-            lineHeight: "1.6",
-            color: "var(--fg-base)",
-            overflowY: "auto",
-            whiteSpace: "pre-wrap",
-            wordBreak: "break-word",
-          }}>
-            {content}
-          </pre>
-        </div>
+        <MarkdownPanel content={content} fill defaultView="preview" />
       )}
     </div>
   );

--- a/apps/desktop/src/pages/harness/FileViewerPage.tsx
+++ b/apps/desktop/src/pages/harness/FileViewerPage.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { readClaudeMd } from "../../lib/tauri";
+import MarkdownPanel from "../../components/MarkdownPanel";
+
+function extOf(name: string): string {
+  const idx = name.lastIndexOf(".");
+  return idx === -1 ? "" : name.slice(idx);
+}
+
+export default function FileViewerPage() {
+  const { filename } = useParams<{ filename: string }>();
+  const navigate = useNavigate();
+  const name = filename ? decodeURIComponent(filename) : "";
+
+  const [content, setContent] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!name) return;
+    readClaudeMd(`~/.claude/${name}`)
+      .then(setContent)
+      .catch((e) => setError(String(e)))
+      .finally(() => setLoading(false));
+  }, [name]);
+
+  const defaultView = extOf(name) === ".md" ? "preview" : "raw";
+
+  return (
+    <div style={{ padding: "20px 24px", display: "flex", flexDirection: "column", height: "100%" }}>
+      {/* Header */}
+      <div style={{ marginBottom: "16px", flexShrink: 0 }}>
+        <button
+          onClick={() => navigate("/harness/settings")}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "4px",
+            background: "none",
+            border: "none",
+            padding: 0,
+            cursor: "pointer",
+            fontSize: "12px",
+            color: "var(--fg-subtle)",
+            marginBottom: "10px",
+          }}
+        >
+          ← Config Files
+        </button>
+        <h1 style={{
+          fontSize: "17px",
+          fontWeight: 600,
+          letterSpacing: "-0.3px",
+          color: "var(--fg-base)",
+          margin: 0,
+          fontFamily: "ui-monospace, monospace",
+        }}>
+          {name}
+        </h1>
+        <p style={{ fontSize: "12px", color: "var(--fg-muted)", margin: "3px 0 0", fontFamily: "ui-monospace, monospace" }}>
+          ~/.claude/{name}
+        </p>
+      </div>
+
+      {loading && <p style={{ fontSize: "13px", color: "var(--fg-subtle)" }}>Loading…</p>}
+
+      {error && (
+        <div style={{
+          background: "var(--bg-surface)",
+          border: "1px solid var(--border-base)",
+          borderRadius: "8px",
+          padding: "10px 14px",
+          fontSize: "13px",
+          color: "var(--danger)",
+        }}>
+          {error}
+        </div>
+      )}
+
+      {!loading && !error && content !== null && (
+        <MarkdownPanel content={content} defaultView={defaultView} fill />
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/pages/harness/SettingsPage.tsx
+++ b/apps/desktop/src/pages/harness/SettingsPage.tsx
@@ -1,14 +1,34 @@
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { listClaudeDir } from "../../lib/tauri";
 
+const TEXT_EXTENSIONS = new Set([".md", ".json", ".yaml", ".yml", ".sh", ".txt", ".toml", ".mjs"]);
+
+function extOf(name: string): string {
+  const idx = name.lastIndexOf(".");
+  return idx === -1 ? "" : name.slice(idx);
+}
+
+const EXT_LABEL: Record<string, string> = {
+  ".md": "Markdown",
+  ".json": "JSON",
+  ".yaml": "YAML",
+  ".yml": "YAML",
+  ".sh": "Shell",
+  ".txt": "Text",
+  ".toml": "TOML",
+  ".mjs": "JS",
+};
+
 export default function SettingsPage() {
-  const [entries, setEntries] = useState<string[]>([]);
+  const navigate = useNavigate();
+  const [files, setFiles] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     listClaudeDir()
-      .then(setEntries)
+      .then((entries) => setFiles(entries.filter((e) => TEXT_EXTENSIONS.has(extOf(e)))))
       .catch((e) => setError(String(e)))
       .finally(() => setLoading(false));
   }, []);
@@ -17,11 +37,11 @@ export default function SettingsPage() {
     <div style={{ padding: "20px 24px" }}>
       <div style={{ marginBottom: "16px" }}>
         <h1 style={{ fontSize: "17px", fontWeight: 600, letterSpacing: "-0.3px", color: "var(--fg-base)", margin: 0 }}>
-          Settings
+          Config Files
         </h1>
         <p style={{ fontSize: "12px", color: "var(--fg-muted)", margin: "3px 0 0" }}>
-          Contents of{" "}
-          <code style={{ fontFamily: "ui-monospace, monospace", fontSize: "11px" }}>~/.claude/</code>.
+          Text files in{" "}
+          <code style={{ fontFamily: "ui-monospace, monospace", fontSize: "11px" }}>~/.claude/</code>
         </p>
       </div>
 
@@ -42,17 +62,47 @@ export default function SettingsPage() {
 
       {!loading && !error && (
         <div className="row-list">
-          {entries.map((entry) => (
-            <div key={entry} className="row-list-item">
-              <span style={{
-                fontFamily: "ui-monospace, monospace",
-                fontSize: "12px",
-                color: "var(--fg-muted)",
-              }}>
-                {entry}
-              </span>
-            </div>
-          ))}
+          {files.map((name) => {
+            const ext = extOf(name);
+            const label = EXT_LABEL[ext] ?? ext.slice(1).toUpperCase();
+            return (
+              <button
+                key={name}
+                onClick={() => navigate(`/harness/settings/${encodeURIComponent(name)}`)}
+                className="row-list-item"
+                style={{
+                  width: "100%",
+                  background: "none",
+                  border: "none",
+                  cursor: "pointer",
+                  textAlign: "left",
+                  justifyContent: "space-between",
+                }}
+              >
+                <span style={{
+                  fontFamily: "ui-monospace, monospace",
+                  fontSize: "13px",
+                  fontWeight: 500,
+                  color: "var(--fg-base)",
+                }}>
+                  {name}
+                </span>
+                <span style={{
+                  fontSize: "10px",
+                  fontWeight: 500,
+                  padding: "1px 6px",
+                  borderRadius: "4px",
+                  background: "var(--bg-base)",
+                  color: "var(--fg-subtle)",
+                  border: "1px solid var(--border-base)",
+                  flexShrink: 0,
+                  marginLeft: "12px",
+                }}>
+                  {label}
+                </span>
+              </button>
+            );
+          })}
         </div>
       )}
     </div>

--- a/apps/desktop/src/pages/marketplace/PluginDetailPage.tsx
+++ b/apps/desktop/src/pages/marketplace/PluginDetailPage.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import { supabase } from "../../lib/supabase";
+import MarkdownPanel from "../../components/MarkdownPanel";
 import type { Component } from "@harness-kit/shared";
 
 type RelatedComponent = Pick<Component, "id" | "slug" | "name" | "install_count">;
@@ -351,82 +350,6 @@ export default function PluginDetailPage() {
         </aside>
       </div>
     </div>
-  );
-}
-
-// ── Markdown panel with Preview / Raw toggle ──────────────────
-
-function MarkdownPanel({ content, title }: { content: string; title: string }) {
-  const [view, setView] = useState<"preview" | "raw">("preview");
-
-  const tabBtn = (active: boolean): React.CSSProperties => ({
-    fontSize: "10px",
-    fontWeight: active ? 600 : 400,
-    padding: "3px 8px",
-    borderRadius: "4px",
-    border: "none",
-    background: active ? "var(--bg-elevated)" : "transparent",
-    color: active ? "var(--fg-base)" : "var(--fg-subtle)",
-    cursor: "pointer",
-    boxShadow: active ? "0 1px 2px rgba(0,0,0,0.08)" : "none",
-    transition: "all 0.1s",
-  });
-
-  return (
-    <section style={{ marginBottom: "24px" }}>
-      <div style={{
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "space-between",
-        marginBottom: "8px",
-      }}>
-        <p style={{
-          fontSize: "10px",
-          fontWeight: 600,
-          textTransform: "uppercase",
-          letterSpacing: "0.05em",
-          color: "var(--fg-subtle)",
-          margin: 0,
-        }}>
-          {title}
-        </p>
-        <div style={{
-          display: "flex",
-          gap: "2px",
-          background: "var(--bg-base)",
-          border: "1px solid var(--border-base)",
-          borderRadius: "6px",
-          padding: "2px",
-        }}>
-          <button onClick={() => setView("preview")} style={tabBtn(view === "preview")}>Preview</button>
-          <button onClick={() => setView("raw")} style={tabBtn(view === "raw")}>Raw</button>
-        </div>
-      </div>
-      <div style={{
-        background: "var(--bg-surface)",
-        border: "1px solid var(--border-base)",
-        borderRadius: "8px",
-        padding: "14px 16px",
-      }}>
-        {view === "preview" ? (
-          <div className="markdown-body">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
-          </div>
-        ) : (
-          <pre style={{
-            margin: 0,
-            fontFamily: "ui-monospace, monospace",
-            fontSize: "11px",
-            lineHeight: "1.6",
-            color: "var(--fg-muted)",
-            whiteSpace: "pre-wrap",
-            wordBreak: "break-word",
-          }}>
-            {content}
-          </pre>
-        )}
-      </div>
-    </section>
   );
 }
 

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -20,6 +20,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "paths": {
+      "@harness-kit/core": ["../../packages/core/src/index.ts"],
       "@harness-kit/shared": ["../../packages/shared/src/index.ts"],
       "@harness-kit/ui": ["../../packages/ui/src/index.ts"]
     }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "build:marketplace": "pnpm --filter harness-kit-marketplace build",
     "dev:desktop": "pnpm --filter harness-kit-desktop tauri dev",
     "build:desktop": "pnpm --filter harness-kit-desktop tauri build",
-    "build": "pnpm -r build"
+    "build": "pnpm -r build",
+    "build:core": "pnpm --filter @harness-kit/core build",
+    "build:cli": "pnpm --filter @harness-kit/cli build",
+    "test:core": "pnpm --filter @harness-kit/core test"
   }
 }

--- a/packages/core/__tests__/compile.test.ts
+++ b/packages/core/__tests__/compile.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { compile } from "../src/compile/compile.js";
+import { MockFsProvider } from "./helpers/mock-fs.js";
+
+const FIXTURES = resolve(import.meta.dirname, "fixtures");
+
+function loadFixture(name: string): string {
+  return readFileSync(resolve(FIXTURES, name), "utf-8");
+}
+
+describe("compile", () => {
+  it("compiles a valid harness for claude-code (dry-run)", async () => {
+    const fs = new MockFsProvider();
+    const yaml = loadFixture("valid-harness.yaml");
+
+    const result = await compile(yaml, ["claude-code"], fs, { dryRun: true });
+
+    expect(result.harnessName).toBe("my-harness");
+    expect(result.targets).toEqual(["claude-code"]);
+    expect(result.files.length).toBeGreaterThan(0);
+
+    // Should have operational, behavioral, mcp-servers, permissions
+    const slots = result.files.map((f) => f.slot);
+    expect(slots).toContain("operational");
+    expect(slots).toContain("behavioral");
+    expect(slots).toContain("mcp-servers");
+    expect(slots).toContain("permissions");
+  });
+
+  it("compiles for all targets (dry-run)", async () => {
+    const fs = new MockFsProvider();
+    const yaml = loadFixture("valid-harness.yaml");
+
+    const result = await compile(
+      yaml,
+      ["claude-code", "cursor", "copilot"],
+      fs,
+      { dryRun: true },
+    );
+
+    expect(result.targets).toHaveLength(3);
+
+    // Claude Code files
+    expect(result.files.some((f) => f.path === "CLAUDE.md")).toBe(true);
+    expect(result.files.some((f) => f.path === "AGENT.md")).toBe(true);
+    expect(result.files.some((f) => f.path === ".mcp.json")).toBe(true);
+
+    // Cursor files
+    expect(result.files.some((f) => f.path === ".cursor/rules/harness.mdc")).toBe(true);
+    expect(result.files.some((f) => f.path === ".cursor/mcp.json")).toBe(true);
+
+    // Copilot files
+    expect(result.files.some((f) => f.path === ".github/copilot-instructions.md")).toBe(true);
+    expect(result.files.some((f) => f.path === ".vscode/mcp.json")).toBe(true);
+  });
+
+  it("throws on invalid harness.yaml", async () => {
+    const fs = new MockFsProvider();
+    const yaml = loadFixture("invalid-harness.yaml");
+
+    await expect(
+      compile(yaml, ["claude-code"], fs),
+    ).rejects.toThrow("validation failed");
+  });
+
+  it("writes files when not dry-run", async () => {
+    const fs = new MockFsProvider();
+    const yaml = loadFixture("valid-harness.yaml");
+
+    await compile(yaml, ["claude-code"], fs, { dryRun: false });
+
+    // Files should exist in the mock filesystem
+    const claudeMd = fs.getFile("/project/CLAUDE.md");
+    expect(claudeMd).toBeDefined();
+    expect(claudeMd).toContain("<!-- BEGIN harness:my-harness:operational -->");
+
+    const mcpJson = fs.getFile("/project/.mcp.json");
+    expect(mcpJson).toBeDefined();
+    expect(JSON.parse(mcpJson!).mcpServers.postgres).toBeDefined();
+  });
+
+  it("generates correct marker format", async () => {
+    const fs = new MockFsProvider();
+    const yaml = loadFixture("valid-harness.yaml");
+
+    const result = await compile(yaml, ["claude-code"], fs, { dryRun: true });
+    const ops = result.files.find(
+      (f) => f.slot === "operational" && f.platform === "claude-code",
+    );
+
+    expect(ops!.content).toMatch(
+      /<!-- BEGIN harness:my-harness:operational -->/,
+    );
+    expect(ops!.content).toMatch(
+      /<!-- END harness:my-harness:operational -->/,
+    );
+  });
+
+  it("includes Cursor .mdc frontmatter", async () => {
+    const fs = new MockFsProvider();
+    const yaml = loadFixture("valid-harness.yaml");
+
+    const result = await compile(yaml, ["cursor"], fs, { dryRun: true });
+    const ops = result.files.find(
+      (f) => f.slot === "operational" && f.platform === "cursor",
+    );
+
+    expect(ops!.content).toContain("description: Harness operational instructions");
+    expect(ops!.content).toContain("alwaysApply: true");
+  });
+
+  it("reports warnings for non-enforceable deny permissions", async () => {
+    const fs = new MockFsProvider();
+    const yaml = loadFixture("valid-harness.yaml");
+
+    const result = await compile(yaml, ["cursor"], fs, { dryRun: true });
+    expect(result.warnings.some((w) => w.includes("not machine-enforceable"))).toBe(true);
+  });
+});

--- a/packages/core/__tests__/detect-platforms.test.ts
+++ b/packages/core/__tests__/detect-platforms.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { detectPlatforms } from "../src/detect/detect-platforms.js";
+import { MockFsProvider } from "./helpers/mock-fs.js";
+
+describe("detectPlatforms", () => {
+  it("detects Claude Code from CLAUDE.md", async () => {
+    const fs = new MockFsProvider({
+      "/project/CLAUDE.md": "# Claude instructions",
+    });
+    const result = await detectPlatforms(fs);
+    expect(result).toHaveLength(1);
+    expect(result[0].platform).toBe("claude-code");
+    expect(result[0].indicators).toContain("CLAUDE.md");
+    expect(result[0].needsConfirmation).toBe(false);
+  });
+
+  it("detects Cursor from .cursor directory", async () => {
+    const fs = new MockFsProvider({
+      "/project/.cursor/rules/test.mdc": "rule",
+    });
+    const result = await detectPlatforms(fs);
+    expect(result).toHaveLength(1);
+    expect(result[0].platform).toBe("cursor");
+  });
+
+  it("detects Copilot from copilot-instructions.md", async () => {
+    const fs = new MockFsProvider({
+      "/project/.github/copilot-instructions.md": "instructions",
+    });
+    const result = await detectPlatforms(fs);
+    expect(result).toHaveLength(1);
+    expect(result[0].platform).toBe("copilot");
+    expect(result[0].needsConfirmation).toBe(false);
+  });
+
+  it("flags .github as ambiguous for Copilot", async () => {
+    const fs = new MockFsProvider({
+      "/project/.github/workflows/ci.yml": "name: CI",
+    });
+    const result = await detectPlatforms(fs);
+    expect(result).toHaveLength(1);
+    expect(result[0].platform).toBe("copilot");
+    expect(result[0].needsConfirmation).toBe(true);
+  });
+
+  it("detects multiple platforms", async () => {
+    const fs = new MockFsProvider({
+      "/project/CLAUDE.md": "# Claude",
+      "/project/.cursor/rules/test.mdc": "rule",
+      "/project/.vscode/mcp.json": "{}",
+    });
+    const result = await detectPlatforms(fs);
+    expect(result.length).toBeGreaterThanOrEqual(2);
+    const platforms = result.map((r) => r.platform);
+    expect(platforms).toContain("claude-code");
+    expect(platforms).toContain("cursor");
+  });
+
+  it("returns empty array when nothing detected", async () => {
+    const fs = new MockFsProvider({});
+    const result = await detectPlatforms(fs);
+    expect(result).toHaveLength(0);
+  });
+});

--- a/packages/core/__tests__/fixtures/invalid-harness.yaml
+++ b/packages/core/__tests__/fixtures/invalid-harness.yaml
@@ -1,0 +1,6 @@
+version: 1
+
+plugins:
+  - name: explain
+    marketplace: harness-kit
+    description: This uses the legacy marketplace field

--- a/packages/core/__tests__/fixtures/legacy-harness.yaml
+++ b/packages/core/__tests__/fixtures/legacy-harness.yaml
@@ -1,0 +1,14 @@
+version: 1
+
+metadata:
+  name: legacy-harness
+  description: A legacy format harness file.
+
+marketplaces:
+  harness-kit:
+    url: harnessprotocol/harness-kit
+
+plugins:
+  - name: explain
+    marketplace: harness-kit
+    description: Layered explanations

--- a/packages/core/__tests__/fixtures/valid-harness.yaml
+++ b/packages/core/__tests__/fixtures/valid-harness.yaml
@@ -1,0 +1,53 @@
+$schema: https://harnessprotocol.ai/schema/v1/harness.schema.json
+version: "1"
+
+metadata:
+  name: my-harness
+  description: My personal harness configuration.
+
+plugins:
+  - name: explain
+    source: siracusa5/harness-kit
+    description: Layered explanations of files, functions, directories, or concepts
+
+  - name: research
+    source: siracusa5/harness-kit
+    description: Process any source into a structured, compounding knowledge base
+
+instructions:
+  operational: |
+    ## Commands
+    - Build: `pnpm build`
+    - Test: `pnpm test`
+  behavioral: |
+    Be concise. Prefer short answers.
+  import-mode: merge
+
+mcp-servers:
+  postgres:
+    transport: stdio
+    command: uvx
+    args:
+      - mcp-server-postgres
+      - ${DB_CONNECTION_STRING}
+
+env:
+  - name: DB_CONNECTION_STRING
+    description: PostgreSQL connection string.
+    required: true
+    sensitive: true
+
+permissions:
+  tools:
+    allow:
+      - Read
+      - Glob
+      - Grep
+      - Write
+      - Edit
+    deny:
+      - mcp__postgres__drop_table
+  paths:
+    writable:
+      - sql/
+      - migrations/

--- a/packages/core/__tests__/helpers/mock-fs.ts
+++ b/packages/core/__tests__/helpers/mock-fs.ts
@@ -1,0 +1,82 @@
+import type { FsProvider } from "../../src/fs-provider.js";
+
+export class MockFsProvider implements FsProvider {
+  private files: Map<string, string>;
+  private _cwd: string;
+  private _homedir: string;
+
+  constructor(
+    initialFiles: Record<string, string> = {},
+    cwd = "/project",
+    homedir = "/home/user",
+  ) {
+    this.files = new Map(Object.entries(initialFiles));
+    this._cwd = cwd;
+    this._homedir = homedir;
+  }
+
+  async readFile(path: string): Promise<string> {
+    const content = this.files.get(path);
+    if (content === undefined) {
+      throw new Error(`ENOENT: no such file: ${path}`);
+    }
+    return content;
+  }
+
+  async writeFile(path: string, content: string): Promise<void> {
+    this.files.set(path, content);
+  }
+
+  async exists(path: string): Promise<boolean> {
+    // Check exact file match
+    if (this.files.has(path)) return true;
+    // Check if it's a "directory" (any file starts with path/)
+    const prefix = path.endsWith("/") ? path : path + "/";
+    for (const key of this.files.keys()) {
+      if (key.startsWith(prefix)) return true;
+    }
+    return false;
+  }
+
+  async mkdir(_path: string, _options?: { recursive?: boolean }): Promise<void> {
+    // No-op for mock — directories are implicit
+  }
+
+  async readDir(path: string): Promise<string[]> {
+    const prefix = path.endsWith("/") ? path : path + "/";
+    const entries = new Set<string>();
+    for (const key of this.files.keys()) {
+      if (key.startsWith(prefix)) {
+        const rest = key.slice(prefix.length);
+        const first = rest.split("/")[0];
+        entries.add(first);
+      }
+    }
+    return [...entries];
+  }
+
+  joinPath(...segments: string[]): string {
+    // Simple path join without node:path
+    return segments
+      .join("/")
+      .replace(/\/+/g, "/")
+      .replace(/\/$/, "");
+  }
+
+  async homedir(): Promise<string> {
+    return this._homedir;
+  }
+
+  cwd(): string {
+    return this._cwd;
+  }
+
+  // Test helpers
+  getFile(path: string): string | undefined {
+    return this.files.get(path);
+  }
+
+  getAllFiles(): Record<string, string> {
+    return Object.fromEntries(this.files);
+  }
+}

--- a/packages/core/__tests__/helpers/mock-fs.ts
+++ b/packages/core/__tests__/helpers/mock-fs.ts
@@ -1,4 +1,5 @@
 import type { FsProvider } from "../../src/fs-provider.js";
+import { posixJoin, posixDirname } from "../../src/utils/posix-path.js";
 
 export class MockFsProvider implements FsProvider {
   private files: Map<string, string>;
@@ -56,16 +57,11 @@ export class MockFsProvider implements FsProvider {
   }
 
   joinPath(...segments: string[]): string {
-    // Simple path join without node:path
-    return segments
-      .join("/")
-      .replace(/\/+/g, "/")
-      .replace(/\/$/, "");
+    return posixJoin(...segments);
   }
 
   dirname(path: string): string {
-    const lastSlash = path.lastIndexOf("/");
-    return lastSlash > 0 ? path.substring(0, lastSlash) : "/";
+    return posixDirname(path);
   }
 
   async homedir(): Promise<string> {

--- a/packages/core/__tests__/helpers/mock-fs.ts
+++ b/packages/core/__tests__/helpers/mock-fs.ts
@@ -63,6 +63,11 @@ export class MockFsProvider implements FsProvider {
       .replace(/\/$/, "");
   }
 
+  dirname(path: string): string {
+    const lastSlash = path.lastIndexOf("/");
+    return lastSlash > 0 ? path.substring(0, lastSlash) : "/";
+  }
+
   async homedir(): Promise<string> {
     return this._homedir;
   }

--- a/packages/core/__tests__/instructions.test.ts
+++ b/packages/core/__tests__/instructions.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import { compileInstructions } from "../src/compile/instructions.js";
+import { MockFsProvider } from "./helpers/mock-fs.js";
+import type { HarnessConfig } from "../src/types.js";
+
+function makeConfig(overrides: Partial<HarnessConfig> = {}): HarnessConfig {
+  return {
+    version: "1",
+    metadata: { name: "test-harness", description: "Test" },
+    instructions: {
+      operational: "## Commands\n- Build: `pnpm build`",
+      behavioral: "Be concise.",
+      "import-mode": "merge",
+    },
+    ...overrides,
+  };
+}
+
+describe("compileInstructions", () => {
+  it("creates instruction files for Claude Code", async () => {
+    const fs = new MockFsProvider();
+    const config = makeConfig();
+    const { files } = await compileInstructions(config, ["claude-code"], fs);
+
+    expect(files).toHaveLength(2); // operational + behavioral
+    const ops = files.find((f) => f.slot === "operational");
+    expect(ops).toBeDefined();
+    expect(ops!.path).toBe("CLAUDE.md");
+    expect(ops!.content).toContain("<!-- BEGIN harness:test-harness:operational -->");
+    expect(ops!.content).toContain("pnpm build");
+    expect(ops!.content).toContain("<!-- END harness:test-harness:operational -->");
+  });
+
+  it("creates Cursor .mdc files with frontmatter", async () => {
+    const fs = new MockFsProvider();
+    const config = makeConfig();
+    const { files } = await compileInstructions(config, ["cursor"], fs);
+
+    const ops = files.find((f) => f.slot === "operational" && f.platform === "cursor");
+    expect(ops).toBeDefined();
+    expect(ops!.path).toBe(".cursor/rules/harness.mdc");
+    expect(ops!.content).toContain("description: Harness operational instructions");
+    expect(ops!.content).toContain("alwaysApply: true");
+  });
+
+  it("creates Copilot files with applyTo frontmatter", async () => {
+    const fs = new MockFsProvider();
+    const config = makeConfig();
+    const { files } = await compileInstructions(config, ["copilot"], fs);
+
+    const ops = files.find((f) => f.slot === "operational");
+    expect(ops).toBeDefined();
+    expect(ops!.path).toBe(".github/copilot-instructions.md");
+    expect(ops!.content).toContain('applyTo: "**"');
+  });
+
+  it("skips identity slot for non-Claude-Code targets", async () => {
+    const fs = new MockFsProvider();
+    const config = makeConfig({
+      instructions: {
+        operational: "ops",
+        identity: "I am helpful.",
+        "import-mode": "merge",
+      },
+    });
+    const { files } = await compileInstructions(config, ["cursor", "copilot"], fs);
+
+    const identity = files.filter((f) => f.slot === "identity");
+    expect(identity).toHaveLength(0);
+  });
+
+  it("updates existing marker blocks on merge", async () => {
+    const existingContent = [
+      "# My manual content",
+      "",
+      "<!-- BEGIN harness:test-harness:operational -->",
+      "old content",
+      "<!-- END harness:test-harness:operational -->",
+    ].join("\n");
+
+    const fs = new MockFsProvider({
+      "/project/CLAUDE.md": existingContent,
+    });
+
+    const config = makeConfig({
+      instructions: {
+        operational: "new content",
+        "import-mode": "merge",
+      },
+    });
+
+    const { files } = await compileInstructions(config, ["claude-code"], fs);
+    const ops = files.find((f) => f.slot === "operational");
+    expect(ops).toBeDefined();
+    expect(ops!.action).toBe("update");
+    expect(ops!.content).toContain("# My manual content");
+    expect(ops!.content).toContain("new content");
+    expect(ops!.content).not.toContain("old content");
+  });
+
+  it("returns needs-confirmation for replace mode", async () => {
+    const fs = new MockFsProvider({
+      "/project/CLAUDE.md": "existing content",
+    });
+
+    const config = makeConfig({
+      instructions: {
+        operational: "replacement",
+        "import-mode": "replace",
+      },
+    });
+
+    const { files } = await compileInstructions(config, ["claude-code"], fs);
+    const ops = files.find((f) => f.slot === "operational");
+    expect(ops!.action).toBe("needs-confirmation");
+  });
+
+  it("returns empty files for skip mode", async () => {
+    const fs = new MockFsProvider();
+    const config = makeConfig({
+      instructions: {
+        operational: "ops",
+        "import-mode": "skip",
+      },
+    });
+
+    const { files } = await compileInstructions(config, ["claude-code"], fs);
+    expect(files).toHaveLength(0);
+  });
+
+  it("uses 'default' name when metadata.name is absent", async () => {
+    const fs = new MockFsProvider();
+    const config: HarnessConfig = {
+      version: "1",
+      kind: "fragment",
+      instructions: {
+        operational: "ops",
+        "import-mode": "merge",
+      },
+    };
+
+    const { files } = await compileInstructions(config, ["claude-code"], fs);
+    const ops = files.find((f) => f.slot === "operational");
+    expect(ops!.content).toContain("<!-- BEGIN harness:default:operational -->");
+  });
+});

--- a/packages/core/__tests__/markers.test.ts
+++ b/packages/core/__tests__/markers.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildMarkerBlock,
+  findMarkerBlock,
+  replaceMarkerBlock,
+  appendMarkerBlock,
+  findOrphanedMarkerBlocks,
+  removeOrphanedBlocks,
+} from "../src/compile/markers.js";
+
+describe("buildMarkerBlock", () => {
+  it("wraps content in markers", () => {
+    const result = buildMarkerBlock("my-harness", "operational", "## Commands\n- Build: `npm run build`");
+    expect(result).toBe(
+      "<!-- BEGIN harness:my-harness:operational -->\n## Commands\n- Build: `npm run build`\n<!-- END harness:my-harness:operational -->",
+    );
+  });
+});
+
+describe("findMarkerBlock", () => {
+  it("finds an existing marker block", () => {
+    const content = [
+      "# My CLAUDE.md",
+      "",
+      "<!-- BEGIN harness:my-harness:operational -->",
+      "## Commands",
+      "- Build: `npm run build`",
+      "<!-- END harness:my-harness:operational -->",
+      "",
+      "# Manual section",
+    ].join("\n");
+
+    const result = findMarkerBlock(content, "my-harness", "operational");
+    expect(result).not.toBeNull();
+    expect(result!.startLine).toBe(2);
+    expect(result!.endLine).toBe(5);
+    expect(result!.content).toBe("## Commands\n- Build: `npm run build`");
+  });
+
+  it("returns null when no block exists", () => {
+    const result = findMarkerBlock("# Just a file", "my-harness", "operational");
+    expect(result).toBeNull();
+  });
+
+  it("does not match different names", () => {
+    const content =
+      "<!-- BEGIN harness:other:operational -->\ncontent\n<!-- END harness:other:operational -->";
+    const result = findMarkerBlock(content, "my-harness", "operational");
+    expect(result).toBeNull();
+  });
+});
+
+describe("replaceMarkerBlock", () => {
+  it("replaces content between markers", () => {
+    const original = [
+      "# Header",
+      "<!-- BEGIN harness:test:operational -->",
+      "old content",
+      "<!-- END harness:test:operational -->",
+      "# Footer",
+    ].join("\n");
+
+    const result = replaceMarkerBlock(original, "test", "operational", "new content");
+    expect(result).toContain("new content");
+    expect(result).not.toContain("old content");
+    expect(result).toContain("# Header");
+    expect(result).toContain("# Footer");
+  });
+
+  it("returns original content if block not found", () => {
+    const original = "# No markers here";
+    const result = replaceMarkerBlock(original, "test", "operational", "new");
+    expect(result).toBe(original);
+  });
+});
+
+describe("appendMarkerBlock", () => {
+  it("appends to existing content", () => {
+    const result = appendMarkerBlock("# Existing\n\nSome content", "test", "operational", "new stuff");
+    expect(result).toContain("# Existing");
+    expect(result).toContain("<!-- BEGIN harness:test:operational -->");
+    expect(result).toContain("new stuff");
+    expect(result).toContain("<!-- END harness:test:operational -->");
+  });
+
+  it("handles empty content", () => {
+    const result = appendMarkerBlock("", "test", "operational", "new stuff");
+    expect(result).toContain("<!-- BEGIN harness:test:operational -->");
+  });
+});
+
+describe("findOrphanedMarkerBlocks", () => {
+  it("finds blocks with a different name", () => {
+    const content = [
+      "<!-- BEGIN harness:old-name:operational -->",
+      "old content",
+      "<!-- END harness:old-name:operational -->",
+      "",
+      "<!-- BEGIN harness:current:operational -->",
+      "current content",
+      "<!-- END harness:current:operational -->",
+    ].join("\n");
+
+    const orphans = findOrphanedMarkerBlocks(content, "current", "CLAUDE.md");
+    expect(orphans).toHaveLength(1);
+    expect(orphans[0].name).toBe("old-name");
+    expect(orphans[0].slot).toBe("operational");
+    expect(orphans[0].file).toBe("CLAUDE.md");
+  });
+
+  it("returns empty array when no orphans", () => {
+    const content =
+      "<!-- BEGIN harness:current:operational -->\ncontent\n<!-- END harness:current:operational -->";
+    const orphans = findOrphanedMarkerBlocks(content, "current", "test.md");
+    expect(orphans).toHaveLength(0);
+  });
+});
+
+describe("removeOrphanedBlocks", () => {
+  it("removes orphaned blocks", () => {
+    const content = [
+      "# Header",
+      "<!-- BEGIN harness:old:operational -->",
+      "old content",
+      "<!-- END harness:old:operational -->",
+      "",
+      "# Footer",
+    ].join("\n");
+
+    const orphans = findOrphanedMarkerBlocks(content, "current", "test.md");
+    const result = removeOrphanedBlocks(content, orphans);
+    expect(result).toContain("# Header");
+    expect(result).toContain("# Footer");
+    expect(result).not.toContain("old content");
+    expect(result).not.toContain("<!-- BEGIN harness:old:operational -->");
+  });
+});

--- a/packages/core/__tests__/mcp-servers.test.ts
+++ b/packages/core/__tests__/mcp-servers.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { compileMcpServers } from "../src/compile/mcp-servers.js";
+import { MockFsProvider } from "./helpers/mock-fs.js";
+import type { HarnessConfig } from "../src/types.js";
+
+function makeConfig(servers: HarnessConfig["mcp-servers"] = {}): HarnessConfig {
+  return {
+    version: "1",
+    metadata: { name: "test", description: "test" },
+    "mcp-servers": servers,
+  };
+}
+
+describe("compileMcpServers", () => {
+  it("creates MCP JSON files for each target", async () => {
+    const fs = new MockFsProvider();
+    const config = makeConfig({
+      postgres: {
+        transport: "stdio",
+        command: "uvx",
+        args: ["mcp-server-postgres"],
+      },
+    });
+
+    const { files } = await compileMcpServers(config, ["claude-code", "cursor"], fs);
+    expect(files).toHaveLength(2);
+
+    const cc = files.find((f) => f.platform === "claude-code");
+    expect(cc!.path).toBe(".mcp.json");
+    const parsed = JSON.parse(cc!.content);
+    expect(parsed.mcpServers.postgres.type).toBe("stdio");
+    expect(parsed.mcpServers.postgres.command).toBe("uvx");
+  });
+
+  it("translates transport to type", async () => {
+    const fs = new MockFsProvider();
+    const config = makeConfig({
+      api: {
+        transport: "sse",
+        url: "https://example.com/mcp",
+      },
+    });
+
+    const { files } = await compileMcpServers(config, ["claude-code"], fs);
+    const parsed = JSON.parse(files[0].content);
+    expect(parsed.mcpServers.api.type).toBe("sse");
+    expect(parsed.mcpServers.api.url).toBe("https://example.com/mcp");
+  });
+
+  it("merges with existing MCP config", async () => {
+    const existing = JSON.stringify({
+      mcpServers: {
+        existing: { type: "stdio", command: "existing-cmd" },
+      },
+    });
+
+    const fs = new MockFsProvider({
+      "/project/.mcp.json": existing,
+    });
+
+    const config = makeConfig({
+      newserver: { transport: "stdio", command: "new-cmd" },
+    });
+
+    const { files } = await compileMcpServers(config, ["claude-code"], fs);
+    const parsed = JSON.parse(files[0].content);
+    expect(parsed.mcpServers.existing.command).toBe("existing-cmd");
+    expect(parsed.mcpServers.newserver.command).toBe("new-cmd");
+  });
+
+  it("warns on name collision and keeps existing", async () => {
+    const existing = JSON.stringify({
+      mcpServers: {
+        postgres: { type: "stdio", command: "old-postgres" },
+      },
+    });
+
+    const fs = new MockFsProvider({
+      "/project/.mcp.json": existing,
+    });
+
+    const config = makeConfig({
+      postgres: { transport: "stdio", command: "new-postgres" },
+    });
+
+    const { files, warnings } = await compileMcpServers(config, ["claude-code"], fs);
+    const parsed = JSON.parse(files[0].content);
+    // Existing config preserved
+    expect(parsed.mcpServers.postgres.command).toBe("old-postgres");
+    // Warning emitted
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain("postgres");
+    expect(warnings[0]).toContain("Existing config kept");
+  });
+
+  it("returns empty files when no mcp-servers", async () => {
+    const fs = new MockFsProvider();
+    const config: HarnessConfig = {
+      version: "1",
+      metadata: { name: "test", description: "test" },
+    };
+
+    const { files } = await compileMcpServers(config, ["claude-code"], fs);
+    expect(files).toHaveLength(0);
+  });
+});

--- a/packages/core/__tests__/parse-harness.test.ts
+++ b/packages/core/__tests__/parse-harness.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { parseHarness } from "../src/parser/parse-harness.js";
+
+const FIXTURES = resolve(import.meta.dirname, "fixtures");
+
+function loadFixture(name: string): string {
+  return readFileSync(resolve(FIXTURES, name), "utf-8");
+}
+
+describe("parseHarness", () => {
+  it("parses a valid harness.yaml", () => {
+    const { config, isLegacyFormat } = parseHarness(
+      loadFixture("valid-harness.yaml"),
+    );
+    expect(isLegacyFormat).toBe(false);
+    expect(config.version).toBe("1");
+    expect(config.metadata?.name).toBe("my-harness");
+    expect(config.plugins).toHaveLength(2);
+    expect(config["mcp-servers"]).toBeDefined();
+    expect(config.instructions?.operational).toContain("pnpm build");
+  });
+
+  it("detects legacy format (integer version)", () => {
+    const { config, isLegacyFormat } = parseHarness(
+      loadFixture("legacy-harness.yaml"),
+    );
+    expect(isLegacyFormat).toBe(true);
+    // version is parsed as integer by YAML
+    expect(config.version).toBe(1 as unknown as string);
+  });
+
+  it("throws on invalid YAML syntax", () => {
+    expect(() => parseHarness("{ invalid yaml: [")).toThrow("YAML syntax error");
+  });
+
+  it("throws on empty content", () => {
+    expect(() => parseHarness("")).toThrow("empty");
+  });
+
+  it("throws on non-object content", () => {
+    expect(() => parseHarness("just a string")).toThrow("does not contain a YAML mapping");
+  });
+
+  it("parses mcp-servers with stdio transport", () => {
+    const { config } = parseHarness(loadFixture("valid-harness.yaml"));
+    const servers = config["mcp-servers"];
+    expect(servers).toBeDefined();
+    expect(servers!.postgres).toBeDefined();
+    expect(servers!.postgres.transport).toBe("stdio");
+  });
+
+  it("parses permissions", () => {
+    const { config } = parseHarness(loadFixture("valid-harness.yaml"));
+    expect(config.permissions?.tools?.allow).toContain("Read");
+    expect(config.permissions?.tools?.deny).toContain("mcp__postgres__drop_table");
+    expect(config.permissions?.paths?.writable).toContain("sql/");
+  });
+});

--- a/packages/core/__tests__/permissions.test.ts
+++ b/packages/core/__tests__/permissions.test.ts
@@ -31,6 +31,7 @@ describe("compilePermissions", () => {
     const parsed = JSON.parse(files[0].content);
     expect(parsed.permissions.allow).toEqual(["Read", "Write"]);
     expect(parsed.permissions.deny).toEqual(["mcp__postgres__drop_table"]);
+    // Only writable paths become additionalDirectories (readonly would gain unintended write access)
     expect(parsed.permissions.additionalDirectories).toEqual(["sql/", "migrations/"]);
   });
 

--- a/packages/core/__tests__/permissions.test.ts
+++ b/packages/core/__tests__/permissions.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { compilePermissions, buildPermissionsText } from "../src/compile/permissions.js";
+import { MockFsProvider } from "./helpers/mock-fs.js";
+import type { HarnessConfig } from "../src/types.js";
+
+function makeConfig(permissions: HarnessConfig["permissions"]): HarnessConfig {
+  return {
+    version: "1",
+    metadata: { name: "test", description: "test" },
+    permissions,
+  };
+}
+
+describe("compilePermissions", () => {
+  it("creates .claude/settings.json for Claude Code", async () => {
+    const fs = new MockFsProvider();
+    const config = makeConfig({
+      tools: {
+        allow: ["Read", "Write"],
+        deny: ["mcp__postgres__drop_table"],
+      },
+      paths: {
+        writable: ["sql/", "migrations/"],
+      },
+    });
+
+    const { files } = await compilePermissions(config, ["claude-code"], fs);
+    expect(files).toHaveLength(1);
+    expect(files[0].path).toBe(".claude/settings.json");
+
+    const parsed = JSON.parse(files[0].content);
+    expect(parsed.permissions.allow).toEqual(["Read", "Write"]);
+    expect(parsed.permissions.deny).toEqual(["mcp__postgres__drop_table"]);
+    expect(parsed.permissions.additionalDirectories).toEqual(["sql/", "migrations/"]);
+  });
+
+  it("merges with existing settings.json", async () => {
+    const existing = JSON.stringify({
+      existingKey: "preserved",
+      permissions: { allow: ["Bash"] },
+    });
+
+    const fs = new MockFsProvider({
+      "/project/.claude/settings.json": existing,
+    });
+
+    const config = makeConfig({
+      tools: { allow: ["Read"] },
+    });
+
+    const { files } = await compilePermissions(config, ["claude-code"], fs);
+    const parsed = JSON.parse(files[0].content);
+    expect(parsed.existingKey).toBe("preserved");
+    expect(parsed.permissions.allow).toEqual(["Read"]);
+  });
+
+  it("warns about deny not being enforceable for non-Claude-Code", async () => {
+    const fs = new MockFsProvider();
+    const config = makeConfig({
+      tools: {
+        allow: ["Read"],
+        deny: ["mcp__postgres__drop_table"],
+      },
+    });
+
+    const { warnings } = await compilePermissions(config, ["cursor"], fs);
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain("not machine-enforceable");
+    expect(warnings[0]).toContain("cursor");
+  });
+});
+
+describe("buildPermissionsText", () => {
+  it("generates human-readable permissions", () => {
+    const text = buildPermissionsText({
+      tools: {
+        allow: ["Read", "Write", "Bash"],
+        deny: ["mcp__*__drop_*"],
+      },
+    });
+
+    expect(text).toContain("## Tool Permissions");
+    expect(text).toContain("Read, Write, Bash");
+    expect(text).toContain("mcp__*__drop_*");
+  });
+
+  it("returns null when no tools defined", () => {
+    const text = buildPermissionsText({});
+    expect(text).toBeNull();
+  });
+});

--- a/packages/core/__tests__/report.test.ts
+++ b/packages/core/__tests__/report.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { buildReport } from "../src/report/report.js";
+import type { CompileResult } from "../src/types.js";
+
+function makeResult(overrides: Partial<CompileResult> = {}): CompileResult {
+  return {
+    harnessName: "test-harness",
+    targets: ["claude-code", "cursor"],
+    files: [],
+    warnings: [],
+    skippedPlugins: [],
+    ...overrides,
+  };
+}
+
+describe("buildReport", () => {
+  it("sorts entries by platform order then slot order", () => {
+    const result = makeResult({
+      files: [
+        { path: ".cursor/mcp.json", content: "{}", action: "create", platform: "cursor", slot: "mcp-servers", linesAdded: 1 },
+        { path: "CLAUDE.md", content: "ops", action: "create", platform: "claude-code", slot: "operational", linesAdded: 10 },
+        { path: ".cursor/rules/harness.mdc", content: "ops", action: "create", platform: "cursor", slot: "operational", linesAdded: 10 },
+        { path: "AGENT.md", content: "beh", action: "create", platform: "claude-code", slot: "behavioral", linesAdded: 5 },
+      ],
+    });
+
+    const report = buildReport(result);
+    const files = report.entries.map((e) => e.file);
+    expect(files).toEqual([
+      "CLAUDE.md",
+      "AGENT.md",
+      ".cursor/rules/harness.mdc",
+      ".cursor/mcp.json",
+    ]);
+  });
+
+  it("formats MCP server counts", () => {
+    const result = makeResult({
+      files: [
+        { path: ".mcp.json", content: "{}", action: "create", platform: "claude-code", slot: "mcp-servers", linesAdded: 3 },
+      ],
+    });
+
+    const report = buildReport(result);
+    expect(report.entries[0].detail).toBe("3 servers");
+  });
+
+  it("formats single server count without plural", () => {
+    const result = makeResult({
+      files: [
+        { path: ".mcp.json", content: "{}", action: "create", platform: "claude-code", slot: "mcp-servers", linesAdded: 1 },
+      ],
+    });
+
+    const report = buildReport(result);
+    expect(report.entries[0].detail).toBe("1 server");
+  });
+
+  it("formats permission details from JSON content", () => {
+    const content = JSON.stringify({
+      permissions: { allow: ["Read", "Write"], deny: ["drop"] },
+    });
+
+    const result = makeResult({
+      files: [
+        { path: ".claude/settings.json", content, action: "create", platform: "claude-code", slot: "permissions" },
+      ],
+    });
+
+    const report = buildReport(result);
+    expect(report.entries[0].detail).toBe("2 allowed, 1 denied");
+  });
+
+  it("omits skipped files", () => {
+    const result = makeResult({
+      files: [
+        { path: "CLAUDE.md", content: "ops", action: "skip", platform: "claude-code", slot: "operational" },
+        { path: "AGENT.md", content: "beh", action: "create", platform: "claude-code", slot: "behavioral", linesAdded: 5 },
+      ],
+    });
+
+    const report = buildReport(result);
+    expect(report.entries).toHaveLength(1);
+    expect(report.entries[0].file).toBe("AGENT.md");
+  });
+
+  it("passes through warnings and skippedPlugins", () => {
+    const result = makeResult({
+      warnings: ["test warning"],
+      skippedPlugins: ["missing: skipped"],
+    });
+
+    const report = buildReport(result);
+    expect(report.warnings).toEqual(["test warning"]);
+    expect(report.skippedPlugins).toEqual(["missing: skipped"]);
+  });
+
+  it("formats skills as copied", () => {
+    const result = makeResult({
+      files: [
+        { path: ".cursor/skills/explain/SKILL.md", content: "# Explain", action: "create", platform: "cursor", slot: "skills" },
+      ],
+    });
+
+    const report = buildReport(result);
+    expect(report.entries[0].detail).toBe("copied");
+  });
+});

--- a/packages/core/__tests__/skills.test.ts
+++ b/packages/core/__tests__/skills.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { compileSkills } from "../src/compile/skills.js";
+import { MockFsProvider } from "./helpers/mock-fs.js";
+import type { HarnessConfig } from "../src/types.js";
+
+function makeConfig(plugins: HarnessConfig["plugins"] = []): HarnessConfig {
+  return {
+    version: "1",
+    metadata: { name: "test", description: "test" },
+    plugins,
+  };
+}
+
+describe("compileSkills", () => {
+  it("copies SKILL.md to target directories", async () => {
+    const fs = new MockFsProvider({
+      "/home/user/.claude/skills/explain/SKILL.md":
+        "---\nname: explain\ndescription: Layered explanations\n---\n\n# Explain",
+    });
+
+    const config = makeConfig([
+      { name: "explain", source: "siracusa5/harness-kit" },
+    ]);
+
+    const { files, skippedPlugins } = await compileSkills(config, ["cursor"], fs);
+    expect(files).toHaveLength(1);
+    expect(files[0].path).toBe(".cursor/skills/explain/SKILL.md");
+    expect(files[0].content).toContain("# Explain");
+    expect(skippedPlugins).toHaveLength(0);
+  });
+
+  it("skips Claude Code (uses plugin install system)", async () => {
+    const fs = new MockFsProvider({
+      "/home/user/.claude/skills/explain/SKILL.md":
+        "---\nname: explain\n---\n\n# Explain",
+    });
+
+    const config = makeConfig([
+      { name: "explain", source: "siracusa5/harness-kit" },
+    ]);
+
+    const { files } = await compileSkills(config, ["claude-code"], fs);
+    expect(files).toHaveLength(0);
+  });
+
+  it("reports skipped plugins when SKILL.md not found", async () => {
+    const fs = new MockFsProvider();
+    const config = makeConfig([
+      { name: "missing-plugin", source: "someone/repo" },
+    ]);
+
+    const { files, skippedPlugins } = await compileSkills(config, ["cursor"], fs);
+    expect(files).toHaveLength(0);
+    expect(skippedPlugins).toHaveLength(1);
+    expect(skippedPlugins[0]).toContain("missing-plugin");
+    expect(skippedPlugins[0]).toContain("skipped");
+  });
+
+  it("renames dependencies to compatibility in frontmatter", async () => {
+    const fs = new MockFsProvider({
+      "/home/user/.claude/skills/test/SKILL.md":
+        "---\nname: test\ndescription: Test skill\ndependencies: node >= 18\n---\n\n# Test",
+    });
+
+    const config = makeConfig([
+      { name: "test", source: "test/repo" },
+    ]);
+
+    const { files } = await compileSkills(config, ["cursor"], fs);
+    expect(files[0].content).toContain("compatibility:");
+    expect(files[0].content).not.toContain("dependencies:");
+  });
+
+  it("copies to both Cursor and Copilot directories", async () => {
+    const fs = new MockFsProvider({
+      "/home/user/.claude/skills/explain/SKILL.md":
+        "---\nname: explain\n---\n\n# Explain",
+    });
+
+    const config = makeConfig([
+      { name: "explain", source: "siracusa5/harness-kit" },
+    ]);
+
+    const { files } = await compileSkills(config, ["cursor", "copilot"], fs);
+    expect(files).toHaveLength(2);
+    expect(files.map((f) => f.path)).toContain(".cursor/skills/explain/SKILL.md");
+    expect(files.map((f) => f.path)).toContain(".github/skills/explain/SKILL.md");
+  });
+});

--- a/packages/core/__tests__/validate.test.ts
+++ b/packages/core/__tests__/validate.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { parseHarness } from "../src/parser/parse-harness.js";
+import { validateHarness } from "../src/schema/validate.js";
+
+const FIXTURES = resolve(import.meta.dirname, "fixtures");
+
+function loadFixture(name: string): string {
+  return readFileSync(resolve(FIXTURES, name), "utf-8");
+}
+
+describe("validateHarness", () => {
+  it("passes for a valid harness.yaml", () => {
+    const { config } = parseHarness(loadFixture("valid-harness.yaml"));
+    const result = validateHarness(config);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("fails for an invalid harness.yaml (integer version)", () => {
+    const { config } = parseHarness(loadFixture("invalid-harness.yaml"));
+    const result = validateHarness(config);
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.isLegacyFormat).toBe(true);
+  });
+
+  it("detects legacy format", () => {
+    const { config, isLegacyFormat } = parseHarness(
+      loadFixture("legacy-harness.yaml"),
+    );
+    expect(isLegacyFormat).toBe(true);
+    const result = validateHarness(config);
+    expect(result.isLegacyFormat).toBe(true);
+  });
+
+  it("fails when version is missing", () => {
+    const result = validateHarness({ metadata: { name: "test", description: "test" } });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.message.includes("version") || e.path.includes("version"))).toBe(true);
+  });
+
+  it("fails when metadata is missing on a profile", () => {
+    const result = validateHarness({ version: "1" });
+    expect(result.valid).toBe(false);
+  });
+
+  it("passes for a fragment without metadata", () => {
+    const result = validateHarness({ version: "1", kind: "fragment" });
+    expect(result.valid).toBe(true);
+  });
+
+  it("reports invalid plugin source format", () => {
+    const result = validateHarness({
+      version: "1",
+      metadata: { name: "test", description: "test" },
+      plugins: [{ name: "foo", source: "not-valid" }],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.fix?.includes("owner/repo"))).toBe(true);
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@harness-kit/core",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./node": {
+      "types": "./dist/node.d.ts",
+      "import": "./dist/node.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "fetch-schema": "npx tsx scripts/fetch-schema.ts"
+  },
+  "dependencies": {
+    "ajv": "^8",
+    "ajv-formats": "^3",
+    "yaml": "^2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.15",
+    "tsup": "^8",
+    "typescript": "^5",
+    "vitest": "^3"
+  }
+}

--- a/packages/core/scripts/fetch-schema.ts
+++ b/packages/core/scripts/fetch-schema.ts
@@ -1,0 +1,37 @@
+/**
+ * Fetches the latest Harness Protocol v1 JSON Schema and writes it to
+ * packages/core/src/schema/harness.schema.json.
+ *
+ * Usage:
+ *   npx tsx packages/core/scripts/fetch-schema.ts
+ */
+
+import { writeFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCHEMA_URL =
+  "https://harnessprotocol.ai/schema/v1/harness.schema.json";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUTPUT = resolve(__dirname, "../src/schema/harness.schema.json");
+
+async function main() {
+  console.log(`Fetching schema from ${SCHEMA_URL}...`);
+
+  const res = await fetch(SCHEMA_URL);
+  if (!res.ok) {
+    console.error(`Failed to fetch schema: ${res.status} ${res.statusText}`);
+    process.exit(1);
+  }
+
+  const schema = await res.json();
+  const formatted = JSON.stringify(schema, null, 2) + "\n";
+
+  writeFileSync(OUTPUT, formatted, "utf-8");
+  console.log(`Schema written to ${OUTPUT}`);
+  console.log(`$id: ${schema.$id}`);
+  console.log(`title: ${schema.title}`);
+}
+
+main();

--- a/packages/core/src/compile/compile.ts
+++ b/packages/core/src/compile/compile.ts
@@ -115,7 +115,7 @@ async function writeFiles(
     }
 
     const fullPath = fs.joinPath(cwd, file.path);
-    const dir = fullPath.substring(0, fullPath.lastIndexOf("/"));
+    const dir = fs.dirname(fullPath);
 
     if (dir) {
       await fs.mkdir(dir, { recursive: true });

--- a/packages/core/src/compile/compile.ts
+++ b/packages/core/src/compile/compile.ts
@@ -1,0 +1,126 @@
+import type { FsProvider } from "../fs-provider.js";
+import type {
+  CompileOptions,
+  CompileResult,
+  FileAction,
+  HarnessConfig,
+  TargetPlatform,
+} from "../types.js";
+import { parseHarness } from "../parser/parse-harness.js";
+import { validateHarness } from "../schema/validate.js";
+import { compileInstructions } from "./instructions.js";
+import { compileMcpServers } from "./mcp-servers.js";
+import { compileSkills } from "./skills.js";
+import { compilePermissions, buildPermissionsText } from "./permissions.js";
+import { appendMarkerBlock, findMarkerBlock, replaceMarkerBlock } from "./markers.js";
+
+export async function compile(
+  yamlString: string,
+  targets: TargetPlatform[],
+  fs: FsProvider,
+  options: CompileOptions = {},
+): Promise<CompileResult> {
+  // Parse
+  const { config } = parseHarness(yamlString);
+
+  // Validate — fail fast
+  const validation = validateHarness(config);
+  if (!validation.valid) {
+    const errMsgs = validation.errors
+      .map((e) => `  ${e.path}: ${e.message}`)
+      .join("\n");
+    throw new Error(`harness.yaml validation failed:\n${errMsgs}`);
+  }
+
+  const harnessName = config.metadata?.name ?? "default";
+  const allFiles: FileAction[] = [];
+  const allWarnings: string[] = [];
+  const allSkipped: string[] = [];
+
+  // Step 3: Compile instructions
+  const instrResult = await compileInstructions(config, targets, fs);
+  allFiles.push(...instrResult.files);
+  allWarnings.push(...instrResult.warnings);
+
+  // Append permissions text to non-Claude-Code instruction files
+  if (config.permissions) {
+    const permText = buildPermissionsText(config.permissions);
+    if (permText) {
+      appendPermissionsToInstructions(allFiles, config, permText);
+    }
+  }
+
+  // Step 4: Compile MCP servers
+  const mcpResult = await compileMcpServers(config, targets, fs);
+  allFiles.push(...mcpResult.files);
+  allWarnings.push(...mcpResult.warnings);
+
+  // Step 5: Compile skills
+  const skillsResult = await compileSkills(config, targets, fs);
+  allFiles.push(...skillsResult.files);
+  allSkipped.push(...skillsResult.skippedPlugins);
+
+  // Step 6: Compile permissions (Claude Code settings.json)
+  const permsResult = await compilePermissions(config, targets, fs);
+  allFiles.push(...permsResult.files);
+  allWarnings.push(...permsResult.warnings);
+
+  // Write files (unless dry-run)
+  if (!options.dryRun) {
+    await writeFiles(allFiles, fs);
+  }
+
+  return {
+    harnessName,
+    targets,
+    files: allFiles,
+    warnings: allWarnings,
+    skippedPlugins: allSkipped,
+  };
+}
+
+function appendPermissionsToInstructions(
+  files: FileAction[],
+  config: HarnessConfig,
+  permText: string,
+): void {
+  const harnessName = config.metadata?.name ?? "default";
+
+  for (const file of files) {
+    if (
+      file.slot === "operational" &&
+      file.platform !== "claude-code"
+    ) {
+      // Append permissions text inside the marker block
+      const existingBlock = findMarkerBlock(file.content, harnessName, "operational");
+      if (existingBlock) {
+        const newContent = existingBlock.content + "\n\n" + permText;
+        file.content = replaceMarkerBlock(file.content, harnessName, "operational", newContent);
+      } else {
+        file.content = appendMarkerBlock(file.content, harnessName, "permissions", permText);
+      }
+    }
+  }
+}
+
+async function writeFiles(
+  files: FileAction[],
+  fs: FsProvider,
+): Promise<void> {
+  const cwd = fs.cwd();
+
+  for (const file of files) {
+    if (file.action === "skip" || file.action === "needs-confirmation") {
+      continue;
+    }
+
+    const fullPath = fs.joinPath(cwd, file.path);
+    const dir = fullPath.substring(0, fullPath.lastIndexOf("/"));
+
+    if (dir) {
+      await fs.mkdir(dir, { recursive: true });
+    }
+
+    await fs.writeFile(fullPath, file.content);
+  }
+}

--- a/packages/core/src/compile/instructions.ts
+++ b/packages/core/src/compile/instructions.ts
@@ -7,6 +7,7 @@ import type {
 } from "../types.js";
 import {
   appendMarkerBlock,
+  buildMarkerBlock,
   findMarkerBlock,
   replaceMarkerBlock,
 } from "./markers.js";
@@ -115,9 +116,10 @@ export async function compileInstructions(
       const frontmatter = buildFrontmatter(target, mapping.slot);
 
       if (importMode === "replace") {
+        const markerBlock = buildMarkerBlock(harnessName, mapping.slot, slotContent);
         const fullContent = frontmatter
-          ? `${frontmatter}\n\n${buildMarkerContent(harnessName, mapping.slot, slotContent)}`
-          : buildMarkerContent(harnessName, mapping.slot, slotContent);
+          ? `${frontmatter}\n\n${markerBlock}`
+          : markerBlock;
 
         files.push({
           path: filePath,
@@ -130,10 +132,13 @@ export async function compileInstructions(
         continue;
       }
 
-      // merge mode
-      const existingContent = (await fs.exists(fullPath))
-        ? await fs.readFile(fullPath)
-        : "";
+      // merge mode — read directly, default to empty on missing file
+      let existingContent = "";
+      try {
+        existingContent = await fs.readFile(fullPath);
+      } catch {
+        // File doesn't exist yet — start empty
+      }
 
       const existing = findMarkerBlock(existingContent, harnessName, mapping.slot);
       let newFileContent: string;
@@ -148,7 +153,7 @@ export async function compileInstructions(
         );
       } else if (existingContent.trim() === "") {
         // New file — include frontmatter if needed
-        const markerBlock = buildMarkerContent(harnessName, mapping.slot, slotContent);
+        const markerBlock = buildMarkerBlock(harnessName, mapping.slot, slotContent);
         newFileContent = frontmatter
           ? `${frontmatter}\n\n${markerBlock}\n`
           : `${markerBlock}\n`;
@@ -177,6 +182,13 @@ export async function compileInstructions(
   return { files, warnings };
 }
 
-function buildMarkerContent(name: string, slot: string, content: string): string {
-  return `<!-- BEGIN harness:${name}:${slot} -->\n${content}\n<!-- END harness:${name}:${slot} -->`;
+/** All instruction file paths across all platforms (for --clean scanning). */
+export function getAllInstructionFilePaths(): string[] {
+  const paths: string[] = [];
+  for (const mapping of SLOT_MAPPINGS) {
+    for (const filePath of Object.values(mapping.file)) {
+      if (filePath) paths.push(filePath);
+    }
+  }
+  return paths;
 }

--- a/packages/core/src/compile/instructions.ts
+++ b/packages/core/src/compile/instructions.ts
@@ -1,0 +1,182 @@
+import type { FsProvider } from "../fs-provider.js";
+import type {
+  FileAction,
+  HarnessConfig,
+  HarnessInstructions,
+  TargetPlatform,
+} from "../types.js";
+import {
+  appendMarkerBlock,
+  findMarkerBlock,
+  replaceMarkerBlock,
+} from "./markers.js";
+
+// ── Slot → file mapping ─────────────────────────────────────
+
+type InstructionSlot = "operational" | "behavioral" | "identity";
+
+interface SlotMapping {
+  slot: InstructionSlot;
+  file: Record<TargetPlatform, string | null>;
+}
+
+const SLOT_MAPPINGS: SlotMapping[] = [
+  {
+    slot: "operational",
+    file: {
+      "claude-code": "CLAUDE.md",
+      cursor: ".cursor/rules/harness.mdc",
+      copilot: ".github/copilot-instructions.md",
+    },
+  },
+  {
+    slot: "behavioral",
+    file: {
+      "claude-code": "AGENT.md",
+      cursor: ".cursor/rules/behavioral.mdc",
+      copilot: ".github/instructions/behavioral.instructions.md",
+    },
+  },
+  {
+    slot: "identity",
+    file: {
+      "claude-code": "SOUL.md",
+      cursor: null, // not supported
+      copilot: null, // not supported
+    },
+  },
+];
+
+// ── Platform-specific frontmatter ────────────────────────────
+
+const CURSOR_FRONTMATTER: Record<string, string> = {
+  operational: `---
+description: Harness operational instructions
+globs: "**/*"
+alwaysApply: true
+---`,
+  behavioral: `---
+description: Harness behavioral preferences
+globs: "**/*"
+alwaysApply: true
+---`,
+};
+
+const COPILOT_FRONTMATTER = `---
+applyTo: "**"
+---`;
+
+function buildFrontmatter(
+  platform: TargetPlatform,
+  slot: InstructionSlot,
+): string | null {
+  if (platform === "cursor" && slot in CURSOR_FRONTMATTER) {
+    return CURSOR_FRONTMATTER[slot];
+  }
+  if (platform === "copilot") {
+    return COPILOT_FRONTMATTER;
+  }
+  return null;
+}
+
+// ── Compile instructions ─────────────────────────────────────
+
+export async function compileInstructions(
+  config: HarnessConfig,
+  targets: TargetPlatform[],
+  fs: FsProvider,
+): Promise<{ files: FileAction[]; warnings: string[] }> {
+  const instructions = config.instructions;
+  if (!instructions) {
+    return { files: [], warnings: [] };
+  }
+
+  const importMode = instructions["import-mode"] ?? "merge";
+  const harnessName = config.metadata?.name ?? "default";
+  const cwd = fs.cwd();
+  const files: FileAction[] = [];
+  const warnings: string[] = [];
+
+  if (importMode === "skip") {
+    return { files, warnings };
+  }
+
+  for (const mapping of SLOT_MAPPINGS) {
+    const slotContent = instructions[mapping.slot];
+    if (slotContent === null || slotContent === undefined) {
+      continue;
+    }
+
+    for (const target of targets) {
+      const filePath = mapping.file[target];
+      if (!filePath) continue; // slot not supported on this platform
+
+      const fullPath = fs.joinPath(cwd, filePath);
+      const frontmatter = buildFrontmatter(target, mapping.slot);
+
+      if (importMode === "replace") {
+        const fullContent = frontmatter
+          ? `${frontmatter}\n\n${buildMarkerContent(harnessName, mapping.slot, slotContent)}`
+          : buildMarkerContent(harnessName, mapping.slot, slotContent);
+
+        files.push({
+          path: filePath,
+          content: fullContent + "\n",
+          action: "needs-confirmation",
+          platform: target,
+          slot: mapping.slot,
+          linesAdded: fullContent.split("\n").length,
+        });
+        continue;
+      }
+
+      // merge mode
+      const existingContent = (await fs.exists(fullPath))
+        ? await fs.readFile(fullPath)
+        : "";
+
+      const existing = findMarkerBlock(existingContent, harnessName, mapping.slot);
+      let newFileContent: string;
+
+      if (existing) {
+        // Update existing marker block
+        newFileContent = replaceMarkerBlock(
+          existingContent,
+          harnessName,
+          mapping.slot,
+          slotContent,
+        );
+      } else if (existingContent.trim() === "") {
+        // New file — include frontmatter if needed
+        const markerBlock = buildMarkerContent(harnessName, mapping.slot, slotContent);
+        newFileContent = frontmatter
+          ? `${frontmatter}\n\n${markerBlock}\n`
+          : `${markerBlock}\n`;
+      } else {
+        // Append to existing file
+        newFileContent = appendMarkerBlock(
+          existingContent,
+          harnessName,
+          mapping.slot,
+          slotContent,
+        );
+      }
+
+      const linesAdded = slotContent.split("\n").length;
+      files.push({
+        path: filePath,
+        content: newFileContent,
+        action: existing ? "update" : "create",
+        platform: target,
+        slot: mapping.slot,
+        linesAdded,
+      });
+    }
+  }
+
+  return { files, warnings };
+}
+
+function buildMarkerContent(name: string, slot: string, content: string): string {
+  return `<!-- BEGIN harness:${name}:${slot} -->\n${content}\n<!-- END harness:${name}:${slot} -->`;
+}

--- a/packages/core/src/compile/markers.ts
+++ b/packages/core/src/compile/markers.ts
@@ -1,0 +1,147 @@
+import type { OrphanedBlock } from "../types.js";
+
+const BEGIN_RE = /^<!-- BEGIN harness:([^:]+):([^ ]+) -->$/;
+const END_RE = /^<!-- END harness:([^:]+):([^ ]+) -->$/;
+
+export function buildMarkerBlock(
+  name: string,
+  slot: string,
+  content: string,
+): string {
+  const begin = `<!-- BEGIN harness:${name}:${slot} -->`;
+  const end = `<!-- END harness:${name}:${slot} -->`;
+  return `${begin}\n${content}\n${end}`;
+}
+
+export interface MarkerBlockLocation {
+  startLine: number;
+  endLine: number;
+  content: string;
+}
+
+export function findMarkerBlock(
+  fileContent: string,
+  name: string,
+  slot: string,
+): MarkerBlockLocation | null {
+  const lines = fileContent.split("\n");
+  const beginTag = `<!-- BEGIN harness:${name}:${slot} -->`;
+  const endTag = `<!-- END harness:${name}:${slot} -->`;
+
+  let startLine = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim() === beginTag) {
+      startLine = i;
+    } else if (lines[i].trim() === endTag && startLine >= 0) {
+      return {
+        startLine,
+        endLine: i,
+        content: lines.slice(startLine + 1, i).join("\n"),
+      };
+    }
+  }
+  return null;
+}
+
+export function replaceMarkerBlock(
+  fileContent: string,
+  name: string,
+  slot: string,
+  newContent: string,
+): string {
+  const location = findMarkerBlock(fileContent, name, slot);
+  if (!location) {
+    return fileContent;
+  }
+
+  const lines = fileContent.split("\n");
+  const before = lines.slice(0, location.startLine);
+  const after = lines.slice(location.endLine + 1);
+  const block = buildMarkerBlock(name, slot, newContent);
+  return [...before, block, ...after].join("\n");
+}
+
+export function appendMarkerBlock(
+  fileContent: string,
+  name: string,
+  slot: string,
+  content: string,
+): string {
+  const block = buildMarkerBlock(name, slot, content);
+  const trimmed = fileContent.trimEnd();
+  if (trimmed.length === 0) {
+    return block + "\n";
+  }
+  return trimmed + "\n\n" + block + "\n";
+}
+
+export function findOrphanedMarkerBlocks(
+  fileContent: string,
+  currentName: string,
+  filePath: string,
+): OrphanedBlock[] {
+  const lines = fileContent.split("\n");
+  const orphans: OrphanedBlock[] = [];
+
+  let inBlock = false;
+  let blockName = "";
+  let blockSlot = "";
+  let blockStart = -1;
+  const blockLines: string[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const beginMatch = lines[i].trim().match(BEGIN_RE);
+    if (beginMatch && !inBlock) {
+      inBlock = true;
+      blockName = beginMatch[1];
+      blockSlot = beginMatch[2];
+      blockStart = i;
+      blockLines.length = 0;
+      continue;
+    }
+
+    const endMatch = lines[i].trim().match(END_RE);
+    if (endMatch && inBlock && endMatch[1] === blockName && endMatch[2] === blockSlot) {
+      if (blockName !== currentName) {
+        orphans.push({
+          name: blockName,
+          slot: blockSlot,
+          file: filePath,
+          startLine: blockStart + 1, // 1-indexed
+          endLine: i + 1, // 1-indexed
+          content: blockLines.join("\n"),
+        });
+      }
+      inBlock = false;
+      continue;
+    }
+
+    if (inBlock) {
+      blockLines.push(lines[i]);
+    }
+  }
+
+  return orphans;
+}
+
+export function removeOrphanedBlocks(
+  fileContent: string,
+  orphans: OrphanedBlock[],
+): string {
+  const lines = fileContent.split("\n");
+  // Collect line ranges to remove (convert 1-indexed to 0-indexed)
+  const removeSet = new Set<number>();
+  for (const orphan of orphans) {
+    for (let i = orphan.startLine - 1; i <= orphan.endLine - 1; i++) {
+      removeSet.add(i);
+    }
+    // Also remove a blank line immediately after the block if present
+    const nextLine = orphan.endLine; // 0-indexed of line after endLine
+    if (nextLine < lines.length && lines[nextLine].trim() === "") {
+      removeSet.add(nextLine);
+    }
+  }
+
+  const result = lines.filter((_, i) => !removeSet.has(i));
+  return result.join("\n");
+}

--- a/packages/core/src/compile/markers.ts
+++ b/packages/core/src/compile/markers.ts
@@ -49,14 +49,25 @@ export function replaceMarkerBlock(
   slot: string,
   newContent: string,
 ): string {
-  const location = findMarkerBlock(fileContent, name, slot);
-  if (!location) {
-    return fileContent;
+  const beginTag = `<!-- BEGIN harness:${name}:${slot} -->`;
+  const endTag = `<!-- END harness:${name}:${slot} -->`;
+  const lines = fileContent.split("\n");
+
+  let startLine = -1;
+  let endLine = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim() === beginTag) {
+      startLine = i;
+    } else if (lines[i].trim() === endTag && startLine >= 0) {
+      endLine = i;
+      break;
+    }
   }
 
-  const lines = fileContent.split("\n");
-  const before = lines.slice(0, location.startLine);
-  const after = lines.slice(location.endLine + 1);
+  if (startLine < 0 || endLine < 0) return fileContent;
+
+  const before = lines.slice(0, startLine);
+  const after = lines.slice(endLine + 1);
   const block = buildMarkerBlock(name, slot, newContent);
   return [...before, block, ...after].join("\n");
 }

--- a/packages/core/src/compile/mcp-servers.ts
+++ b/packages/core/src/compile/mcp-servers.ts
@@ -5,6 +5,7 @@ import type {
   McpServer,
   TargetPlatform,
 } from "../types.js";
+import { readJsonOrDefault } from "../utils/read-json.js";
 
 const MCP_FILE_MAP: Record<TargetPlatform, string> = {
   "claude-code": ".mcp.json",
@@ -64,16 +65,9 @@ export async function compileMcpServers(
     const filePath = MCP_FILE_MAP[target];
     const fullPath = fs.joinPath(cwd, filePath);
 
-    // Read existing config
-    let existing: Record<string, Record<string, unknown>> = {};
-    if (await fs.exists(fullPath)) {
-      try {
-        const raw = await fs.readFile(fullPath);
-        existing = JSON.parse(raw);
-      } catch {
-        // Malformed JSON — start fresh
-      }
-    }
+    const { data: existing, existed } = await readJsonOrDefault<Record<string, Record<string, unknown>>>(
+      fs, fullPath, {},
+    );
 
     const existingServers =
       (existing.mcpServers as Record<string, unknown> | undefined) ?? {};
@@ -99,7 +93,7 @@ export async function compileMcpServers(
     files.push({
       path: filePath,
       content,
-      action: (await fs.exists(fullPath)) ? "update" : "create",
+      action: existed ? "update" : "create",
       platform: target,
       slot: "mcp-servers",
       linesAdded: serverCount,

--- a/packages/core/src/compile/mcp-servers.ts
+++ b/packages/core/src/compile/mcp-servers.ts
@@ -1,0 +1,110 @@
+import type { FsProvider } from "../fs-provider.js";
+import type {
+  FileAction,
+  HarnessConfig,
+  McpServer,
+  TargetPlatform,
+} from "../types.js";
+
+const MCP_FILE_MAP: Record<TargetPlatform, string> = {
+  "claude-code": ".mcp.json",
+  cursor: ".cursor/mcp.json",
+  copilot: ".vscode/mcp.json",
+};
+
+interface McpJsonEntry {
+  type: string;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string;
+  headers?: Record<string, string>;
+}
+
+function translateServer(server: McpServer): McpJsonEntry {
+  if (server.transport === "stdio") {
+    const entry: McpJsonEntry = {
+      type: "stdio",
+      command: server.command,
+    };
+    if (server.args) entry.args = server.args;
+    if (server.env) entry.env = server.env;
+    return entry;
+  }
+  // Network transports (http, sse, ws)
+  const entry: McpJsonEntry = {
+    type: server.transport,
+    url: server.url,
+  };
+  if (server.headers) entry.headers = server.headers;
+  return entry;
+}
+
+export async function compileMcpServers(
+  config: HarnessConfig,
+  targets: TargetPlatform[],
+  fs: FsProvider,
+): Promise<{ files: FileAction[]; warnings: string[] }> {
+  const mcpServers = config["mcp-servers"];
+  if (!mcpServers || Object.keys(mcpServers).length === 0) {
+    return { files: [], warnings: [] };
+  }
+
+  const cwd = fs.cwd();
+  const files: FileAction[] = [];
+  const warnings: string[] = [];
+
+  // Translate all servers
+  const translated: Record<string, McpJsonEntry> = {};
+  for (const [name, server] of Object.entries(mcpServers)) {
+    translated[name] = translateServer(server);
+  }
+
+  for (const target of targets) {
+    const filePath = MCP_FILE_MAP[target];
+    const fullPath = fs.joinPath(cwd, filePath);
+
+    // Read existing config
+    let existing: Record<string, Record<string, unknown>> = {};
+    if (await fs.exists(fullPath)) {
+      try {
+        const raw = await fs.readFile(fullPath);
+        existing = JSON.parse(raw);
+      } catch {
+        // Malformed JSON — start fresh
+      }
+    }
+
+    const existingServers =
+      (existing.mcpServers as Record<string, unknown> | undefined) ?? {};
+
+    // Merge: add new servers, keep existing ones
+    const merged = { ...existingServers };
+    let serverCount = 0;
+
+    for (const [name, entry] of Object.entries(translated)) {
+      if (name in existingServers) {
+        warnings.push(
+          `${filePath} already defines server '${name}'. Existing config kept.\n  To update it, edit ${filePath} directly or remove the entry and re-run.`,
+        );
+      } else {
+        merged[name] = entry;
+        serverCount++;
+      }
+    }
+
+    const output = { ...existing, mcpServers: merged };
+    const content = JSON.stringify(output, null, 2) + "\n";
+
+    files.push({
+      path: filePath,
+      content,
+      action: (await fs.exists(fullPath)) ? "update" : "create",
+      platform: target,
+      slot: "mcp-servers",
+      linesAdded: serverCount,
+    });
+  }
+
+  return { files, warnings };
+}

--- a/packages/core/src/compile/permissions.ts
+++ b/packages/core/src/compile/permissions.ts
@@ -1,0 +1,122 @@
+import type { FsProvider } from "../fs-provider.js";
+import type {
+  FileAction,
+  HarnessConfig,
+  HarnessPermissions,
+  TargetPlatform,
+} from "../types.js";
+
+export async function compilePermissions(
+  config: HarnessConfig,
+  targets: TargetPlatform[],
+  fs: FsProvider,
+): Promise<{ files: FileAction[]; warnings: string[] }> {
+  const perms = config.permissions;
+  if (!perms) {
+    return { files: [], warnings: [] };
+  }
+
+  const cwd = fs.cwd();
+  const files: FileAction[] = [];
+  const warnings: string[] = [];
+
+  for (const target of targets) {
+    if (target === "claude-code") {
+      const result = await compileClaudeCodePermissions(perms, fs, cwd);
+      files.push(result);
+    } else {
+      const text = buildPermissionsText(perms);
+      if (text) {
+        // Permissions text is appended to the operational instruction file
+        // via marker blocks — the instructions compiler handles the file.
+        // We just return a standalone FileAction for the report.
+        const denyList = perms.tools?.deny;
+        if (denyList && denyList.length > 0) {
+          warnings.push(
+            `permissions.tools.deny is not machine-enforceable for target '${target}'.\n  Denied tools: ${denyList.join(", ")}\n  Instructions have been updated to describe the intended permissions,\n  but manual tool configuration is required.`,
+          );
+        }
+      }
+    }
+  }
+
+  return { files, warnings };
+}
+
+async function compileClaudeCodePermissions(
+  perms: HarnessPermissions,
+  fs: FsProvider,
+  cwd: string,
+): Promise<FileAction> {
+  const settingsPath = fs.joinPath(cwd, ".claude/settings.json");
+
+  let existing: Record<string, unknown> = {};
+  if (await fs.exists(settingsPath)) {
+    try {
+      const raw = await fs.readFile(settingsPath);
+      existing = JSON.parse(raw);
+    } catch {
+      // Malformed JSON — start fresh
+    }
+  }
+
+  const permissionsObj: Record<string, unknown> = {};
+
+  if (perms.tools?.allow) {
+    permissionsObj.allow = perms.tools.allow;
+  }
+  if (perms.tools?.deny) {
+    permissionsObj.deny = perms.tools.deny;
+  }
+  if (perms.paths) {
+    const dirs = [
+      ...(perms.paths.writable ?? []),
+      ...(perms.paths.readonly ?? []),
+    ];
+    if (dirs.length > 0) {
+      permissionsObj.additionalDirectories = dirs;
+    }
+  }
+
+  const output = { ...existing, permissions: permissionsObj };
+  const content = JSON.stringify(output, null, 2) + "\n";
+
+  const allowCount = perms.tools?.allow?.length ?? 0;
+  const denyCount = perms.tools?.deny?.length ?? 0;
+
+  return {
+    path: ".claude/settings.json",
+    content,
+    action: (await fs.exists(settingsPath)) ? "update" : "create",
+    platform: "claude-code",
+    slot: "permissions",
+    linesAdded: allowCount + denyCount,
+  };
+}
+
+export function buildPermissionsText(perms: HarnessPermissions): string | null {
+  const lines: string[] = ["## Tool Permissions", ""];
+  lines.push("This harness specifies the following tool permissions:");
+
+  let hasContent = false;
+
+  if (perms.tools?.allow && perms.tools.allow.length > 0) {
+    lines.push(`- **Allowed**: ${perms.tools.allow.join(", ")}`);
+    hasContent = true;
+  }
+  if (perms.tools?.deny && perms.tools.deny.length > 0) {
+    lines.push(`- **Denied**: ${perms.tools.deny.join(", ")}`);
+    hasContent = true;
+  }
+  if (perms.tools?.ask && perms.tools.ask.length > 0) {
+    lines.push(`- **Ask before use**: ${perms.tools.ask.join(", ")}`);
+    hasContent = true;
+  }
+
+  if (!hasContent) return null;
+
+  lines.push("");
+  lines.push("Please configure your tool's permission settings to match these constraints.");
+
+  return lines.join("\n");
+}

--- a/packages/core/src/compile/permissions.ts
+++ b/packages/core/src/compile/permissions.ts
@@ -69,10 +69,9 @@ async function compileClaudeCodePermissions(
     permissionsObj.deny = perms.tools.deny;
   }
   if (perms.paths) {
-    const dirs = [
-      ...(perms.paths.writable ?? []),
-      ...(perms.paths.readonly ?? []),
-    ];
+    // Claude Code's additionalDirectories grants full read+write access.
+    // Only map writable paths; readonly paths would gain unintended write access.
+    const dirs = perms.paths.writable ?? [];
     if (dirs.length > 0) {
       permissionsObj.additionalDirectories = dirs;
     }

--- a/packages/core/src/compile/permissions.ts
+++ b/packages/core/src/compile/permissions.ts
@@ -5,6 +5,7 @@ import type {
   HarnessPermissions,
   TargetPlatform,
 } from "../types.js";
+import { readJsonOrDefault } from "../utils/read-json.js";
 
 export async function compilePermissions(
   config: HarnessConfig,
@@ -50,15 +51,9 @@ async function compileClaudeCodePermissions(
 ): Promise<FileAction> {
   const settingsPath = fs.joinPath(cwd, ".claude/settings.json");
 
-  let existing: Record<string, unknown> = {};
-  if (await fs.exists(settingsPath)) {
-    try {
-      const raw = await fs.readFile(settingsPath);
-      existing = JSON.parse(raw);
-    } catch {
-      // Malformed JSON — start fresh
-    }
-  }
+  const { data: existing, existed } = await readJsonOrDefault<Record<string, unknown>>(
+    fs, settingsPath, {},
+  );
 
   const permissionsObj: Record<string, unknown> = {};
 
@@ -86,7 +81,7 @@ async function compileClaudeCodePermissions(
   return {
     path: ".claude/settings.json",
     content,
-    action: (await fs.exists(settingsPath)) ? "update" : "create",
+    action: existed ? "update" : "create",
     platform: "claude-code",
     slot: "permissions",
     linesAdded: allowCount + denyCount,

--- a/packages/core/src/compile/skills.ts
+++ b/packages/core/src/compile/skills.ts
@@ -1,0 +1,131 @@
+import type { FsProvider } from "../fs-provider.js";
+import type {
+  FileAction,
+  HarnessConfig,
+  HarnessPlugin,
+  TargetPlatform,
+} from "../types.js";
+
+const SKILL_SEARCH_PATHS = [
+  "~/.claude/skills/{name}/SKILL.md",
+  ".cursor/skills/{name}/SKILL.md",
+  ".agents/skills/{name}/SKILL.md",
+];
+
+const SKILL_TARGET_DIR: Record<TargetPlatform, string | null> = {
+  "claude-code": null, // uses plugin install system
+  cursor: ".cursor/skills",
+  copilot: ".github/skills",
+};
+
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 64);
+}
+
+function adaptFrontmatter(content: string): string {
+  // Parse frontmatter if present
+  const fmMatch = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!fmMatch) return content;
+
+  let frontmatter = fmMatch[1];
+  const body = fmMatch[2];
+
+  // Rename dependencies → compatibility
+  frontmatter = frontmatter.replace(
+    /^dependencies:/m,
+    "compatibility:",
+  );
+
+  // Enforce name constraints
+  const nameMatch = frontmatter.match(/^name:\s*(.+)$/m);
+  if (nameMatch) {
+    const slugged = slugify(nameMatch[1].trim());
+    frontmatter = frontmatter.replace(
+      /^name:\s*.+$/m,
+      `name: ${slugged}`,
+    );
+  }
+
+  // Truncate description
+  const descMatch = frontmatter.match(/^description:\s*(.+)$/m);
+  if (descMatch && descMatch[1].length > 1024) {
+    const truncated = descMatch[1].slice(0, 1024).replace(/\s+\S*$/, "") + "…";
+    frontmatter = frontmatter.replace(
+      /^description:\s*.+$/m,
+      `description: ${truncated}`,
+    );
+  }
+
+  return `---\n${frontmatter}\n---\n${body}`;
+}
+
+export async function compileSkills(
+  config: HarnessConfig,
+  targets: TargetPlatform[],
+  fs: FsProvider,
+): Promise<{ files: FileAction[]; skippedPlugins: string[] }> {
+  const plugins = config.plugins;
+  if (!plugins || plugins.length === 0) {
+    return { files: [], skippedPlugins: [] };
+  }
+
+  const cwd = fs.cwd();
+  const home = await fs.homedir();
+  const files: FileAction[] = [];
+  const skippedPlugins: string[] = [];
+
+  for (const plugin of plugins) {
+    const skillContent = await findSkillMd(plugin, fs, cwd, home);
+    if (!skillContent) {
+      skippedPlugins.push(
+        `${plugin.name}: skipped (no SKILL.md found in ~/.claude/skills/, .cursor/skills/, or .agents/skills/)`,
+      );
+      continue;
+    }
+
+    const adapted = adaptFrontmatter(skillContent);
+
+    for (const target of targets) {
+      const targetDir = SKILL_TARGET_DIR[target];
+      if (!targetDir) continue; // claude-code skips file copy
+
+      const destPath = fs.joinPath(targetDir, plugin.name, "SKILL.md");
+      files.push({
+        path: destPath,
+        content: adapted,
+        action: "create",
+        platform: target,
+        slot: "skills",
+      });
+    }
+  }
+
+  return { files, skippedPlugins };
+}
+
+async function findSkillMd(
+  plugin: HarnessPlugin,
+  fs: FsProvider,
+  cwd: string,
+  home: string,
+): Promise<string | null> {
+  for (const template of SKILL_SEARCH_PATHS) {
+    const relPath = template
+      .replace("{name}", plugin.name)
+      .replace("~", home);
+
+    const fullPath = relPath.startsWith("/")
+      ? relPath
+      : fs.joinPath(cwd, relPath);
+
+    if (await fs.exists(fullPath)) {
+      return fs.readFile(fullPath);
+    }
+  }
+  return null;
+}

--- a/packages/core/src/detect/detect-platforms.ts
+++ b/packages/core/src/detect/detect-platforms.ts
@@ -37,33 +37,27 @@ export async function detectPlatforms(
   const results: DetectedPlatform[] = [];
 
   for (const indicator of INDICATORS) {
-    const foundIndicators: string[] = [];
-    const foundAmbiguous: string[] = [];
+    const allPaths = [...indicator.paths, ...indicator.ambiguousPaths];
+    const ambiguousSet = new Set(indicator.ambiguousPaths);
 
-    for (const p of indicator.paths) {
-      const fullPath = fs.joinPath(cwd, p);
-      if (await fs.exists(fullPath)) {
-        foundIndicators.push(p);
-      }
-    }
+    // Check all paths for this platform in parallel
+    const checks = await Promise.all(
+      allPaths.map(async (p) => ({
+        path: p,
+        exists: await fs.exists(fs.joinPath(cwd, p)),
+        ambiguous: ambiguousSet.has(p),
+      })),
+    );
 
-    for (const p of indicator.ambiguousPaths) {
-      const fullPath = fs.joinPath(cwd, p);
-      if (await fs.exists(fullPath)) {
-        foundAmbiguous.push(p);
-      }
-    }
-
+    const foundIndicators = checks.filter((c) => c.exists && !c.ambiguous).map((c) => c.path);
+    const foundAmbiguous = checks.filter((c) => c.exists && c.ambiguous).map((c) => c.path);
     const allFound = [...foundIndicators, ...foundAmbiguous];
-    if (allFound.length > 0) {
-      // Only ambiguous paths found → needs confirmation
-      const needsConfirmation =
-        foundIndicators.length === 0 && foundAmbiguous.length > 0;
 
+    if (allFound.length > 0) {
       results.push({
         platform: indicator.platform,
         indicators: allFound,
-        needsConfirmation,
+        needsConfirmation: foundIndicators.length === 0 && foundAmbiguous.length > 0,
       });
     }
   }

--- a/packages/core/src/detect/detect-platforms.ts
+++ b/packages/core/src/detect/detect-platforms.ts
@@ -1,0 +1,72 @@
+import type { FsProvider } from "../fs-provider.js";
+import type { DetectedPlatform, TargetPlatform } from "../types.js";
+
+interface PlatformIndicator {
+  platform: TargetPlatform;
+  paths: string[];
+  /** If this is the only indicator found, flag for user confirmation */
+  ambiguousPaths: string[];
+}
+
+const INDICATORS: PlatformIndicator[] = [
+  {
+    platform: "claude-code",
+    paths: ["CLAUDE.md", ".claude", ".mcp.json"],
+    ambiguousPaths: [],
+  },
+  {
+    platform: "cursor",
+    paths: [".cursor", ".cursor/rules", ".cursor/mcp.json", ".cursor/skills"],
+    ambiguousPaths: [],
+  },
+  {
+    platform: "copilot",
+    paths: [
+      ".github/copilot-instructions.md",
+      ".vscode/mcp.json",
+      ".github/skills",
+    ],
+    ambiguousPaths: [".github"],
+  },
+];
+
+export async function detectPlatforms(
+  fs: FsProvider,
+): Promise<DetectedPlatform[]> {
+  const cwd = fs.cwd();
+  const results: DetectedPlatform[] = [];
+
+  for (const indicator of INDICATORS) {
+    const foundIndicators: string[] = [];
+    const foundAmbiguous: string[] = [];
+
+    for (const p of indicator.paths) {
+      const fullPath = fs.joinPath(cwd, p);
+      if (await fs.exists(fullPath)) {
+        foundIndicators.push(p);
+      }
+    }
+
+    for (const p of indicator.ambiguousPaths) {
+      const fullPath = fs.joinPath(cwd, p);
+      if (await fs.exists(fullPath)) {
+        foundAmbiguous.push(p);
+      }
+    }
+
+    const allFound = [...foundIndicators, ...foundAmbiguous];
+    if (allFound.length > 0) {
+      // Only ambiguous paths found → needs confirmation
+      const needsConfirmation =
+        foundIndicators.length === 0 && foundAmbiguous.length > 0;
+
+      results.push({
+        platform: indicator.platform,
+        indicators: allFound,
+        needsConfirmation,
+      });
+    }
+  }
+
+  return results;
+}

--- a/packages/core/src/fs-node.ts
+++ b/packages/core/src/fs-node.ts
@@ -1,5 +1,5 @@
 import { readFile, writeFile, access, mkdir, readdir } from "node:fs/promises";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 import type { FsProvider } from "./fs-provider.js";
 
@@ -37,6 +37,10 @@ export class NodeFsProvider implements FsProvider {
 
   joinPath(...segments: string[]): string {
     return join(...segments);
+  }
+
+  dirname(path: string): string {
+    return dirname(path);
   }
 
   async homedir(): Promise<string> {

--- a/packages/core/src/fs-node.ts
+++ b/packages/core/src/fs-node.ts
@@ -1,0 +1,49 @@
+import { readFile, writeFile, access, mkdir, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import type { FsProvider } from "./fs-provider.js";
+
+export class NodeFsProvider implements FsProvider {
+  private _cwd: string;
+
+  constructor(cwd?: string) {
+    this._cwd = cwd ?? process.cwd();
+  }
+
+  async readFile(path: string): Promise<string> {
+    return readFile(path, "utf-8");
+  }
+
+  async writeFile(path: string, content: string): Promise<void> {
+    await writeFile(path, content, "utf-8");
+  }
+
+  async exists(path: string): Promise<boolean> {
+    try {
+      await access(path);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async mkdir(path: string, options?: { recursive?: boolean }): Promise<void> {
+    await mkdir(path, options);
+  }
+
+  async readDir(path: string): Promise<string[]> {
+    return readdir(path);
+  }
+
+  joinPath(...segments: string[]): string {
+    return join(...segments);
+  }
+
+  async homedir(): Promise<string> {
+    return homedir();
+  }
+
+  cwd(): string {
+    return this._cwd;
+  }
+}

--- a/packages/core/src/fs-provider.ts
+++ b/packages/core/src/fs-provider.ts
@@ -1,0 +1,10 @@
+export interface FsProvider {
+  readFile(path: string): Promise<string>;
+  writeFile(path: string, content: string): Promise<void>;
+  exists(path: string): Promise<boolean>;
+  mkdir(path: string, options?: { recursive?: boolean }): Promise<void>;
+  readDir(path: string): Promise<string[]>;
+  joinPath(...segments: string[]): string;
+  homedir(): Promise<string>;
+  cwd(): string;
+}

--- a/packages/core/src/fs-provider.ts
+++ b/packages/core/src/fs-provider.ts
@@ -5,6 +5,7 @@ export interface FsProvider {
   mkdir(path: string, options?: { recursive?: boolean }): Promise<void>;
   readDir(path: string): Promise<string[]>;
   joinPath(...segments: string[]): string;
+  dirname(path: string): string;
   homedir(): Promise<string>;
   cwd(): string;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,7 +36,7 @@ export { detectPlatforms } from "./detect/detect-platforms.js";
 
 // Compile
 export { compile } from "./compile/compile.js";
-export { compileInstructions } from "./compile/instructions.js";
+export { compileInstructions, getAllInstructionFilePaths } from "./compile/instructions.js";
 export { compileMcpServers } from "./compile/mcp-servers.js";
 export { compileSkills } from "./compile/skills.js";
 export { compilePermissions, buildPermissionsText } from "./compile/permissions.js";
@@ -53,3 +53,7 @@ export {
 
 // Report
 export { buildReport } from "./report/report.js";
+
+// Utilities
+export { posixJoin, posixDirname } from "./utils/posix-path.js";
+export { isLegacyFormat } from "./utils/legacy.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,55 @@
+// Types
+export type {
+  CompileOptions,
+  CompileReport,
+  CompileReportEntry,
+  CompileResult,
+  DetectedPlatform,
+  EnvDeclaration,
+  FileAction,
+  FileActionType,
+  HarnessConfig,
+  HarnessInstructions,
+  HarnessMetadata,
+  HarnessPermissions,
+  HarnessPlugin,
+  McpServer,
+  McpServerNetwork,
+  McpServerStdio,
+  OrphanedBlock,
+  TargetPlatform,
+  ValidationError,
+  ValidationResult,
+} from "./types.js";
+
+export type { FsProvider } from "./fs-provider.js";
+export type { ParseResult } from "./parser/parse-harness.js";
+
+// Parser
+export { parseHarness } from "./parser/parse-harness.js";
+
+// Validation
+export { validateHarness, validateHarnessYaml } from "./schema/validate.js";
+
+// Platform detection
+export { detectPlatforms } from "./detect/detect-platforms.js";
+
+// Compile
+export { compile } from "./compile/compile.js";
+export { compileInstructions } from "./compile/instructions.js";
+export { compileMcpServers } from "./compile/mcp-servers.js";
+export { compileSkills } from "./compile/skills.js";
+export { compilePermissions, buildPermissionsText } from "./compile/permissions.js";
+
+// Markers
+export {
+  buildMarkerBlock,
+  findMarkerBlock,
+  replaceMarkerBlock,
+  appendMarkerBlock,
+  findOrphanedMarkerBlocks,
+  removeOrphanedBlocks,
+} from "./compile/markers.js";
+
+// Report
+export { buildReport } from "./report/report.js";

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -1,0 +1,1 @@
+export { NodeFsProvider } from "./fs-node.js";

--- a/packages/core/src/parser/parse-harness.ts
+++ b/packages/core/src/parser/parse-harness.ts
@@ -1,5 +1,6 @@
 import { parse } from "yaml";
 import type { HarnessConfig } from "../types.js";
+import { isLegacyFormat } from "../utils/legacy.js";
 
 export interface ParseResult {
   config: HarnessConfig;
@@ -25,12 +26,8 @@ export function parseHarness(yamlString: string): ParseResult {
 
   const doc = raw as Record<string, unknown>;
 
-  // Detect legacy format: version is integer 1 instead of string "1"
-  const isLegacyFormat =
-    "version" in doc && typeof doc.version === "number" && doc.version === 1;
-
   return {
     config: doc as unknown as HarnessConfig,
-    isLegacyFormat,
+    isLegacyFormat: isLegacyFormat(doc),
   };
 }

--- a/packages/core/src/parser/parse-harness.ts
+++ b/packages/core/src/parser/parse-harness.ts
@@ -1,0 +1,36 @@
+import { parse } from "yaml";
+import type { HarnessConfig } from "../types.js";
+
+export interface ParseResult {
+  config: HarnessConfig;
+  isLegacyFormat: boolean;
+}
+
+export function parseHarness(yamlString: string): ParseResult {
+  let raw: unknown;
+  try {
+    raw = parse(yamlString);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(
+      `YAML syntax error: ${msg}\n\nCommon causes: wrong indentation, missing quotes around special characters (like ':' in strings), or tabs used instead of spaces.`,
+    );
+  }
+
+  if (raw === null || raw === undefined || typeof raw !== "object") {
+    throw new Error(
+      "harness.yaml is empty or does not contain a YAML mapping.",
+    );
+  }
+
+  const doc = raw as Record<string, unknown>;
+
+  // Detect legacy format: version is integer 1 instead of string "1"
+  const isLegacyFormat =
+    "version" in doc && typeof doc.version === "number" && doc.version === 1;
+
+  return {
+    config: doc as unknown as HarnessConfig,
+    isLegacyFormat,
+  };
+}

--- a/packages/core/src/report/report.ts
+++ b/packages/core/src/report/report.ts
@@ -1,0 +1,79 @@
+import type {
+  CompileReport,
+  CompileReportEntry,
+  CompileResult,
+  TargetPlatform,
+} from "../types.js";
+
+const PLATFORM_ORDER: TargetPlatform[] = ["claude-code", "cursor", "copilot"];
+
+const SLOT_ORDER = [
+  "operational",
+  "behavioral",
+  "identity",
+  "mcp-servers",
+  "permissions",
+  "skills",
+];
+
+export function buildReport(result: CompileResult): CompileReport {
+  const entries: CompileReportEntry[] = [];
+
+  // Sort files by platform order, then slot order
+  const sorted = [...result.files].sort((a, b) => {
+    const platDiff =
+      PLATFORM_ORDER.indexOf(a.platform) -
+      PLATFORM_ORDER.indexOf(b.platform);
+    if (platDiff !== 0) return platDiff;
+    return SLOT_ORDER.indexOf(a.slot) - SLOT_ORDER.indexOf(b.slot);
+  });
+
+  for (const file of sorted) {
+    if (file.action === "skip") continue;
+
+    let detail: string;
+    if (file.slot === "mcp-servers") {
+      const serverCount = file.linesAdded ?? 0;
+      detail = `${serverCount} server${serverCount !== 1 ? "s" : ""}`;
+    } else if (file.slot === "permissions") {
+      detail = formatPermissionDetail(file.content);
+    } else if (file.slot === "skills") {
+      detail = "copied";
+    } else {
+      const lines = file.linesAdded ?? file.content.split("\n").length;
+      detail = `${lines} lines added`;
+    }
+
+    entries.push({
+      file: file.path,
+      slot: file.slot,
+      action: file.slot === "mcp-servers" || file.slot === "permissions" ? "——" : file.action,
+      detail,
+      platform: file.platform,
+    });
+  }
+
+  return {
+    harnessName: result.harnessName,
+    targets: result.targets,
+    entries,
+    warnings: result.warnings,
+    skippedPlugins: result.skippedPlugins,
+  };
+}
+
+function formatPermissionDetail(content: string): string {
+  try {
+    const parsed = JSON.parse(content);
+    const perms = parsed.permissions;
+    if (!perms) return "updated";
+    const allow = perms.allow?.length ?? 0;
+    const deny = perms.deny?.length ?? 0;
+    const parts: string[] = [];
+    if (allow > 0) parts.push(`${allow} allowed`);
+    if (deny > 0) parts.push(`${deny} denied`);
+    return parts.join(", ") || "updated";
+  } catch {
+    return "updated";
+  }
+}

--- a/packages/core/src/schema/harness.schema.json
+++ b/packages/core/src/schema/harness.schema.json
@@ -1,0 +1,219 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnessprotocol.ai/schema/v1/harness.schema.json",
+  "title": "Harness Protocol v1",
+  "description": "Schema for harness.yaml profiles following the Harness Protocol v1 specification. Validates both full profiles and partial fragments.",
+  "type": "object",
+  "required": ["version"],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "JSON Schema URI for editor tooling."
+    },
+    "version": {
+      "type": "string",
+      "const": "1",
+      "description": "Harness Protocol format version. Must be the string '1'."
+    },
+    "kind": {
+      "type": "string",
+      "enum": ["profile", "fragment"],
+      "default": "profile",
+      "description": "Document type. 'profile' is a complete harness configuration. 'fragment' is a partial piece for composition."
+    },
+    "metadata": {
+      "type": "object",
+      "required": ["name", "description"],
+      "description": "Profile identity and discovery metadata.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?$",
+          "description": "Lowercase kebab-case profile identifier. Max 64 characters."
+        },
+        "description": {
+          "type": "string",
+          "maxLength": 256,
+          "description": "Human-readable description. Max 256 characters."
+        },
+        "author": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "url": { "type": "string", "format": "uri" }
+          },
+          "additionalProperties": false
+        },
+        "version": {
+          "type": "string",
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+          "description": "Semantic version of this profile."
+        },
+        "license": { "type": "string" },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string", "maxLength": 32 },
+          "maxItems": 10,
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "plugins": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "source"],
+        "properties": {
+          "name": { "type": "string" },
+          "source": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$"
+          },
+          "version": { "type": "string" },
+          "description": { "type": "string" },
+          "config": { "type": "object", "additionalProperties": true },
+          "integrity": {
+            "type": "object",
+            "properties": {
+              "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "mcp-servers": {
+      "type": "object",
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "title": "stdio transport",
+            "type": "object",
+            "required": ["transport", "command"],
+            "properties": {
+              "transport": { "type": "string", "const": "stdio" },
+              "command": { "type": "string" },
+              "args": { "type": "array", "items": { "type": "string" } },
+              "env": { "type": "object", "additionalProperties": { "type": "string" } }
+            },
+            "additionalProperties": false
+          },
+          {
+            "title": "HTTP/SSE/WebSocket transport",
+            "type": "object",
+            "required": ["transport", "url"],
+            "properties": {
+              "transport": { "type": "string", "enum": ["http", "sse", "ws"] },
+              "url": { "type": "string", "format": "uri" },
+              "headers": { "type": "object", "additionalProperties": { "type": "string" } }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "env": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "description"],
+        "properties": {
+          "name": { "type": "string", "pattern": "^[A-Z_][A-Z0-9_]*$" },
+          "description": { "type": "string" },
+          "required": { "type": "boolean", "default": false },
+          "sensitive": { "type": "boolean", "default": true },
+          "when": { "type": "string" },
+          "default": { "type": "string" }
+        },
+        "if": {
+          "required": ["sensitive"],
+          "properties": { "sensitive": { "const": false } }
+        },
+        "then": {},
+        "else": {
+          "properties": { "default": false }
+        },
+        "additionalProperties": false
+      }
+    },
+    "instructions": {
+      "type": "object",
+      "properties": {
+        "operational": {
+          "oneOf": [{ "type": "string" }, { "type": "null" }]
+        },
+        "behavioral": {
+          "oneOf": [{ "type": "string" }, { "type": "null" }]
+        },
+        "identity": {
+          "oneOf": [{ "type": "string" }, { "type": "null" }]
+        },
+        "import-mode": {
+          "type": "string",
+          "enum": ["merge", "replace", "skip"],
+          "default": "merge"
+        }
+      },
+      "additionalProperties": false
+    },
+    "permissions": {
+      "type": "object",
+      "properties": {
+        "tools": {
+          "type": "object",
+          "properties": {
+            "allow": { "type": "array", "items": { "type": "string" } },
+            "deny": { "type": "array", "items": { "type": "string" } },
+            "ask": { "type": "array", "items": { "type": "string" } }
+          },
+          "additionalProperties": false
+        },
+        "paths": {
+          "type": "object",
+          "properties": {
+            "writable": { "type": "array", "items": { "type": "string" } },
+            "readonly": { "type": "array", "items": { "type": "string" } }
+          },
+          "additionalProperties": false
+        },
+        "network": {
+          "type": "object",
+          "properties": {
+            "allowed-hosts": { "type": "array", "items": { "type": "string" } }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "extends": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["source"],
+        "properties": {
+          "source": { "type": "string" },
+          "version": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "if": {
+    "not": {
+      "required": ["kind"],
+      "properties": { "kind": { "const": "fragment" } }
+    }
+  },
+  "then": {
+    "required": ["version", "metadata"]
+  },
+  "patternProperties": {
+    "^x-": {
+      "description": "Implementation-specific extension field."
+    }
+  },
+  "additionalProperties": false
+}

--- a/packages/core/src/schema/validate.ts
+++ b/packages/core/src/schema/validate.ts
@@ -1,0 +1,91 @@
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+import { parse as parseYaml } from "yaml";
+import harnessSchema from "./harness.schema.json" with { type: "json" };
+import type { ValidationError, ValidationResult } from "../types.js";
+
+const ajv = new Ajv2020({ allErrors: true, verbose: true });
+addFormats(ajv);
+
+const validate = ajv.compile(harnessSchema);
+
+const COMMON_FIXES: Record<string, string> = {
+  "/version": 'Change version: 1 to version: "1" (add quotes).',
+  "/metadata/name":
+    "Add a metadata.name field (lowercase kebab-case, max 64 characters).",
+  "/metadata/description": "Add a metadata.description field (max 256 characters).",
+  "/metadata": "Add a metadata section with name and description fields.",
+};
+
+function getFix(schemaPath: string, keyword: string, params: Record<string, unknown>): string | undefined {
+  if (keyword === "additionalProperties" && typeof params.additionalProperty === "string") {
+    const prop = params.additionalProperty;
+    if (prop === "marketplace" || prop === "marketplaces") {
+      return 'Use source: owner/repo instead of marketplace: key.';
+    }
+    return `Remove unknown property '${prop}', or check for typos.`;
+  }
+  if (keyword === "const" && schemaPath.includes("version")) {
+    return 'version must be the string "1". Change version: 1 to version: "1".';
+  }
+  if (keyword === "required") {
+    const missing = params.missingProperty as string;
+    const key = schemaPath.replace(/\/properties/g, "") + "/" + missing;
+    return COMMON_FIXES[key];
+  }
+  if (keyword === "pattern") {
+    if (schemaPath.includes("source")) {
+      return "source must be in owner/repo format. Example: siracusa5/harness-kit";
+    }
+    if (schemaPath.includes("metadata/properties/name")) {
+      return "metadata.name must be lowercase kebab-case (a-z, 0-9, hyphens), max 64 characters.";
+    }
+  }
+  return undefined;
+}
+
+function formatPath(instancePath: string): string {
+  if (!instancePath) return "(root)";
+  return instancePath
+    .replace(/^\//, "")
+    .replace(/\//g, " → ");
+}
+
+export function validateHarness(config: unknown): ValidationResult {
+  const doc = config as Record<string, unknown>;
+  const isLegacyFormat =
+    "version" in doc && typeof doc.version === "number" && doc.version === 1;
+
+  const valid = validate(config);
+
+  if (valid) {
+    return { valid: true, errors: [], isLegacyFormat };
+  }
+
+  const errors: ValidationError[] = (validate.errors ?? []).map((err) => ({
+    path: formatPath(err.instancePath),
+    message: err.message ?? "Unknown validation error",
+    fix: getFix(
+      err.schemaPath,
+      err.keyword,
+      (err.params as Record<string, unknown>) ?? {},
+    ),
+  }));
+
+  return { valid: false, errors, isLegacyFormat };
+}
+
+export function validateHarnessYaml(yamlString: string): ValidationResult {
+  let doc: unknown;
+  try {
+    doc = parseYaml(yamlString);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      valid: false,
+      errors: [{ path: "(root)", message: `YAML parse error: ${msg}` }],
+      isLegacyFormat: false,
+    };
+  }
+  return validateHarness(doc);
+}

--- a/packages/core/src/schema/validate.ts
+++ b/packages/core/src/schema/validate.ts
@@ -3,6 +3,7 @@ import addFormats from "ajv-formats";
 import { parse as parseYaml } from "yaml";
 import harnessSchema from "./harness.schema.json" with { type: "json" };
 import type { ValidationError, ValidationResult } from "../types.js";
+import { isLegacyFormat } from "../utils/legacy.js";
 
 const ajv = new Ajv2020({ allErrors: true, verbose: true });
 addFormats(ajv);
@@ -53,13 +54,12 @@ function formatPath(instancePath: string): string {
 
 export function validateHarness(config: unknown): ValidationResult {
   const doc = config as Record<string, unknown>;
-  const isLegacyFormat =
-    "version" in doc && typeof doc.version === "number" && doc.version === 1;
+  const legacy = isLegacyFormat(doc);
 
   const valid = validate(config);
 
   if (valid) {
-    return { valid: true, errors: [], isLegacyFormat };
+    return { valid: true, errors: [], isLegacyFormat: legacy };
   }
 
   const errors: ValidationError[] = (validate.errors ?? []).map((err) => ({
@@ -72,7 +72,7 @@ export function validateHarness(config: unknown): ValidationResult {
     ),
   }));
 
-  return { valid: false, errors, isLegacyFormat };
+  return { valid: false, errors, isLegacyFormat: legacy };
 }
 
 export function validateHarnessYaml(yamlString: string): ValidationResult {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,0 +1,165 @@
+// ── Target platforms ─────────────────────────────────────────
+
+export type TargetPlatform = "claude-code" | "cursor" | "copilot";
+
+// ── Harness config (parsed harness.yaml) ─────────────────────
+
+export interface HarnessMetadata {
+  name: string;
+  description: string;
+  author?: { name: string; url?: string };
+  version?: string;
+  license?: string;
+  tags?: string[];
+}
+
+export interface HarnessPlugin {
+  name: string;
+  source: string;
+  version?: string;
+  description?: string;
+  config?: Record<string, unknown>;
+  integrity?: { sha256: string };
+}
+
+export interface McpServerStdio {
+  transport: "stdio";
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+export interface McpServerNetwork {
+  transport: "http" | "sse" | "ws";
+  url: string;
+  headers?: Record<string, string>;
+}
+
+export type McpServer = McpServerStdio | McpServerNetwork;
+
+export interface EnvDeclaration {
+  name: string;
+  description: string;
+  required?: boolean;
+  sensitive?: boolean;
+  when?: string;
+  default?: string;
+}
+
+export interface HarnessInstructions {
+  operational?: string | null;
+  behavioral?: string | null;
+  identity?: string | null;
+  "import-mode"?: "merge" | "replace" | "skip";
+}
+
+export interface HarnessPermissions {
+  tools?: {
+    allow?: string[];
+    deny?: string[];
+    ask?: string[];
+  };
+  paths?: {
+    writable?: string[];
+    readonly?: string[];
+  };
+  network?: {
+    "allowed-hosts"?: string[];
+  };
+}
+
+export interface HarnessConfig {
+  $schema?: string;
+  version: string;
+  kind?: "profile" | "fragment";
+  metadata?: HarnessMetadata;
+  plugins?: HarnessPlugin[];
+  "mcp-servers"?: Record<string, McpServer>;
+  env?: EnvDeclaration[];
+  instructions?: HarnessInstructions;
+  permissions?: HarnessPermissions;
+  extends?: Array<{ source: string; version?: string }>;
+}
+
+// ── Compile types ────────────────────────────────────────────
+
+export interface CompileOptions {
+  target?: TargetPlatform[];
+  dryRun?: boolean;
+  clean?: boolean;
+  verbose?: boolean;
+}
+
+export type FileActionType =
+  | "create"
+  | "update"
+  | "skip"
+  | "needs-confirmation";
+
+export interface FileAction {
+  path: string;
+  content: string;
+  action: FileActionType;
+  platform: TargetPlatform;
+  slot: string;
+  linesAdded?: number;
+}
+
+export interface CompileResult {
+  harnessName: string;
+  targets: TargetPlatform[];
+  files: FileAction[];
+  warnings: string[];
+  skippedPlugins: string[];
+}
+
+// ── Validation types ─────────────────────────────────────────
+
+export interface ValidationError {
+  path: string;
+  message: string;
+  fix?: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: ValidationError[];
+  isLegacyFormat: boolean;
+}
+
+// ── Orphaned block (for --clean) ─────────────────────────────
+
+export interface OrphanedBlock {
+  name: string;
+  slot: string;
+  file: string;
+  startLine: number;
+  endLine: number;
+  content: string;
+}
+
+// ── Platform detection ───────────────────────────────────────
+
+export interface DetectedPlatform {
+  platform: TargetPlatform;
+  indicators: string[];
+  needsConfirmation: boolean;
+}
+
+// ── Compile report ───────────────────────────────────────────
+
+export interface CompileReportEntry {
+  file: string;
+  slot: string;
+  action: string;
+  detail: string;
+  platform: TargetPlatform;
+}
+
+export interface CompileReport {
+  harnessName: string;
+  targets: TargetPlatform[];
+  entries: CompileReportEntry[];
+  warnings: string[];
+  skippedPlugins: string[];
+}

--- a/packages/core/src/utils/legacy.ts
+++ b/packages/core/src/utils/legacy.ts
@@ -1,0 +1,4 @@
+/** Detect whether a parsed harness config uses the legacy format (version: 1 integer). */
+export function isLegacyFormat(doc: Record<string, unknown>): boolean {
+  return "version" in doc && typeof doc.version === "number" && doc.version === 1;
+}

--- a/packages/core/src/utils/posix-path.ts
+++ b/packages/core/src/utils/posix-path.ts
@@ -1,0 +1,13 @@
+/** POSIX path utilities for non-Node environments (browser, Tauri). */
+
+export function posixJoin(...segments: string[]): string {
+  return segments
+    .join("/")
+    .replace(/\/+/g, "/")
+    .replace(/\/$/, "");
+}
+
+export function posixDirname(path: string): string {
+  const lastSlash = path.lastIndexOf("/");
+  return lastSlash > 0 ? path.substring(0, lastSlash) : "/";
+}

--- a/packages/core/src/utils/read-json.ts
+++ b/packages/core/src/utils/read-json.ts
@@ -1,0 +1,15 @@
+import type { FsProvider } from "../fs-provider.js";
+
+/** Read a JSON file, returning a default value on missing file or parse error. */
+export async function readJsonOrDefault<T>(
+  fs: FsProvider,
+  path: string,
+  defaultValue: T,
+): Promise<{ data: T; existed: boolean }> {
+  try {
+    const raw = await fs.readFile(path);
+    return { data: JSON.parse(raw) as T, existed: true };
+  } catch {
+    return { data: defaultValue, existed: false };
+  }
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "__tests__"]
+}

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts", "src/node.ts"],
+  format: ["esm"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+});

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["__tests__/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,8 +8,33 @@ importers:
 
   .: {}
 
+  apps/cli:
+    dependencies:
+      '@harness-kit/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@inquirer/prompts':
+        specifier: ^7
+        version: 7.10.1(@types/node@22.19.15)
+      chalk:
+        specifier: ^5
+        version: 5.6.2
+      commander:
+        specifier: ^13
+        version: 13.1.0
+    devDependencies:
+      tsup:
+        specifier: ^8
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+
   apps/desktop:
     dependencies:
+      '@harness-kit/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@harness-kit/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -46,7 +71,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.0.0
-        version: 4.2.1(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1))
+        version: 4.2.1(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
       '@tauri-apps/cli':
         specifier: ^2
         version: 2.10.1
@@ -70,10 +95,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1))
+        version: 4.7.0(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
       '@vitest/coverage-v8':
         specifier: ^4.1.0
-        version: 4.1.0(vitest@4.1.0(@types/node@22.19.15)(jsdom@28.1.0)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)))
+        version: 4.1.0(vitest@4.1.0(@types/node@22.19.15)(jsdom@28.1.0)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.27(postcss@8.5.8)
@@ -88,10 +113,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.0.3
-        version: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)
+        version: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@22.19.15)(jsdom@28.1.0)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1))
+        version: 4.1.0(@types/node@22.19.15)(jsdom@28.1.0)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
 
   marketplace:
     dependencies:
@@ -133,6 +158,31 @@ importers:
         specifier: ^5.0.0
         version: 5.9.3
 
+  packages/core:
+    dependencies:
+      ajv:
+        specifier: ^8
+        version: 8.18.0
+      ajv-formats:
+        specifier: ^3
+        version: 3.0.1(ajv@8.18.0)
+      yaml:
+        specifier: ^2
+        version: 2.8.2
+    devDependencies:
+      '@types/node':
+        specifier: ^22.19.15
+        version: 22.19.15
+      tsup:
+        specifier: ^8
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+      vitest:
+        specifier: ^3
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(yaml@2.8.2)
+
   packages/shared:
     devDependencies:
       typescript:
@@ -159,7 +209,7 @@ importers:
         version: 15.8.5(@types/react@19.2.14)(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       fumadocs-mdx:
         specifier: ^11.0.0
-        version: 11.10.1(fumadocs-core@15.8.5(@types/react@19.2.14)(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1))
+        version: 11.10.1(fumadocs-core@15.8.5(@types/react@19.2.14)(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
       fumadocs-ui:
         specifier: ^15.0.0
         version: 15.8.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1)
@@ -364,8 +414,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.4':
+    resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.4':
+    resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -376,8 +438,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.4':
+    resolution: {integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.4':
+    resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -388,8 +462,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.27.4':
+    resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.25.12':
     resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.4':
+    resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -400,8 +486,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.27.4':
+    resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.25.12':
     resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.4':
+    resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -412,8 +510,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.27.4':
+    resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.25.12':
     resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.4':
+    resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -424,8 +534,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.4':
+    resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.25.12':
     resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.4':
+    resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -436,8 +558,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.4':
+    resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.25.12':
     resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.4':
+    resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -448,8 +582,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.4':
+    resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.4':
+    resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -460,8 +606,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.4':
+    resolution: {integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -472,8 +630,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.27.4':
+    resolution: {integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -484,8 +654,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.4':
+    resolution: {integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.27.4':
+    resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -496,8 +678,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.27.4':
+    resolution: {integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.4':
+    resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -508,8 +702,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.4':
+    resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.4':
+    resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -693,6 +899,140 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
+
+  '@inquirer/ansi@1.0.2':
+    resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
+    engines: {node: '>=18'}
+
+  '@inquirer/checkbox@4.3.2':
+    resolution: {integrity: sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@5.1.21':
+    resolution: {integrity: sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@10.3.2':
+    resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@4.2.23':
+    resolution: {integrity: sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@4.0.23':
+    resolution: {integrity: sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/external-editor@1.0.3':
+    resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@1.0.15':
+    resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
+    engines: {node: '>=18'}
+
+  '@inquirer/input@4.3.1':
+    resolution: {integrity: sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@3.0.23':
+    resolution: {integrity: sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@4.0.23':
+    resolution: {integrity: sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@7.10.1':
+    resolution: {integrity: sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@4.1.11':
+    resolution: {integrity: sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@3.2.2':
+    resolution: {integrity: sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@4.4.2':
+    resolution: {integrity: sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@3.0.10':
+    resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1633,8 +1973,22 @@ packages:
       '@vitest/browser':
         optional: true
 
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
   '@vitest/expect@4.1.0':
     resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
 
   '@vitest/mocker@4.1.0':
     resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
@@ -1647,17 +2001,32 @@ packages:
       vite:
         optional: true
 
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
   '@vitest/pretty-format@4.1.0':
     resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
 
   '@vitest/runner@4.1.0':
     resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
 
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
   '@vitest/snapshot@4.1.0':
     resolution: {integrity: sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==}
 
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
   '@vitest/spy@4.1.0':
     resolution: {integrity: sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   '@vitest/utils@4.1.0':
     resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
@@ -1676,13 +2045,31 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -1732,15 +2119,33 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   caniuse-lite@1.0.30001778:
     resolution: {integrity: sha512-PN7uxFL+ExFJO61aVmP1aIEG4i9whQd4eoSCebav62UwDyp5OHh06zN4jqKSMePVgxHifCw1QJxdRkA1Pisekg==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -1754,12 +2159,23 @@ packages:
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
+  chardet@2.1.1:
+    resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -1771,11 +2187,33 @@ packages:
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
 
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
   compute-scroll-into-view@3.1.1:
     resolution: {integrity: sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -1822,6 +2260,10 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -1848,6 +2290,9 @@ packages:
   electron-to-chromium@1.5.313:
     resolution: {integrity: sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==}
 
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
   enhanced-resolve@5.20.0:
     resolution: {integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==}
     engines: {node: '>=10.13.0'}
@@ -1855,6 +2300,9 @@ packages:
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
@@ -1867,6 +2315,11 @@ packages:
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.27.4:
+    resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1909,6 +2362,12 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1917,6 +2376,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
@@ -2057,6 +2519,10 @@ packages:
     resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
     engines: {node: '>=20.0.0'}
 
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
   image-size@2.0.2:
     resolution: {integrity: sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==}
     engines: {node: '>=16.x'}
@@ -2077,6 +2543,10 @@ packages:
 
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
@@ -2104,11 +2574,18 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
@@ -2127,6 +2604,9 @@ packages:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -2207,11 +2687,25 @@ packages:
     resolution: {integrity: sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==}
     engines: {node: '>= 12.0.0'}
 
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lru-cache@11.2.6:
     resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
@@ -2401,8 +2895,18 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
+  mlly@1.8.1:
+    resolution: {integrity: sha512-SnL6sNutTwRWWR/vcmCYHSADjiEesp5TGQQ0pXyLhW5IoeibRlF/CbSLailbB3CNqJUk9cVJ9dUDnbD7GrcHBQ==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mute-stream@2.0.0:
+    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -2447,6 +2951,10 @@ packages:
     resolution: {integrity: sha512-tt6PvKu4WyzPwWUzy/hvPFqn+uwXO0K1ZHka8az3NnrhWJDmSqI8ncWq0fkL0k/lmmi5tAC11FXwXuh0rFbt1A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
@@ -2468,12 +2976,41 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
@@ -2638,10 +3175,17 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
   rollup@4.59.0:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -2675,6 +3219,10 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2689,15 +3237,29 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -2718,6 +3280,11 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -2735,8 +3302,18 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
@@ -2746,8 +3323,20 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
   tldts-core@7.0.25:
@@ -2765,19 +3354,48 @@ packages:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  ufo@1.6.3:
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -2842,6 +3460,11 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite@6.4.1:
     resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -2880,6 +3503,34 @@ packages:
       tsx:
         optional: true
       yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   vitest@4.1.0:
@@ -2938,6 +3589,10 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
   ws@8.19.0:
     resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
     engines: {node: '>=10.0.0'}
@@ -2959,6 +3614,15 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yaml@2.8.2:
+    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yoctocolors-cjs@2.1.3:
+    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
+    engines: {node: '>=18'}
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -3142,79 +3806,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.4':
+    optional: true
+
   '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.4':
     optional: true
 
   '@esbuild/android-arm@0.25.12':
     optional: true
 
+  '@esbuild/android-arm@0.27.4':
+    optional: true
+
   '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.27.4':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.4':
+    optional: true
+
   '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.4':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.4':
+    optional: true
+
   '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.4':
     optional: true
 
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.4':
+    optional: true
+
   '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.4':
     optional: true
 
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.4':
+    optional: true
+
   '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.4':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.4':
+    optional: true
+
   '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.4':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.4':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.4':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
+  '@esbuild/linux-x64@0.27.4':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.4':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.4':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.4':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.4':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.4':
     optional: true
 
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.4':
+    optional: true
+
   '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.4':
     optional: true
 
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.4':
+    optional: true
+
   '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.4':
     optional: true
 
   '@exodus/bytes@1.15.0': {}
@@ -3336,6 +4078,131 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.5':
     optional: true
+
+  '@inquirer/ansi@1.0.2': {}
+
+  '@inquirer/checkbox@4.3.2(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/confirm@5.1.21(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/core@10.3.2(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/editor@4.2.23(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/external-editor': 1.0.3(@types/node@22.19.15)
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/expand@4.0.23(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/external-editor@1.0.3(@types/node@22.19.15)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/figures@1.0.15': {}
+
+  '@inquirer/input@4.3.1(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/number@3.0.23(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/password@4.0.23(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/prompts@7.10.1(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@22.19.15)
+      '@inquirer/confirm': 5.1.21(@types/node@22.19.15)
+      '@inquirer/editor': 4.2.23(@types/node@22.19.15)
+      '@inquirer/expand': 4.0.23(@types/node@22.19.15)
+      '@inquirer/input': 4.3.1(@types/node@22.19.15)
+      '@inquirer/number': 3.0.23(@types/node@22.19.15)
+      '@inquirer/password': 4.0.23(@types/node@22.19.15)
+      '@inquirer/rawlist': 4.1.11(@types/node@22.19.15)
+      '@inquirer/search': 3.2.2(@types/node@22.19.15)
+      '@inquirer/select': 4.4.2(@types/node@22.19.15)
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/rawlist@4.1.11(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/search@3.2.2(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/select@4.4.2(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/type@3.0.10(@types/node@22.19.15)':
+    optionalDependencies:
+      '@types/node': 22.19.15
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -4007,12 +4874,12 @@ snapshots:
       postcss: 8.5.8
       tailwindcss: 4.2.1
 
-  '@tailwindcss/vite@4.2.1(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1))':
+  '@tailwindcss/vite@4.2.1(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))':
     dependencies:
       '@tailwindcss/node': 4.2.1
       '@tailwindcss/oxide': 4.2.1
       tailwindcss: 4.2.1
-      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)
+      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
 
   '@tauri-apps/api@2.10.1': {}
 
@@ -4184,7 +5051,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -4192,11 +5059,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)
+      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@types/node@22.19.15)(jsdom@28.1.0)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)))':
+  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@types/node@22.19.15)(jsdom@28.1.0)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.0
@@ -4208,7 +5075,15 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@types/node@22.19.15)(jsdom@28.1.0)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1))
+      vitest: 4.1.0(@types/node@22.19.15)(jsdom@28.1.0)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
 
   '@vitest/expect@4.1.0':
     dependencies:
@@ -4219,21 +5094,45 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.0(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1))':
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
+
+  '@vitest/mocker@4.1.0(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)
+      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
 
   '@vitest/pretty-format@4.1.0':
     dependencies:
       tinyrainbow: 3.1.0
 
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
   '@vitest/runner@4.1.0':
     dependencies:
       '@vitest/utils': 4.1.0
+      pathe: 2.0.3
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
       pathe: 2.0.3
 
   '@vitest/snapshot@4.1.0':
@@ -4243,7 +5142,17 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
   '@vitest/spy@4.1.0': {}
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@vitest/utils@4.1.0':
     dependencies:
@@ -4259,9 +5168,26 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   ansi-regex@5.0.1: {}
 
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
   ansi-styles@5.2.0: {}
+
+  any-promise@1.3.0: {}
 
   argparse@2.0.1: {}
 
@@ -4310,11 +5236,28 @@ snapshots:
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
+  bundle-require@5.1.0(esbuild@0.27.4):
+    dependencies:
+      esbuild: 0.27.4
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
   caniuse-lite@1.0.30001778: {}
 
   ccount@2.0.1: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chai@6.2.2: {}
+
+  chalk@5.6.2: {}
 
   character-entities-html4@2.1.0: {}
 
@@ -4324,6 +5267,10 @@ snapshots:
 
   character-reference-invalid@2.0.1: {}
 
+  chardet@2.1.1: {}
+
+  check-error@2.1.3: {}
+
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
@@ -4332,15 +5279,31 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
+  cli-width@4.1.0: {}
+
   client-only@0.0.1: {}
 
   clsx@2.1.1: {}
 
   collapse-white-space@2.1.0: {}
 
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
   comma-separated-tokens@2.0.3: {}
 
+  commander@13.1.0: {}
+
+  commander@4.1.1: {}
+
   compute-scroll-into-view@3.1.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
 
   convert-source-map@2.0.0: {}
 
@@ -4381,6 +5344,8 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  deep-eql@5.0.2: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
@@ -4401,12 +5366,16 @@ snapshots:
 
   electron-to-chromium@1.5.313: {}
 
+  emoji-regex@8.0.0: {}
+
   enhanced-resolve@5.20.0:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
 
   entities@6.0.1: {}
+
+  es-module-lexer@1.7.0: {}
 
   es-module-lexer@2.0.0: {}
 
@@ -4453,6 +5422,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
 
+  esbuild@0.27.4:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.4
+      '@esbuild/android-arm': 0.27.4
+      '@esbuild/android-arm64': 0.27.4
+      '@esbuild/android-x64': 0.27.4
+      '@esbuild/darwin-arm64': 0.27.4
+      '@esbuild/darwin-x64': 0.27.4
+      '@esbuild/freebsd-arm64': 0.27.4
+      '@esbuild/freebsd-x64': 0.27.4
+      '@esbuild/linux-arm': 0.27.4
+      '@esbuild/linux-arm64': 0.27.4
+      '@esbuild/linux-ia32': 0.27.4
+      '@esbuild/linux-loong64': 0.27.4
+      '@esbuild/linux-mips64el': 0.27.4
+      '@esbuild/linux-ppc64': 0.27.4
+      '@esbuild/linux-riscv64': 0.27.4
+      '@esbuild/linux-s390x': 0.27.4
+      '@esbuild/linux-x64': 0.27.4
+      '@esbuild/netbsd-arm64': 0.27.4
+      '@esbuild/netbsd-x64': 0.27.4
+      '@esbuild/openbsd-arm64': 0.27.4
+      '@esbuild/openbsd-x64': 0.27.4
+      '@esbuild/openharmony-arm64': 0.27.4
+      '@esbuild/sunos-x64': 0.27.4
+      '@esbuild/win32-arm64': 0.27.4
+      '@esbuild/win32-ia32': 0.27.4
+      '@esbuild/win32-x64': 0.27.4
+
   escalade@3.2.0: {}
 
   escape-string-regexp@5.0.0: {}
@@ -4498,9 +5496,19 @@ snapshots:
 
   extend@3.0.2: {}
 
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.0: {}
+
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.1
+      rollup: 4.59.0
 
   fraction.js@5.3.4: {}
 
@@ -4536,7 +5544,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@11.10.1(fumadocs-core@15.8.5(@types/react@19.2.14)(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)):
+  fumadocs-mdx@11.10.1(fumadocs-core@15.8.5(@types/react@19.2.14)(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
@@ -4557,7 +5565,7 @@ snapshots:
     optionalDependencies:
       next: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
-      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)
+      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -4699,6 +5707,10 @@ snapshots:
 
   iceberg-js@0.8.1: {}
 
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
   image-size@2.0.2: {}
 
   indent-string@4.0.0: {}
@@ -4713,6 +5725,8 @@ snapshots:
       is-decimal: 2.0.1
 
   is-decimal@2.0.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-hexadecimal@2.0.1: {}
 
@@ -4735,9 +5749,13 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  joycon@3.1.1: {}
+
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
 
   js-yaml@4.1.1:
     dependencies:
@@ -4771,6 +5789,8 @@ snapshots:
       - supports-color
 
   jsesc@3.1.0: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json5@2.2.3: {}
 
@@ -4823,9 +5843,17 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.31.1
       lightningcss-win32-x64-msvc: 1.31.1
 
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
   lodash.merge@4.6.2: {}
 
   longest-streak@3.1.0: {}
+
+  loupe@3.2.1: {}
 
   lru-cache@11.2.6: {}
 
@@ -5284,7 +6312,22 @@ snapshots:
 
   min-indent@1.0.1: {}
 
+  mlly@1.8.1:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.3
+
   ms@2.1.3: {}
+
+  mute-stream@2.0.0: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
 
   nanoid@3.3.11: {}
 
@@ -5322,6 +6365,8 @@ snapshots:
 
   npm-to-yarn@3.0.1: {}
 
+  object-assign@4.1.1: {}
+
   obug@2.1.1: {}
 
   oniguruma-parser@0.12.1: {}
@@ -5350,9 +6395,27 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pathval@2.0.1: {}
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.3: {}
+
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.1
+      pathe: 2.0.3
+
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.8)(yaml@2.8.2):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 2.6.1
+      postcss: 8.5.8
+      yaml: 2.8.2
 
   postcss-selector-parser@7.1.1:
     dependencies:
@@ -5582,6 +6645,8 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  resolve-from@5.0.0: {}
+
   rollup@4.59.0:
     dependencies:
       '@types/estree': 1.0.8
@@ -5612,6 +6677,8 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.59.0
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
+
+  safer-buffer@2.1.2: {}
 
   saxes@6.0.0:
     dependencies:
@@ -5674,6 +6741,8 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@4.1.0: {}
+
   source-map-js@1.2.1: {}
 
   source-map@0.7.6: {}
@@ -5682,16 +6751,32 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  std-env@3.10.0: {}
+
   std-env@4.0.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
 
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
 
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
 
   style-to-js@1.1.21:
     dependencies:
@@ -5706,6 +6791,16 @@ snapshots:
       client-only: 0.0.1
       react: 19.2.4
 
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -5718,7 +6813,17 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
   tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
 
   tinyexec@1.0.2: {}
 
@@ -5727,7 +6832,13 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
   tinyrainbow@3.1.0: {}
+
+  tinyspy@4.0.4: {}
 
   tldts-core@7.0.25: {}
 
@@ -5743,13 +6854,47 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  tree-kill@1.2.2: {}
+
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
 
+  ts-interface-checker@0.1.13: {}
+
   tslib@2.8.1: {}
 
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.2):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.4)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.4
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.8)(yaml@2.8.2)
+      resolve-from: 5.0.0
+      rollup: 4.59.0
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.8
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
   typescript@5.9.3: {}
+
+  ufo@1.6.3: {}
 
   undici-types@6.21.0: {}
 
@@ -5825,7 +6970,28 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1):
+  vite-node@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -5838,11 +7004,55 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.31.1
+      yaml: 2.8.2
 
-  vitest@4.1.0(@types/node@22.19.15)(jsdom@28.1.0)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(yaml@2.8.2):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
+      vite-node: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 22.19.15
+      jsdom: 28.1.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@4.1.0(@types/node@22.19.15)(jsdom@28.1.0)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1))
+      '@vitest/mocker': 4.1.0(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -5859,7 +7069,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)
+      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.15
@@ -5888,6 +7098,12 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   ws@8.19.0: {}
 
   xml-name-validator@5.0.0: {}
@@ -5895,6 +7111,10 @@ snapshots:
   xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
+
+  yaml@2.8.2: {}
+
+  yoctocolors-cjs@2.1.3: {}
 
   zod@4.3.6: {}
 


### PR DESCRIPTION
## Summary

- **`packages/core/` (`@harness-kit/core`)** — Environment-agnostic compilation engine that translates `harness.yaml` into native config files for Claude Code, Cursor, and GitHub Copilot. Includes JSON Schema validation (Ajv 2020-12), YAML parsing with legacy format detection, platform detection, marker block management, and a structured report builder. All file I/O goes through an injected `FsProvider` interface.

- **`apps/cli/` (`@harness-kit/cli`)** — Commander.js CLI with `validate` and `compile` subcommands, interactive platform selection via `@inquirer/prompts`, chalk-colored output, and `--target`/`--dry-run`/`--clean`/`--verbose` flags.

- **Desktop integration** — `TauriFsProvider` in `apps/desktop/src/lib/harness-fs.ts` wires the core library to Tauri's FS plugin, enabling the desktop app to call `compile()` and `validateHarness()` directly.

- **CI** — New `core-build-test` job builds both packages and runs the core test suite.

## Test plan

- [x] `pnpm --filter @harness-kit/core build` — builds without errors
- [x] `pnpm --filter @harness-kit/core test` — 61 tests pass across 9 files (validate, parse, markers, detect, instructions, mcp-servers, skills, permissions, compile)
- [x] `pnpm --filter @harness-kit/cli build` — builds without errors
- [x] `harness-kit validate harness.yaml.example` → PASS
- [x] `harness-kit compile ... --target all --dry-run` → shows files for all 3 platforms
- [x] `harness-kit validate` with invalid file → reports errors with field paths and fix suggestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)