### PR TITLE
docs: LangChain industry validation + deepagents comparison

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -8,7 +8,7 @@ harness-kit is a plugin collection for Claude Code. Each plugin packages a speci
 
 Your harness is the configuration that tells Claude how to work in a given session — files like `CLAUDE.md` and `AGENT.md`, plus any installed plugins. harness-kit helps you build and share that setup so it's not stuck on one machine.
 
-The term has become standard across the industry in 2026. LangChain published "The Anatomy of an Agent Harness" and ships `deepagents`, which they explicitly call a harness. They showed that harness changes alone moved a coding agent from Top 30 to Top 5 on Terminal Bench 2.0 — evidence that the configuration layer is a first-class concern, not an afterthought.
+The term is gaining traction — LangChain published ["The Anatomy of an Agent Harness"](https://blog.langchain.com/the-anatomy-of-an-agent-harness/) and ships `deepagents`, which they explicitly call a harness.
 
 ## Why do I need this? Can't I just write prompts myself?
 
@@ -83,11 +83,11 @@ See [Where harness-kit fits](https://harnesskit.ai/docs/concepts/comparison) for
 
 They work at different layers and complement each other.
 
-**deepagents** is a harness runtime — you build agents with it. It's Python, built on LangGraph, and opinionated about the execution environment. Think of it as an OS distribution for agents.
+**deepagents** is an agent harness framework — you build agents with it. It's Python, built on LangGraph, and opinionated about the execution environment.
 
-**harness-kit** is a harness configuration framework — you configure any harness with it. It works across Claude Code, Cursor, and Copilot without coupling you to a specific runtime or language. Think of it as dotfiles that work across distributions.
+**harness-kit** is a harness configuration framework — you configure any harness with it. It works across Claude Code, Cursor, and Copilot without coupling you to a specific runtime or language. Think of it as dotfiles that work across tools.
 
-You could use a harness-kit profile to configure a deepagents-based harness. They don't compete — one builds agents, the other makes agent configuration portable.
+LangChain demonstrated that harness changes alone moved a coding agent from Top 30 to Top 5 on Terminal Bench 2.0 — evidence that the configuration layer is a first-class performance variable. In principle, you could use a harness-kit profile to configure a deepagents-based harness. They don't compete — one builds agents, the other makes agent configuration portable.
 
 ## What is the Harness Protocol?
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -8,6 +8,8 @@ harness-kit is a plugin collection for Claude Code. Each plugin packages a speci
 
 Your harness is the configuration that tells Claude how to work in a given session — files like `CLAUDE.md` and `AGENT.md`, plus any installed plugins. harness-kit helps you build and share that setup so it's not stuck on one machine.
 
+The term has become standard across the industry in 2026. LangChain published "The Anatomy of an Agent Harness" and ships `deepagents`, which they explicitly call a harness. They showed that harness changes alone moved a coding agent from Top 30 to Top 5 on Terminal Bench 2.0 — evidence that the configuration layer is a first-class concern, not an afterthought.
+
 ## Why do I need this? Can't I just write prompts myself?
 
 You can. The issue is that good prompts tend to disappear — scattered across projects, left behind when you move to a new machine. Plugins give them a stable home with a version number.
@@ -76,6 +78,16 @@ They operate at different layers and don't overlap.
 MCP gives your agent tools. A2A lets agents delegate tasks to each other at runtime. The Claude Agent SDK is for building agent-powered applications. harness-kit describes the complete environment, plugins, MCP servers, instructions, permissions, so you can reproduce it on another machine or share it with a teammate. They compose well: a `harness.yaml` can declare MCP servers, the agent runs on the Claude SDK, and could speak A2A to other agents.
 
 See [Where harness-kit fits](https://harnesskit.ai/docs/concepts/comparison) for the full breakdown.
+
+## How does harness-kit compare to LangChain's deepagents?
+
+They work at different layers and complement each other.
+
+**deepagents** is a harness runtime — you build agents with it. It's Python, built on LangGraph, and opinionated about the execution environment. Think of it as an OS distribution for agents.
+
+**harness-kit** is a harness configuration framework — you configure any harness with it. It works across Claude Code, Cursor, and Copilot without coupling you to a specific runtime or language. Think of it as dotfiles that work across distributions.
+
+You could use a harness-kit profile to configure a deepagents-based harness. They don't compete — one builds agents, the other makes agent configuration portable.
 
 ## What is the Harness Protocol?
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Works with [Claude Code](https://claude.ai/claude-code), [Cursor](https://cursor
 
 Building a good AI setup takes real work. harness-kit makes it portable. Package your plugins, skills, MCP servers, hooks, and conventions into a config you can apply to any harness on any machine — and share with your team in one file. Works with Claude Code, Cursor, and GitHub Copilot. Designed to travel.
 
-The "harness" concept has become industry-standard terminology in 2026 — LangChain now ships [deepagents](https://blog.langchain.dev/the-anatomy-of-an-agent-harness/), a product they explicitly call an agent harness, and demonstrated that harness changes alone moved a coding agent from Top 30 to Top 5 on Terminal Bench 2.0. The configuration layer matters. harness-kit is a framework for managing that layer across tools.
+The harness concept is gaining industry adoption — LangChain's [deepagents](https://blog.langchain.com/the-anatomy-of-an-agent-harness/) is built around the same idea.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Works with [Claude Code](https://claude.ai/claude-code), [Cursor](https://cursor
 
 Building a good AI setup takes real work. harness-kit makes it portable. Package your plugins, skills, MCP servers, hooks, and conventions into a config you can apply to any harness on any machine — and share with your team in one file. Works with Claude Code, Cursor, and GitHub Copilot. Designed to travel.
 
+The "harness" concept has become industry-standard terminology in 2026 — LangChain now ships [deepagents](https://blog.langchain.dev/the-anatomy-of-an-agent-harness/), a product they explicitly call an agent harness, and demonstrated that harness changes alone moved a coding agent from Top 30 to Top 5 on Terminal Bench 2.0. The configuration layer matters. harness-kit is a framework for managing that layer across tools.
+
 ## Install
 
 ```


### PR DESCRIPTION
## Summary

- Add LangChain "harness" terminology convergence to README and FAQ
- Reference Terminal Bench 2.0 stat (Top 30 → Top 5 from harness changes alone)
- Add new FAQ entry comparing harness-kit (config framework) vs deepagents (runtime)

## Motivation

LangChain published "The Anatomy of an Agent Harness" (March 2026) and now ships `deepagents` — a product they explicitly call an agent harness. This is significant external validation of the "harness" category. The FAQ needed a comparison entry since deepagents is the most visible new entrant.

## Changes

| File | Change |
|------|--------|
| `README.md` | Add industry validation paragraph after intro |
| `FAQ.md` | Add LangChain context to "What is an AI harness?" answer |
| `FAQ.md` | Add "How does harness-kit compare to LangChain's deepagents?" entry |

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify FAQ entry reads naturally in context

🤖 Generated with [Claude Code](https://claude.com/claude-code)