### PR TITLE
fix: add missing security module declarations and cargo check to CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -149,6 +149,21 @@ jobs:
           node-version: 20
           cache: pnpm
 
+      - name: Install system dependencies (Tauri v2)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/desktop/src-tauri
+
+      - name: Rust check (desktop backend)
+        run: cargo check
+        working-directory: apps/desktop/src-tauri
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ packages/core/dist/
 
 # CLI
 apps/cli/dist/
+
+# devlaunch (local project config)
+.devlaunch.yml

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -5,6 +5,8 @@ pub mod settings;
 pub mod observatory;
 pub mod comparator;
 pub mod comparator_db;
+pub mod security;
+pub mod security_db;
 pub mod git;
 pub mod evaluation;
 pub mod export;


### PR DESCRIPTION
## Summary
- Adds missing `pub mod security` and `pub mod security_db` declarations to `commands/mod.rs` — the files were merged in #23 but the module wiring was lost during conflict resolution, breaking desktop compilation
- Adds `cargo check` to the `desktop-build-test` CI job so Rust compilation errors are caught before merge (previously only TypeScript/frontend was validated)
- Adds `.devlaunch.yml` to `.gitignore`

## Test plan
- [x] `cargo check` passes locally
- [ ] CI `desktop-build-test` job passes with the new Rust check step
- [ ] `tauri dev` launches without compilation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)