### PR TITLE
fix: close stored XSS, anon RPC, and rate limiting gaps in marketplace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ website/.source/
 # Marketplace
 marketplace/.next/
 marketplace/out/
+*.tsbuildinfo
 
 # Supabase local
 marketplace/supabase/.temp/

--- a/marketplace/app/api/install/route.ts
+++ b/marketplace/app/api/install/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
+import { checkRateLimit, getClientIp } from "@/lib/rate-limit";
 
 function getServiceSupabase() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -30,6 +31,19 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(
       { error: "Missing required field: slug" },
       { status: 400 },
+    );
+  }
+
+  // 5 installs per slug per IP per hour
+  const ip = getClientIp(request);
+  const { allowed, retryAfter } = checkRateLimit(`install:${ip}:${slug}`, {
+    maxRequests: 5,
+    windowMs: 60 * 60 * 1000,
+  });
+  if (!allowed) {
+    return NextResponse.json(
+      { error: "Too many requests" },
+      { status: 429, headers: { "Retry-After": String(retryAfter) } },
     );
   }
 

--- a/marketplace/app/api/register/route.ts
+++ b/marketplace/app/api/register/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
+import { checkRateLimit, getClientIp } from "@/lib/rate-limit";
 
 function getServiceSupabase() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -63,6 +64,19 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(
       { error: "Invalid or missing API key" },
       { status: 401 },
+    );
+  }
+
+  // 10 registrations per hour per IP
+  const ip = getClientIp(request);
+  const { allowed, retryAfter } = checkRateLimit(`register:${ip}`, {
+    maxRequests: 10,
+    windowMs: 60 * 60 * 1000,
+  });
+  if (!allowed) {
+    return NextResponse.json(
+      { error: "Too many requests" },
+      { status: 429, headers: { "Retry-After": String(retryAfter) } },
     );
   }
 

--- a/marketplace/app/api/register/route.ts
+++ b/marketplace/app/api/register/route.ts
@@ -50,6 +50,20 @@ async function fetchGitHubFile(
 }
 
 export async function POST(request: NextRequest) {
+  // Rate limit before auth so brute-force attempts are counted regardless of
+  // whether the key is correct. 10 requests per hour per IP.
+  const ip = getClientIp(request);
+  const { allowed, retryAfter } = checkRateLimit(`register:${ip}`, {
+    maxRequests: 10,
+    windowMs: 60 * 60 * 1000,
+  });
+  if (!allowed) {
+    return NextResponse.json(
+      { error: "Too many requests" },
+      { status: 429, headers: { "Retry-After": String(retryAfter) } },
+    );
+  }
+
   // Require API key for registration to prevent spam
   const apiKey = process.env.REGISTER_API_KEY;
   if (!apiKey) {
@@ -64,19 +78,6 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(
       { error: "Invalid or missing API key" },
       { status: 401 },
-    );
-  }
-
-  // 10 registrations per hour per IP
-  const ip = getClientIp(request);
-  const { allowed, retryAfter } = checkRateLimit(`register:${ip}`, {
-    maxRequests: 10,
-    windowMs: 60 * 60 * 1000,
-  });
-  if (!allowed) {
-    return NextResponse.json(
-      { error: "Too many requests" },
-      { status: 429, headers: { "Retry-After": String(retryAfter) } },
     );
   }
 

--- a/marketplace/app/api/search/route.ts
+++ b/marketplace/app/api/search/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabase } from "@/lib/supabase";
+import { checkRateLimit, getClientIp } from "@/lib/rate-limit";
 
 type SearchType = "component" | "profile";
 
@@ -12,6 +13,19 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(
       { error: "Missing required query parameter: q" },
       { status: 400 },
+    );
+  }
+
+  // 60 searches per minute per IP
+  const ip = getClientIp(request);
+  const { allowed, retryAfter } = checkRateLimit(`search:${ip}`, {
+    maxRequests: 60,
+    windowMs: 60 * 1000,
+  });
+  if (!allowed) {
+    return NextResponse.json(
+      { error: "Too many requests" },
+      { status: 429, headers: { "Retry-After": String(retryAfter) } },
     );
   }
 

--- a/marketplace/app/plugins/[slug]/page.tsx
+++ b/marketplace/app/plugins/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import sanitizeHtml from "sanitize-html";
 import { supabase } from "@/lib/supabase";
 import type { Component, Profile, TrustTier } from "@/lib/types";
 
@@ -19,8 +20,23 @@ function TrustBadge({ tier }: { tier: TrustTier }) {
 }
 
 /**
+ * Allowed tags and attributes for sanitizeHtml.
+ * Permits the Tailwind classes emitted by renderMarkdown while blocking all
+ * event handlers and javascript: URLs.
+ */
+const SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
+  allowedTags: ["h1", "h2", "h3", "h4", "p", "pre", "code", "strong", "a", "li", "ul"],
+  allowedAttributes: {
+    "*": ["class"],
+    a: ["href", "target", "rel"],
+  },
+  allowedSchemes: ["http", "https", "mailto"],
+};
+
+/**
  * Minimal server-side markdown-to-HTML renderer.
- * Content is trusted (from our own Supabase database, not user input).
+ * Output is sanitized via sanitizeHtml before rendering — community plugins
+ * store arbitrary markdown from GitHub repos which is untrusted content.
  */
 function renderMarkdown(md: string): string {
   const html = md
@@ -138,12 +154,11 @@ export default async function PluginDetailPage({
     notFound();
   }
 
-  // Trusted content from our own database -- see renderMarkdown comment above
   const skillHtml = component.skill_md
-    ? renderMarkdown(component.skill_md)
+    ? sanitizeHtml(renderMarkdown(component.skill_md), SANITIZE_OPTIONS)
     : null;
   const readmeHtml = component.readme_md
-    ? renderMarkdown(component.readme_md)
+    ? sanitizeHtml(renderMarkdown(component.readme_md), SANITIZE_OPTIONS)
     : null;
 
   const updatedDate = component.updated_at
@@ -220,7 +235,7 @@ export default async function PluginDetailPage({
             </div>
           )}
 
-          {/* SKILL.md content -- trusted content from our own Supabase database */}
+          {/* SKILL.md content */}
           {skillHtml && (
             <section className="mb-10">
               <h2 className="mb-4 text-xl font-bold">Skill Definition</h2>
@@ -231,7 +246,7 @@ export default async function PluginDetailPage({
             </section>
           )}
 
-          {/* README.md content -- trusted content from our own Supabase database */}
+          {/* README.md content */}
           {readmeHtml && (
             <section className="mb-10">
               <h2 className="mb-4 text-xl font-bold">Documentation</h2>

--- a/marketplace/lib/rate-limit.ts
+++ b/marketplace/lib/rate-limit.ts
@@ -1,0 +1,62 @@
+interface RateLimitEntry {
+  count: number;
+  resetAt: number;
+}
+
+const store = new Map<string, RateLimitEntry>();
+
+export interface RateLimitConfig {
+  /** Maximum number of requests allowed within the window. */
+  maxRequests: number;
+  /** Window duration in milliseconds. */
+  windowMs: number;
+}
+
+/**
+ * In-memory sliding-window rate limiter.
+ *
+ * Keyed by an arbitrary string (e.g. "install:<ip>:<slug>"). Expired entries
+ * are pruned on each call so the Map doesn't grow unbounded.
+ *
+ * NOTE: This is per-process. In a multi-instance deployment use an external
+ * store (Redis / Cloudflare KV). Sufficient for a single-instance launch.
+ */
+export function checkRateLimit(
+  key: string,
+  config: RateLimitConfig,
+): { allowed: boolean; retryAfter?: number } {
+  const now = Date.now();
+
+  // Prune expired entries to prevent memory growth.
+  for (const [k, entry] of store.entries()) {
+    if (entry.resetAt <= now) store.delete(k);
+  }
+
+  const entry = store.get(key);
+
+  if (!entry || entry.resetAt <= now) {
+    store.set(key, { count: 1, resetAt: now + config.windowMs });
+    return { allowed: true };
+  }
+
+  if (entry.count >= config.maxRequests) {
+    return {
+      allowed: false,
+      retryAfter: Math.ceil((entry.resetAt - now) / 1000),
+    };
+  }
+
+  entry.count++;
+  return { allowed: true };
+}
+
+/**
+ * Extract the client IP from a request, preferring Cloudflare headers.
+ */
+export function getClientIp(request: Request): string {
+  return (
+    request.headers.get("cf-connecting-ip") ??
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    "unknown"
+  );
+}

--- a/marketplace/package.json
+++ b/marketplace/package.json
@@ -8,19 +8,21 @@
     "start": "next start"
   },
   "dependencies": {
+    "@harness-kit/shared": "workspace:*",
+    "@supabase/supabase-js": "^2.0.0",
     "next": "^15.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@supabase/supabase-js": "^2.0.0",
-    "@harness-kit/shared": "workspace:*"
+    "sanitize-html": "^2.17.1"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.0.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "typescript": "^5.0.0",
+    "@types/sanitize-html": "^2.16.1",
+    "postcss": "^8.0.0",
     "tailwindcss": "^4.0.0",
-    "@tailwindcss/postcss": "^4.0.0",
-    "postcss": "^8.0.0"
+    "typescript": "^5.0.0"
   }
 }

--- a/marketplace/supabase/migrations/00003_revoke_anon_rpc.sql
+++ b/marketplace/supabase/migrations/00003_revoke_anon_rpc.sql
@@ -1,0 +1,6 @@
+-- Revoke direct RPC access to increment_install_count from unprivileged roles.
+-- The /api/install route uses service_role which bypasses grants and continues
+-- to work. Direct calls via the anon or authenticated key (e.g., from the
+-- Supabase client SDK) are now blocked, preventing install-count manipulation.
+REVOKE EXECUTE ON FUNCTION increment_install_count(text) FROM anon;
+REVOKE EXECUTE ON FUNCTION increment_install_count(text) FROM authenticated;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
+      sanitize-html:
+        specifier: ^2.17.1
+        version: 2.17.1
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.0.0
@@ -215,6 +218,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.0.0
         version: 19.2.3(@types/react@19.2.14)
+      '@types/sanitize-html':
+        specifier: ^2.16.1
+        version: 2.16.1
       postcss:
         specifier: ^8.0.0
         version: 8.5.8
@@ -2165,6 +2171,9 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/sanitize-html@2.16.1':
+    resolution: {integrity: sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==}
+
   '@types/send@0.17.6':
     resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
 
@@ -2620,6 +2629,10 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -2648,8 +2661,21 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
   dompurify@3.3.3:
     resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -2675,8 +2701,16 @@ packages:
   entities@2.2.0:
     resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
 
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   es-define-property@1.0.1:
@@ -2722,6 +2756,10 @@ packages:
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
 
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
@@ -3010,6 +3048,12 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
+  htmlparser2@8.0.2:
+    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -3086,6 +3130,10 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
+    engines: {node: '>=0.10.0'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -3585,6 +3633,9 @@ packages:
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
+  parse-srcset@1.0.2:
+    resolution: {integrity: sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==}
+
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
@@ -3884,6 +3935,9 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sanitize-html@2.17.1:
+    resolution: {integrity: sha512-ehFCW+q1a4CSOWRAdX97BX/6/PDEkCqw7/0JXZAGQV57FQB3YOkTa/rrzHPeJ+Aghy4vZAFfWMYyfxIiB7F/gw==}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -5979,6 +6033,10 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/sanitize-html@2.16.1':
+    dependencies:
+      htmlparser2: 10.1.0
+
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
@@ -6432,6 +6490,8 @@ snapshots:
 
   deep-eql@5.0.2: {}
 
+  deepmerge@4.3.1: {}
+
   depd@2.0.0: {}
 
   dequal@2.0.3: {}
@@ -6450,9 +6510,27 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
   dompurify@3.3.3:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
 
   dunder-proto@1.0.1:
     dependencies:
@@ -6475,7 +6553,11 @@ snapshots:
 
   entities@2.2.0: {}
 
+  entities@4.5.0: {}
+
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   es-define-property@1.0.1: {}
 
@@ -6566,6 +6648,8 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
+
+  escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
 
@@ -6970,6 +7054,20 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
+  htmlparser2@8.0.2:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 4.5.0
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -7034,6 +7132,8 @@ snapshots:
   is-hexadecimal@2.0.1: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-plain-object@5.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -7750,6 +7850,8 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
+  parse-srcset@1.0.2: {}
+
   parse5@8.0.0:
     dependencies:
       entities: 6.0.1
@@ -8131,6 +8233,15 @@ snapshots:
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
+
+  sanitize-html@2.17.1:
+    dependencies:
+      deepmerge: 4.3.1
+      escape-string-regexp: 4.0.0
+      htmlparser2: 8.0.2
+      is-plain-object: 5.0.0
+      parse-srcset: 1.0.2
+      postcss: 8.5.8
 
   saxes@6.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

Pre-launch security hardening for the marketplace backend. Closes three critical/high findings from the security audit: stored XSS via community plugin markdown rendering, unauthenticated RPC access to inflate install counts, and missing rate limiting across all API routes.

## Changes

- **Stored XSS fix** — replaced the raw `dangerouslySetInnerHTML` pipeline with `sanitize-html` (allowlist-based) in `app/plugins/[slug]/page.tsx`. Blocks event handlers, `<script>` tags, `javascript:` URLs, and all other non-allowlisted content while preserving Tailwind classes for styling.
- **Anon RPC lockdown** — `marketplace/supabase/migrations/00003_revoke_anon_rpc.sql` revokes `EXECUTE` on `increment_install_count` from `anon` and `authenticated` roles. Migration already applied to production. The `/api/install` route continues to work via `service_role`.
- **Rate limiting** — new `marketplace/lib/rate-limit.ts`: in-memory sliding-window limiter (Map-based, TTL cleanup). Applied to:
  - `/api/install`: 5 requests per slug per IP per hour
  - `/api/search`: 60 requests per IP per minute
  - `/api/register`: 10 requests per IP per hour
  - All return `429` with `Retry-After` header
- **`.gitignore`** — added `*.tsbuildinfo` (Next.js incremental build artifact)

## Test Plan

- [x] Local tests pass (68 core + 191 desktop = 259 tests)
- [x] `pnpm build:marketplace` passes with no type errors
- [x] XSS vectors verified stripped: `<img onerror>`, `<script>`, `javascript:` href, inline event handlers
- [x] Tailwind classes verified preserved on safe tags
- [x] Rate limiter: allows N requests, returns 429 with correct `Retry-After` on N+1
- [x] Supabase migration applied and confirmed via MCP
- [ ] CI checks pass

## Notes

Used `sanitize-html` instead of `isomorphic-dompurify` (specified in audit plan) — `isomorphic-dompurify` has a known jsdom bundling incompatibility with Next.js App Router where `browser/default-stylesheet.css` can't be resolved from the webpack output. `sanitize-html` is the idiomatic server-side choice and has no DOM dependency.

Rate limiter is in-process (single-instance safe for launch). When traffic grows, swap for Cloudflare rate limiting rules or Upstash — the interface in `rate-limit.ts` is the same either way.

Deferred (follow-up PR): search ilike wildcard sanitization, security headers middleware, Tauri CSP, `.env.example` files, board server CORS fix.