### PR TITLE
fix(desktop): visible vibrancy, board auto-start, ⌘6 shortcut, regression tests

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "identifier": "com.harnesskit.desktop",
   "build": {
-    "beforeDevCommand": "pnpm dev",
+    "beforeDevCommand": "pnpm --filter board-server dev & pnpm dev",
     "devUrl": "http://localhost:1420",
     "beforeBuildCommand": "pnpm build",
     "frontendDist": "../dist"

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -6,7 +6,7 @@
   --bg-base: #f4f2ef;
   --bg-surface: #faf9f7;
   --bg-elevated: #ffffff;
-  --bg-sidebar: rgba(236, 234, 230, 0.92);
+  --bg-sidebar: rgba(228, 226, 222, 0.82);
   --bg-sidebar-solid: #ece9e5;
 
   /* Foregrounds */
@@ -50,7 +50,7 @@
   --bg-base: #1c1c1e;
   --bg-surface: #242426;
   --bg-elevated: #2c2c2e;
-  --bg-sidebar: rgba(28, 28, 30, 0.85);
+  --bg-sidebar: rgba(44, 44, 48, 0.78);
   --bg-sidebar-solid: #1e1e20;
 
   /* Foregrounds */

--- a/apps/desktop/src/hooks/__tests__/useArrowNavigation.test.ts
+++ b/apps/desktop/src/hooks/__tests__/useArrowNavigation.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useArrowNavigation } from "../useArrowNavigation";
+
+// ── Helpers ───────────────────────────────────────────────────
+
+function reactKey(key: string): React.KeyboardEvent {
+  return { key, preventDefault: vi.fn() } as unknown as React.KeyboardEvent;
+}
+
+function hook(count: number, onActivate?: (i: number) => void) {
+  return renderHook(
+    ({ c, fn }: { c: number; fn?: (i: number) => void }) =>
+      useArrowNavigation({ count: c, onActivate: fn }),
+    { initialProps: { c: count, fn: onActivate } },
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────
+
+describe("ArrowDown", () => {
+  it("increments focusedIndex from -1 to 0", () => {
+    const { result } = hook(3);
+    act(() => result.current.onKeyDown(reactKey("ArrowDown")));
+    expect(result.current.focusedIndex).toBe(0);
+  });
+
+  it("increments up to count-1 and does not exceed it", () => {
+    const { result } = hook(3);
+    act(() => result.current.onKeyDown(reactKey("ArrowDown")));
+    act(() => result.current.onKeyDown(reactKey("ArrowDown")));
+    act(() => result.current.onKeyDown(reactKey("ArrowDown")));
+    act(() => result.current.onKeyDown(reactKey("ArrowDown"))); // extra press
+    expect(result.current.focusedIndex).toBe(2);
+  });
+});
+
+describe("ArrowUp", () => {
+  it("does not go below 0", () => {
+    const { result } = hook(3);
+    act(() => result.current.onKeyDown(reactKey("ArrowUp")));
+    expect(result.current.focusedIndex).toBe(0);
+  });
+
+  it("decrements from a positive index", () => {
+    const { result } = hook(3);
+    act(() => result.current.onKeyDown(reactKey("ArrowDown")));
+    act(() => result.current.onKeyDown(reactKey("ArrowDown")));
+    act(() => result.current.onKeyDown(reactKey("ArrowUp")));
+    expect(result.current.focusedIndex).toBe(0);
+  });
+});
+
+describe("Home / End", () => {
+  it("Home goes to index 0", () => {
+    const { result } = hook(5);
+    act(() => result.current.onKeyDown(reactKey("ArrowDown")));
+    act(() => result.current.onKeyDown(reactKey("ArrowDown")));
+    act(() => result.current.onKeyDown(reactKey("Home")));
+    expect(result.current.focusedIndex).toBe(0);
+  });
+
+  it("End goes to count-1", () => {
+    const { result } = hook(5);
+    act(() => result.current.onKeyDown(reactKey("End")));
+    expect(result.current.focusedIndex).toBe(4);
+  });
+});
+
+describe("Enter", () => {
+  it("calls onActivate with current focusedIndex", () => {
+    const onActivate = vi.fn();
+    const { result } = hook(3, onActivate);
+    act(() => result.current.onKeyDown(reactKey("ArrowDown")));
+    act(() => result.current.onKeyDown(reactKey("Enter")));
+    expect(onActivate).toHaveBeenCalledWith(0);
+  });
+
+  it("does not call onActivate when focusedIndex is -1", () => {
+    const onActivate = vi.fn();
+    const { result } = hook(3, onActivate);
+    act(() => result.current.onKeyDown(reactKey("Enter")));
+    expect(onActivate).not.toHaveBeenCalled();
+  });
+});
+
+describe("focusedIndex resets when count changes", () => {
+  it("resets to -1 when count changes", () => {
+    const { result, rerender } = hook(3);
+    act(() => result.current.onKeyDown(reactKey("ArrowDown")));
+    expect(result.current.focusedIndex).toBe(0);
+    rerender({ c: 5, fn: undefined });
+    expect(result.current.focusedIndex).toBe(-1);
+  });
+});

--- a/apps/desktop/src/hooks/__tests__/useGlobalShortcuts.test.ts
+++ b/apps/desktop/src/hooks/__tests__/useGlobalShortcuts.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { fireEvent } from "@testing-library/react";
+import { NAV_PATHS } from "../useGlobalShortcuts";
+import { NAV_SECTIONS } from "../../layouts/AppLayout";
+import { useGlobalShortcuts } from "../useGlobalShortcuts";
+
+// ── Helpers ───────────────────────────────────────────────────
+
+function metaKey(key: string) {
+  return { metaKey: true, key };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyMock = ReturnType<typeof vi.fn<any>>;
+
+function renderShortcuts(overrides?: { navigate?: AnyMock; setSettingsOpen?: AnyMock }) {
+  const navigate = overrides?.navigate ?? vi.fn();
+  const setSettingsOpen = overrides?.setSettingsOpen ?? vi.fn();
+  renderHook(() =>
+    useGlobalShortcuts({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      navigate: navigate as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      setSettingsOpen: setSettingsOpen as any,
+    }),
+  );
+  return { navigate, setSettingsOpen };
+}
+
+// ── Tests ─────────────────────────────────────────────────────
+
+describe("NAV_PATHS coverage", () => {
+  it("covers every NAV_SECTION — lengths must match", () => {
+    expect(NAV_PATHS.length).toBe(NAV_SECTIONS.length);
+  });
+});
+
+describe("⌘1–⌘N navigation", () => {
+  NAV_PATHS.forEach((path, idx) => {
+    const num = idx + 1;
+    it(`⌘${num} navigates to ${path}`, () => {
+      const { navigate } = renderShortcuts();
+      fireEvent.keyDown(document, metaKey(String(num)));
+      expect(navigate).toHaveBeenCalledWith(path);
+    });
+  });
+});
+
+describe("out-of-bounds key does nothing", () => {
+  it(`⌘${NAV_PATHS.length + 1} does not call navigate`, () => {
+    const { navigate } = renderShortcuts();
+    fireEvent.keyDown(document, metaKey(String(NAV_PATHS.length + 1)));
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("⌘0 does not call navigate", () => {
+    const { navigate } = renderShortcuts();
+    fireEvent.keyDown(document, metaKey("0"));
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});
+
+describe("⌘, toggles preferences", () => {
+  it("calls setSettingsOpen with toggle function", () => {
+    const setSettingsOpen = vi.fn();
+    renderShortcuts({ setSettingsOpen });
+    fireEvent.keyDown(document, metaKey(","));
+    expect(setSettingsOpen).toHaveBeenCalledTimes(1);
+    // The argument should be a function (toggler)
+    const arg = setSettingsOpen.mock.calls[0][0];
+    expect(typeof arg).toBe("function");
+    expect(arg(false)).toBe(true);
+    expect(arg(true)).toBe(false);
+  });
+});
+
+describe("Escape closes preferences", () => {
+  it("calls setSettingsOpen(false) on Escape", () => {
+    const setSettingsOpen = vi.fn();
+    renderShortcuts({ setSettingsOpen });
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(setSettingsOpen).toHaveBeenCalledWith(false);
+  });
+});

--- a/apps/desktop/src/hooks/useGlobalShortcuts.ts
+++ b/apps/desktop/src/hooks/useGlobalShortcuts.ts
@@ -1,12 +1,13 @@
 import { useEffect } from "react";
 import type { NavigateFunction } from "react-router-dom";
 
-const NAV_PATHS = [
+export const NAV_PATHS = [
   "/harness/plugins",
   "/marketplace",
   "/observatory",
   "/comparator",
   "/security/permissions",
+  "/board",
 ] as const;
 
 interface Options {
@@ -32,9 +33,9 @@ export function useGlobalShortcuts({ setSettingsOpen, navigate }: Options) {
         return;
       }
 
-      // ⌘1–⌘5 — navigate to sections
+      // ⌘1–⌘6 — navigate to sections
       const num = parseInt(e.key, 10);
-      if (num >= 1 && num <= 5) {
+      if (num >= 1 && num <= NAV_PATHS.length) {
         e.preventDefault();
         navigate(NAV_PATHS[num - 1]);
       }

--- a/apps/desktop/src/layouts/AppLayout.tsx
+++ b/apps/desktop/src/layouts/AppLayout.tsx
@@ -17,7 +17,7 @@ type NavSection = {
   children?: { label: string; path: string }[];
 };
 
-const NAV_SECTIONS: NavSection[] = [
+export const NAV_SECTIONS: NavSection[] = [
   {
     id: "harness",
     label: "Harness",
@@ -152,7 +152,11 @@ export default function AppLayout() {
           backdropFilter: "blur(20px)",
           WebkitBackdropFilter: "blur(20px)",
           borderRight: "1px solid var(--border-base)",
-          position: "relative",
+          position: "fixed",
+          top: 0,
+          left: 0,
+          bottom: 0,
+          zIndex: 30,
         }}
       >
         {/* App name */}
@@ -290,7 +294,7 @@ export default function AppLayout() {
       </aside>
 
       {/* Main content */}
-      <main className="flex-1 overflow-y-auto" style={{ background: "var(--bg-base)" }}>
+      <main className="flex-1 overflow-y-auto" style={{ background: "var(--bg-base)", paddingLeft: "var(--sidebar-width)" }}>
         <Outlet />
       </main>
     </div>

--- a/apps/desktop/src/layouts/__tests__/AppLayout.test.tsx
+++ b/apps/desktop/src/layouts/__tests__/AppLayout.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import AppLayout, { NAV_SECTIONS } from "../AppLayout";
+import { NAV_PATHS } from "../../hooks/useGlobalShortcuts";
+
+// ── Mocks ─────────────────────────────────────────────────────
+
+// Tauri APIs used by theme lib must not throw in jsdom
+vi.mock("../../lib/theme", () => ({
+  initTheme: vi.fn(),
+  getTheme: vi.fn(() => "system"),
+  setTheme: vi.fn(),
+  getAccent: vi.fn(() => "blue"),
+  setAccent: vi.fn(),
+  ACCENT_PRESETS: {
+    blue: { label: "Blue", swatch: "#5b50e8" },
+  },
+}));
+
+beforeEach(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      media: "",
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }),
+  });
+});
+
+function renderLayout() {
+  return render(
+    <MemoryRouter initialEntries={["/harness/plugins"]}>
+      <AppLayout />
+    </MemoryRouter>,
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────
+
+describe("sidebar layout — vibrancy regression guard", () => {
+  it("sidebar has position: fixed", () => {
+    renderLayout();
+    const aside = document.querySelector("aside");
+    expect(aside).not.toBeNull();
+    expect(aside!.style.position).toBe("fixed");
+  });
+
+  it("sidebar has backdropFilter with blur", () => {
+    renderLayout();
+    const aside = document.querySelector("aside");
+    expect(aside!.style.backdropFilter).toMatch(/blur/);
+  });
+
+  it("main content has paddingLeft set to sidebar-width variable", () => {
+    renderLayout();
+    const main = document.querySelector("main");
+    expect(main!.style.paddingLeft).toBe("var(--sidebar-width)");
+  });
+});
+
+describe("NAV alignment", () => {
+  it("NAV_SECTIONS and NAV_PATHS have matching lengths", () => {
+    expect(NAV_SECTIONS.length).toBe(NAV_PATHS.length);
+  });
+});
+
+describe("sidebar renders all nav sections", () => {
+  it("renders every section label", () => {
+    renderLayout();
+    for (const section of NAV_SECTIONS) {
+      expect(screen.getByText(section.label)).toBeInTheDocument();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Three post-#26 regressions fixed: the sidebar vibrancy was mathematically invisible (same color composited over itself), the Board page required a manual server start, and ⌘6 did not navigate to Board. Also adds 25 regression tests covering the exact failure modes so these can't silently regress again.

## Changes

- **Sidebar vibrancy** — Position sidebar `fixed` so `<main>` extends full-width behind it, giving `backdrop-filter: blur` content to blur. Differentiate `--bg-sidebar` from `--bg-base` in both themes so the translucency is actually perceptible: light `rgba(228,226,222,0.82)`, dark `rgba(44,44,48,0.78)`.
- **Board server auto-start** — `beforeDevCommand` now starts `board-server` in the background (`& pnpm dev`) so the Board page connects without a manual `pnpm --filter board-server dev`.
- **⌘6 shortcut** — Added `/board` as the 6th entry in `NAV_PATHS`; guard changed from `num <= 5` to `num <= NAV_PATHS.length` to prevent this class of bug recurring.
- **Exports** — `NAV_PATHS` and `NAV_SECTIONS` exported so tests can assert coverage alignment.
- **Tests (25 new)** — `useGlobalShortcuts`: NAV coverage, all ⌘1–⌘6 paths, out-of-bounds, ⌘,, Escape. `AppLayout`: sidebar `position: fixed`, `backdropFilter`, main `paddingLeft`, NAV alignment, section labels. `useArrowNavigation`: ArrowDown/Up clamping, Home/End, Enter activation, reset on count change.

## Test Plan

- [x] Local tests pass (177/177, 9 test files)
- [ ] CI checks pass
- [ ] Manual: `tauri dev` starts board server automatically at port 4800
- [ ] Manual: ⌘6 navigates to Board; ⌘1–⌘5 still work
- [ ] Manual: sidebar appears as distinct frosted-glass layer in light and dark modes

## Notes

CI does not invoke `beforeDevCommand`, so the shell `&` in that field has no impact on builds. z-index safety was verified: all overlays (tooltips: 100, context menus: 200, preferences panel: 50, Board detail panel: 40–50, secrets modal: 100) remain above the sidebar's `zIndex: 30`.