### PR TITLE
ci: harden validation — release trigger, plugin registration, clippy, tsc, PR-based evals

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -135,6 +135,16 @@
       "license": "Apache-2.0",
       "category": "productivity",
       "tags": ["notifications", "macos", "iterm2", "hooks"]
+    },
+    {
+      "name": "board",
+      "source": "./board",
+      "description": "Lightweight Kanban board with real-time Claude ↔ web UI two-way sync via MCP.",
+      "version": "0.1.0",
+      "author": { "name": "harnessprotocol" },
+      "license": "Apache-2.0",
+      "category": "productivity",
+      "tags": ["kanban", "tasks", "project-management", "mcp", "board"]
     }
   ]
 }

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 
@@ -35,10 +36,20 @@ jobs:
       - name: Render compatibility page
         run: python evals/render_results.py
 
-      - name: Commit results
+      - name: Open PR with results
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add evals/results/latest.json website/docs/evals/compatibility.md
-          git diff --staged --quiet || git commit -m "chore: update eval results $(date -u +%Y-%m-%d)"
-          git push
+          if git diff --staged --quiet; then
+            echo "No eval result changes — skipping PR"
+            exit 0
+          fi
+          DATE=$(date -u +%Y-%m-%d)
+          BRANCH="chore/eval-results-${DATE}"
+          git checkout -b "$BRANCH"
+          git commit -m "chore: update eval results ${DATE}"
+          git push origin "$BRANCH"
+          gh pr create --title "chore: update eval results ${DATE}" --body "Automated eval results from release run. Merge after reviewing the compatibility page." --base main --head "$BRANCH"

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -5,6 +5,10 @@ on:
     types: [published]
   workflow_dispatch:
 
+concurrency:
+  group: evals-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   run-evals:
     runs-on: ubuntu-latest
@@ -48,7 +52,7 @@ jobs:
             exit 0
           fi
           DATE=$(date -u +%Y-%m-%d)
-          BRANCH="chore/eval-results-${DATE}"
+          BRANCH="chore/eval-results-${DATE}-${{ github.run_id }}"
           git checkout -b "$BRANCH"
           git commit -m "chore: update eval results ${DATE}"
           git push origin "$BRANCH"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  release:
+    types: [published]
+
+concurrency:
+  group: validate-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   validate:
@@ -55,6 +61,31 @@ jobs:
               for plugin in marketplace['plugins']:
                   print(f\"{plugin['name']}: v{plugin['version']}\")
               print('All versions aligned.')
+          "
+
+      - name: Check all plugins registered
+        run: |
+          python3 -c "
+          import json, sys, os, glob
+
+          marketplace = json.load(open('.claude-plugin/marketplace.json'))
+          registered = {p['name'] for p in marketplace['plugins']}
+
+          on_disk = {os.path.basename(d) for d in glob.glob('plugins/*') if os.path.isdir(d)}
+
+          errors = []
+          for name in sorted(on_disk - registered):
+              errors.append(f'{name}: directory exists but not registered in marketplace.json')
+          for name in sorted(registered - on_disk):
+              errors.append(f'{name}: registered in marketplace.json but directory not found')
+
+          if errors:
+              print('Plugin registration mismatch:')
+              for e in errors:
+                  print(f'  {e}')
+              sys.exit(1)
+          else:
+              print(f'All {len(on_disk)} plugins registered: {sorted(on_disk)}')
           "
 
       - name: Validate developed_with field
@@ -137,6 +168,12 @@ jobs:
       - name: Build CLI package
         run: pnpm --filter @harness-kit/cli build
 
+      - name: TypeScript check (shared)
+        run: pnpm --filter @harness-kit/shared exec tsc --noEmit
+
+      - name: TypeScript check (cli)
+        run: pnpm --filter @harness-kit/cli exec tsc --noEmit
+
   desktop-build-test:
     runs-on: ubuntu-latest
     steps:
@@ -162,6 +199,10 @@ jobs:
 
       - name: Rust check (desktop backend)
         run: cargo check
+        working-directory: apps/desktop/src-tauri
+
+      - name: Rust clippy (desktop backend)
+        run: cargo clippy -- -D warnings
         working-directory: apps/desktop/src-tauri
 
       - name: Install dependencies

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -165,11 +165,11 @@ jobs:
       - name: Run core tests
         run: pnpm --filter @harness-kit/core test
 
-      - name: Build CLI package
-        run: pnpm --filter @harness-kit/cli build
-
       - name: TypeScript check (shared)
         run: pnpm --filter @harness-kit/shared exec tsc --noEmit
+
+      - name: Build CLI package
+        run: pnpm --filter @harness-kit/cli build
 
       - name: TypeScript check (cli)
         run: pnpm --filter @harness-kit/cli exec tsc --noEmit

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -12,11 +12,12 @@
   },
   "dependencies": {
     "@harness-kit/core": "workspace:*",
-    "commander": "^13",
     "@inquirer/prompts": "^7",
-    "chalk": "^5"
+    "chalk": "^5",
+    "commander": "^13"
   },
   "devDependencies": {
+    "@types/node": "^25.5.0",
     "tsup": "^8",
     "typescript": "^5"
   }

--- a/apps/desktop/src-tauri/src/commands/claude_md.rs
+++ b/apps/desktop/src-tauri/src/commands/claude_md.rs
@@ -4,8 +4,8 @@ pub fn read_claude_md(path: String) -> Result<String, String> {
         .ok_or_else(|| "Could not resolve home directory".to_string())?;
 
     // Expand ~ to home directory
-    let expanded = if path.starts_with("~/") {
-        home.join(&path[2..])
+    let expanded = if let Some(stripped) = path.strip_prefix("~/") {
+        home.join(stripped)
     } else {
         std::path::PathBuf::from(&path)
     };

--- a/apps/desktop/src-tauri/src/commands/evaluation.rs
+++ b/apps/desktop/src-tauri/src/commands/evaluation.rs
@@ -4,6 +4,7 @@ use tauri::State;
 pub use super::types::Evaluation;
 
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub fn save_evaluation(
     db: State<'_, Db>,
     id: String,

--- a/apps/desktop/src-tauri/src/commands/observatory.rs
+++ b/apps/desktop/src-tauri/src/commands/observatory.rs
@@ -164,7 +164,7 @@ pub fn list_sessions_summary() -> Result<Vec<SessionSummary>, String> {
             let project_short = std::path::Path::new(&project)
                 .file_name()
                 .and_then(|n| n.to_str())
-                .unwrap_or_else(|| project.as_str())
+                .unwrap_or(project.as_str())
                 .to_string();
             SessionSummary {
                 session_id,

--- a/install.sh
+++ b/install.sh
@@ -39,13 +39,13 @@ else
   echo "Remote install: downloading from ${REPO}"
 
   MARKETPLACE_JSON=$(curl -fsSL "${RAW_BASE}/.claude-plugin/marketplace.json")
-  PLUGINS=$(python3 -c "
+  mapfile -t PLUGINS < <(python3 -c "
 import json, sys
 data = json.loads(sys.stdin.read())
-print(' '.join(p['name'] for p in data['plugins']))
+print('\n'.join(p['name'] for p in data['plugins']))
 " <<< "$MARKETPLACE_JSON")
 
-  for plugin in $PLUGINS; do
+  for plugin in "${PLUGINS[@]}"; do
     dest="${SKILLS_DEST}/${plugin}"
     mkdir -p "$dest"
     skill_url="${RAW_BASE}/plugins/${plugin}/skills/${plugin}/SKILL.md"

--- a/install.sh
+++ b/install.sh
@@ -38,12 +38,23 @@ if [[ -n "$LOCAL_PLUGINS" ]]; then
 else
   echo "Remote install: downloading from ${REPO}"
 
-  for plugin in research explain lineage orient capture review docgen; do
+  MARKETPLACE_JSON=$(curl -fsSL "${RAW_BASE}/.claude-plugin/marketplace.json")
+  PLUGINS=$(python3 -c "
+import json, sys
+data = json.loads(sys.stdin.read())
+print(' '.join(p['name'] for p in data['plugins']))
+" <<< "$MARKETPLACE_JSON")
+
+  for plugin in $PLUGINS; do
     dest="${SKILLS_DEST}/${plugin}"
     mkdir -p "$dest"
-    curl -fsSL "${RAW_BASE}/plugins/${plugin}/skills/${plugin}/SKILL.md"  -o "${dest}/SKILL.md"
-    curl -fsSL "${RAW_BASE}/plugins/${plugin}/skills/${plugin}/README.md" -o "${dest}/README.md"
-    echo "  ~/.claude/skills/${plugin}/"
+    skill_url="${RAW_BASE}/plugins/${plugin}/skills/${plugin}/SKILL.md"
+    if curl -fsSL "$skill_url" -o "${dest}/SKILL.md"; then
+      curl -fsSL "${RAW_BASE}/plugins/${plugin}/skills/${plugin}/README.md" -o "${dest}/README.md" || true
+      echo "  ~/.claude/skills/${plugin}/"
+    else
+      rmdir "$dest" 2>/dev/null || true
+    fi
   done
 
   echo "Installed all skills."

--- a/plugins/board/.claude-plugin/plugin.json
+++ b/plugins/board/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "board",
   "description": "Harness Board — a lightweight Kanban board with real-time Claude ↔ web UI two-way sync",
   "version": "0.1.0",
-  "category": "project-management",
+  "category": "productivity",
   "tags": ["kanban", "tasks", "project-management", "mcp", "board"],
   "mcp": {
     "server": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,7 +58,7 @@ importers:
         version: link:../../packages/core
       '@inquirer/prompts':
         specifier: ^7
-        version: 7.10.1(@types/node@22.19.15)
+        version: 7.10.1(@types/node@25.5.0)
       chalk:
         specifier: ^5
         version: 5.6.2
@@ -66,6 +66,9 @@ importers:
         specifier: ^13
         version: 13.1.0
     devDependencies:
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.5.0
       tsup:
         specifier: ^8
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -135,7 +138,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.0.0
-        version: 4.2.1(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.2.1(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       '@tauri-apps/cli':
         specifier: ^2
         version: 2.10.1
@@ -159,10 +162,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.7.0(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/coverage-v8':
         specifier: ^4.1.0
-        version: 4.1.0(vitest@4.1.0(@types/node@22.19.15)(jsdom@28.1.0)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)))
+        version: 4.1.0(vitest@4.1.0(@types/node@25.5.0)(jsdom@28.1.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.27(postcss@8.5.8)
@@ -177,10 +180,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.0.3
-        version: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@22.19.15)(jsdom@28.1.0)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.0(@types/node@25.5.0)(jsdom@28.1.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
 
   marketplace:
     dependencies:
@@ -2141,6 +2144,9 @@ packages:
 
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
+
+  '@types/node@25.5.0':
+    resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
   '@types/phoenix@1.6.7':
     resolution: {integrity: sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==}
@@ -4159,6 +4165,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
   undici@7.24.2:
     resolution: {integrity: sha512-P9J1HWYV/ajFr8uCqk5QixwiRKmB1wOamgS0e+o2Z4A44Ej2+thFVRLG/eA7qprx88XXhnV5Bl8LHXTURpzB3Q==}
     engines: {node: '>=20.18.1'}
@@ -4912,128 +4921,128 @@ snapshots:
 
   '@inquirer/ansi@1.0.2': {}
 
-  '@inquirer/checkbox@4.3.2(@types/node@22.19.15)':
+  '@inquirer/checkbox@4.3.2(@types/node@25.5.0)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/core': 10.3.2(@types/node@25.5.0)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+      '@inquirer/type': 3.0.10(@types/node@25.5.0)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
 
-  '@inquirer/confirm@5.1.21(@types/node@22.19.15)':
+  '@inquirer/confirm@5.1.21(@types/node@25.5.0)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.15)
-      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+      '@inquirer/core': 10.3.2(@types/node@25.5.0)
+      '@inquirer/type': 3.0.10(@types/node@25.5.0)
     optionalDependencies:
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
 
-  '@inquirer/core@10.3.2(@types/node@22.19.15)':
+  '@inquirer/core@10.3.2(@types/node@25.5.0)':
     dependencies:
       '@inquirer/ansi': 1.0.2
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+      '@inquirer/type': 3.0.10(@types/node@25.5.0)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
 
-  '@inquirer/editor@4.2.23(@types/node@22.19.15)':
+  '@inquirer/editor@4.2.23(@types/node@25.5.0)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.15)
-      '@inquirer/external-editor': 1.0.3(@types/node@22.19.15)
-      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+      '@inquirer/core': 10.3.2(@types/node@25.5.0)
+      '@inquirer/external-editor': 1.0.3(@types/node@25.5.0)
+      '@inquirer/type': 3.0.10(@types/node@25.5.0)
     optionalDependencies:
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
 
-  '@inquirer/expand@4.0.23(@types/node@22.19.15)':
+  '@inquirer/expand@4.0.23(@types/node@25.5.0)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.15)
-      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+      '@inquirer/core': 10.3.2(@types/node@25.5.0)
+      '@inquirer/type': 3.0.10(@types/node@25.5.0)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
 
-  '@inquirer/external-editor@1.0.3(@types/node@22.19.15)':
+  '@inquirer/external-editor@1.0.3(@types/node@25.5.0)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
 
   '@inquirer/figures@1.0.15': {}
 
-  '@inquirer/input@4.3.1(@types/node@22.19.15)':
+  '@inquirer/input@4.3.1(@types/node@25.5.0)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.15)
-      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+      '@inquirer/core': 10.3.2(@types/node@25.5.0)
+      '@inquirer/type': 3.0.10(@types/node@25.5.0)
     optionalDependencies:
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
 
-  '@inquirer/number@3.0.23(@types/node@22.19.15)':
+  '@inquirer/number@3.0.23(@types/node@25.5.0)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.15)
-      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+      '@inquirer/core': 10.3.2(@types/node@25.5.0)
+      '@inquirer/type': 3.0.10(@types/node@25.5.0)
     optionalDependencies:
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
 
-  '@inquirer/password@4.0.23(@types/node@22.19.15)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@22.19.15)
-      '@inquirer/type': 3.0.10(@types/node@22.19.15)
-    optionalDependencies:
-      '@types/node': 22.19.15
-
-  '@inquirer/prompts@7.10.1(@types/node@22.19.15)':
-    dependencies:
-      '@inquirer/checkbox': 4.3.2(@types/node@22.19.15)
-      '@inquirer/confirm': 5.1.21(@types/node@22.19.15)
-      '@inquirer/editor': 4.2.23(@types/node@22.19.15)
-      '@inquirer/expand': 4.0.23(@types/node@22.19.15)
-      '@inquirer/input': 4.3.1(@types/node@22.19.15)
-      '@inquirer/number': 3.0.23(@types/node@22.19.15)
-      '@inquirer/password': 4.0.23(@types/node@22.19.15)
-      '@inquirer/rawlist': 4.1.11(@types/node@22.19.15)
-      '@inquirer/search': 3.2.2(@types/node@22.19.15)
-      '@inquirer/select': 4.4.2(@types/node@22.19.15)
-    optionalDependencies:
-      '@types/node': 22.19.15
-
-  '@inquirer/rawlist@4.1.11(@types/node@22.19.15)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.15)
-      '@inquirer/type': 3.0.10(@types/node@22.19.15)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 22.19.15
-
-  '@inquirer/search@3.2.2(@types/node@22.19.15)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.15)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@22.19.15)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 22.19.15
-
-  '@inquirer/select@4.4.2(@types/node@22.19.15)':
+  '@inquirer/password@4.0.23(@types/node@25.5.0)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@22.19.15)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+      '@inquirer/core': 10.3.2(@types/node@25.5.0)
+      '@inquirer/type': 3.0.10(@types/node@25.5.0)
+    optionalDependencies:
+      '@types/node': 25.5.0
+
+  '@inquirer/prompts@7.10.1(@types/node@25.5.0)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@25.5.0)
+      '@inquirer/confirm': 5.1.21(@types/node@25.5.0)
+      '@inquirer/editor': 4.2.23(@types/node@25.5.0)
+      '@inquirer/expand': 4.0.23(@types/node@25.5.0)
+      '@inquirer/input': 4.3.1(@types/node@25.5.0)
+      '@inquirer/number': 3.0.23(@types/node@25.5.0)
+      '@inquirer/password': 4.0.23(@types/node@25.5.0)
+      '@inquirer/rawlist': 4.1.11(@types/node@25.5.0)
+      '@inquirer/search': 3.2.2(@types/node@25.5.0)
+      '@inquirer/select': 4.4.2(@types/node@25.5.0)
+    optionalDependencies:
+      '@types/node': 25.5.0
+
+  '@inquirer/rawlist@4.1.11(@types/node@25.5.0)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@25.5.0)
+      '@inquirer/type': 3.0.10(@types/node@25.5.0)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
 
-  '@inquirer/type@3.0.10(@types/node@22.19.15)':
+  '@inquirer/search@3.2.2(@types/node@25.5.0)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@25.5.0)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@25.5.0)
+      yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
+
+  '@inquirer/select@4.4.2(@types/node@25.5.0)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@25.5.0)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@25.5.0)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 25.5.0
+
+  '@inquirer/type@3.0.10(@types/node@25.5.0)':
+    optionalDependencies:
+      '@types/node': 25.5.0
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -5741,12 +5750,12 @@ snapshots:
       postcss: 8.5.8
       tailwindcss: 4.2.1
 
-  '@tailwindcss/vite@4.2.1(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@tailwindcss/vite@4.2.1(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@tailwindcss/node': 4.2.1
       '@tailwindcss/oxide': 4.2.1
       tailwindcss: 4.2.1
-      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@tauri-apps/api@2.10.1': {}
 
@@ -5952,6 +5961,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@25.5.0':
+    dependencies:
+      undici-types: 7.18.2
+
   '@types/phoenix@1.6.7': {}
 
   '@types/qs@6.15.0': {}
@@ -5996,7 +6009,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -6004,11 +6017,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@types/node@22.19.15)(jsdom@28.1.0)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@types/node@25.5.0)(jsdom@28.1.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.0
@@ -6020,7 +6033,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@types/node@22.19.15)(jsdom@28.1.0)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.0(@types/node@25.5.0)(jsdom@28.1.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -6047,13 +6060,13 @@ snapshots:
     optionalDependencies:
       vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
 
-  '@vitest/mocker@4.1.0(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.1.0(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -8449,6 +8462,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici-types@7.18.2: {}
+
   undici@7.24.2: {}
 
   unified@11.0.5:
@@ -8585,6 +8600,22 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.2
 
+  vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.8
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 25.5.0
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.31.1
+      tsx: 4.21.0
+      yaml: 2.8.2
+
   vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@types/chai': 5.2.3
@@ -8628,10 +8659,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.0(@types/node@22.19.15)(jsdom@28.1.0)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vitest@4.1.0(@types/node@25.5.0)(jsdom@28.1.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.1.0(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -8648,10 +8679,10 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
       jsdom: 28.1.0
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
## Summary

Closes the gaps that let broken code reach production. The biggest fix: validate.yml now runs on every GitHub release publish, so Cloudflare deploys can't race ahead of validation. Six additional hardening changes round out the suite.

## Changes

- **Release trigger** — `validate.yml` now runs on `release: types: [published]`, blocking blind deploys to Cloudflare production
- **Concurrency group** — cancels superseded validate runs on the same ref
- **Plugin registration check** — new CI step diffs `plugins/*/` against `marketplace.json`; fails if anything is unregistered in either direction
- **board registered** — `board` plugin was on disk but absent from `marketplace.json`; added with version `0.1.0`
- **cargo clippy** — `cargo clippy -- -D warnings` added to `desktop-build-test`; fixed 3 pre-existing warnings (`manual_strip`, `unnecessary_lazy_evaluations`, `too_many_arguments`)
- **TypeScript type-checking** — `tsc --noEmit` added for `@harness-kit/shared` and `@harness-kit/cli`; added `@types/node` to cli devDependencies to resolve pre-existing errors
- **Dynamic install.sh** — remote mode now fetches the plugin list from `marketplace.json` at install time instead of a hardcoded 7-plugin list; all 13 plugins now install
- **PR-based evals** — `evals.yml` opens a PR for eval results instead of pushing directly to main (bypassing all checks)

## Test Plan

- [ ] Local tests pass (68 core + 152 desktop — verified)
- [ ] CI checks pass on this PR
- [ ] "All plugins registered" check passes (verified locally: all 13 plugins registered)
- [ ] `cargo clippy -- -D warnings` passes locally (verified)
- [ ] `tsc --noEmit` passes for shared and cli (verified)

## Notes

The `too_many_arguments` clippy lint on `save_evaluation` is suppressed with `#[allow]` — it's a Tauri command with a 1:1 mapping to a JS call, so restructuring the signature would break the frontend contract.

The evals PR flow uses `${{ secrets.GITHUB_TOKEN }}` with `pull-requests: write` permission — no additional secrets needed.