### PR TITLE
feat(research): add /refresh-research skill and source_type tracking

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,8 +19,8 @@
     {
       "name": "research",
       "source": "./research",
-      "description": "Process any source into a structured, compounding knowledge base",
-      "version": "0.3.0",
+      "description": "Process any source into a structured, compounding knowledge base with refresh capability",
+      "version": "0.4.0",
       "author": { "name": "harnessprotocol" },
       "license": "Apache-2.0",
       "category": "research-knowledge",

--- a/plugins/research/.claude-plugin/plugin.json
+++ b/plugins/research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "research",
-  "description": "Process any source into a structured, compounding knowledge base",
-  "version": "0.3.0",
+  "description": "Process any source into a structured, compounding knowledge base with refresh capability",
+  "version": "0.4.0",
   "category": "research-knowledge",
   "tags": ["research", "knowledge-base", "web-scraping", "pdf", "github", "sources"],
   "requires": {

--- a/plugins/research/scripts/rebuild-research-index.py
+++ b/plugins/research/scripts/rebuild-research-index.py
@@ -118,6 +118,10 @@ def scan_synthesis_files() -> list[dict]:
         tags = fm.get("tags", [])
         if isinstance(tags, str):
             tags = [t.strip() for t in tags.split(",")]
+        source_type = fm.get("source_type", "")
+        last_checked = fm.get("last_checked", "")
+        if last_checked:
+            last_checked = str(last_checked)
         synthesis_path = get_relative_synthesis_path(md_file)
 
         rows.append({
@@ -126,6 +130,8 @@ def scan_synthesis_files() -> list[dict]:
             "date": date_str,
             "source": source,
             "tags": tags,
+            "source_type": source_type,
+            "last_checked": last_checked,
             "synthesis": synthesis_path,
             "filepath": md_file,
         })
@@ -141,8 +147,8 @@ def _escape_pipes(s: str) -> str:
 def build_index(rows: list[dict]) -> str:
     lines = [
         "# Research Index\n",
-        "| Name | Category | Date | Source | Tags | Synthesis |",
-        "|------|----------|------|--------|------|-----------|",
+        "| Name | Category | Date | Source | Tags | Type | Last Checked | Synthesis |",
+        "|------|----------|------|--------|------|------|--------------|-----------|",
     ]
     for row in rows:
         name = row["name"]
@@ -150,8 +156,10 @@ def build_index(rows: list[dict]) -> str:
         d = row["date"]
         src = row["source"]
         tags_str = format_tags(row["tags"])
+        stype = row.get("source_type", "")
+        checked = row.get("last_checked", "")
         synth = row["synthesis"]
-        lines.append(f"| {_escape_pipes(name)} | {cat} | {d} | {_escape_pipes(src)} | {tags_str} | {synth} |")
+        lines.append(f"| {_escape_pipes(name)} | {cat} | {d} | {_escape_pipes(src)} | {tags_str} | {stype} | {checked} | {synth} |")
     return "\n".join(lines) + "\n"
 
 

--- a/plugins/research/skills/refresh-research/README.md
+++ b/plugins/research/skills/refresh-research/README.md
@@ -1,0 +1,41 @@
+# /refresh-research
+
+Re-fetch live research sources, detect meaningful changes, and update synthesis files.
+
+## What It Does
+
+Your research corpus ages. GitHub repos get new releases, documentation sites update their APIs, features ship. This skill goes back to refreshable sources (repos and docs — not blogs or papers), fetches the current state, diffs against what you captured, and surgically updates syntheses.
+
+Raw sources are versioned (new file per fetch, never overwritten). Syntheses are updated in place, preserving your analysis while updating facts.
+
+## Usage
+
+```
+/refresh-research                              # Interactive — show stale entries, pick which to refresh
+/refresh-research research/agent-memory/cognee-architecture.md  # Specific file
+/refresh-research agent-memory                 # All refreshable entries in a category
+/refresh-research --all                        # All refreshable entries
+/refresh-research --stale 14                   # Entries not checked in 14+ days (default: 30)
+/refresh-research --backfill                   # One-time: add source_type to entries missing it
+/refresh-research --audit                      # Dry-run: staleness report, no modifications
+```
+
+## Frontmatter Fields
+
+Three fields added to synthesis YAML frontmatter:
+
+| Field | Values | Purpose |
+|-------|--------|---------|
+| `source_type` | `repo`, `docs`, `blog`, `paper`, `internal`, `video` | Gates refresh eligibility |
+| `last_checked` | `YYYY-MM-DD` | Staleness clock (separate from `date`) |
+| `refresh_status` | `changed`, `unchanged`, `dead-link`, `archived` | Informational |
+
+## Getting Started
+
+1. Run `/refresh-research --audit` to see your corpus staleness
+2. Run `/refresh-research --backfill` to classify sources (one-time)
+3. Run `/refresh-research --stale 30` periodically to keep sources fresh
+
+## Related Skills
+
+- **`/research`** — the primary research workflow. Use it to process new sources into your knowledge base. `/refresh-research` keeps those sources up to date over time.

--- a/plugins/research/skills/refresh-research/SKILL.md
+++ b/plugins/research/skills/refresh-research/SKILL.md
@@ -1,0 +1,401 @@
+---
+name: refresh-research
+description: Use when user invokes /refresh-research to re-fetch refreshable research sources, detect meaningful changes, and update synthesis files. Supports specific files, categories, staleness thresholds, backfill of source_type, and audit-only dry runs.
+dependencies: python>=3.10
+---
+
+# Research Refresh Protocol
+
+## Overview
+
+Re-fetch live research sources (repos, docs), detect meaningful changes since initial capture, and update synthesis files. Raw sources are versioned (never overwritten), syntheses are surgically updated, and INDEX.md is rebuilt.
+
+**Core principles:**
+1. **Only refreshable sources are fetched.** `repo` and `docs` source types. Blogs, papers, videos, and internal docs are static — skip them.
+2. **Raw sources are versioned, never overwritten.** New fetch → new file with today's date.
+3. **Syntheses are updated, not replaced.** Preserve analysis and structure; update facts.
+
+## When to Use
+
+User types `/refresh-research` followed by:
+
+| Invocation | Behavior |
+|------------|----------|
+| *(empty)* | Interactive — show stale entries, let user pick which to refresh |
+| `research/agent-memory/cognee-architecture.md` | Refresh a specific synthesis file |
+| `agent-memory` | All refreshable entries in that category |
+| `--all` | All refreshable entries across all categories |
+| `--stale 14` | Entries not checked in 14+ days (default threshold: 30) |
+| `--backfill` | One-time: add `source_type` to entries missing it |
+| `--audit` | Dry-run: staleness report, no modifications |
+
+Flags can be combined: `/refresh-research agent-memory --stale 7`
+
+## Frontmatter Fields
+
+Three optional fields extend the existing synthesis frontmatter:
+
+```yaml
+---
+tags: [github, memory, open-source]
+date: 2026-02-12              # original research date (unchanged meaning)
+source: https://docs.cognee.ai/
+source_type: docs              # NEW — repo | docs | blog | paper | internal | video
+last_checked: 2026-03-16      # NEW — when last verified against source
+refresh_status: changed        # NEW — changed | unchanged | dead-link | archived
+---
+```
+
+- `source_type` gates refresh eligibility — only `repo` and `docs` are refreshable
+- `last_checked` is the staleness clock (separate from `date` which means "first captured")
+- `refresh_status` is informational only (doesn't gate behavior)
+
+## Source Type Classification Logic
+
+When `source_type` is missing, auto-detect from the `source` URL:
+
+```
+github.com/{owner}/{repo}                  → repo
+contains "docs." or "/docs" or "/api"      → docs
+contains ".io" or ".dev" or ".ai"          → docs (if not a blog path)
+contains "blog" or "medium" or "substack"  → blog
+contains "arxiv" or ".pdf"                 → paper
+starts with "internal" or empty            → internal
+contains "youtube" or "youtu.be"           → video
+else                                       → blog (safe default, not refreshable)
+```
+
+Borderline cases: flag for user confirmation during `--backfill`.
+
+## Workflow (MANDATORY — 8 Steps)
+
+**You MUST follow this order. No skipping steps.**
+
+---
+
+### Step 0: Build Candidate List
+
+Based on invocation mode:
+
+1. **Specific file:** Read that file's frontmatter. If missing `source_type`, auto-detect from URL.
+2. **Category:** Scan all `research/{category}/*.md` files.
+3. **`--all`:** Scan all `research/**/*.md` files (excluding INDEX.md, README.md, etc.).
+4. **`--stale N`:** Scan all, then filter to entries where `last_checked` is missing or older than N days (default 30).
+5. **Empty (interactive):** Scan all, display staleness table, ask user which to refresh.
+6. **`--backfill`:** Jump to Backfill Mode (see below).
+7. **`--audit`:** Jump to Audit Mode (see below).
+
+**Filter to refreshable types:** Only proceed with entries where `source_type` is `repo` or `docs` (auto-detect if missing).
+
+**Display staleness table:**
+
+```
+Refreshable entries:
+| # | File | Source Type | Last Checked | Days Stale | Status |
+|---|------|-------------|-------------|------------|--------|
+| 1 | research/agent-memory/cognee-architecture.md | docs | (never) | 33+ | — |
+| 2 | research/tools/ntfy.md | docs | 2026-03-11 | 5 | unchanged |
+...
+
+N entries eligible for refresh. Proceed with all / pick numbers / cancel?
+```
+
+**Confirm with user before proceeding.** Never auto-refresh without confirmation.
+
+---
+
+### Step 1: Fetch Current Content
+
+For each confirmed entry:
+
+**For `repo` source type:**
+1. Extract `{owner}/{repo}` from the source URL
+2. Fast-path check: `gh api repos/{owner}/{repo} --jq '.pushed_at'`
+   - Compare `pushed_at` with `last_checked`
+   - If no pushes since last check → mark `unchanged`, update `last_checked`, skip
+3. If changed: fetch key content
+   - `gh api repos/{owner}/{repo}/git/trees/HEAD?recursive=1 --jq '[.tree[] | select(.type=="blob") | .path]'`
+   - Identify README, docs/, key .md files (same logic as `/research` Step 1)
+   - Fetch each via `gh api repos/{owner}/{repo}/contents/{path} --jq '.content' | tr -d '\n' | base64 -d`
+   - Also fetch: `gh api repos/{owner}/{repo}/releases?per_page=5` for recent releases
+
+**For `docs` source type:**
+1. Try Context7 first:
+   - `resolve-library-id` with the library/tool name
+   - If resolved: `query-docs` for key topics
+2. If Context7 has no coverage: fall back to WebFetch on the source URL
+3. If 404 or unreachable: mark `refresh_status: dead-link`, update `last_checked`, report to user, skip
+
+**Error handling:**
+- 404 / dead link → mark `dead-link`, preserve synthesis, report
+- Repo archived → mark `archived`, note in Update Log
+- GitHub rate limit → `gh api rate_limit`, report quota, offer to continue or stop
+
+---
+
+### Step 2: Change Detection
+
+For each fetched entry:
+
+1. **Load existing raw source** from `resources/` (find the most recent file matching the topic)
+2. **Structural diff** — compare:
+   - Section headers (H1-H4)
+   - Version numbers (semver patterns)
+   - Key content blocks (feature lists, API endpoints, architecture sections)
+   - For repos: star count, last commit date, release versions
+3. **Classify the change:**
+   - **No changes** → mark `unchanged`, update `last_checked` only, skip Steps 3-6
+   - **Minor update** → version bump, small section additions, typo fixes
+   - **Major update** → new features, architecture changes, breaking changes, significant new content
+
+4. **Report diff summary to user:**
+
+```
+## cognee-architecture.md
+Source: https://docs.cognee.ai/
+Change level: MINOR
+- Version bump: 0.5.0 → 0.6.2
+- New section: "Streaming Pipeline"
+- Updated: "Storage Architecture" (minor wording changes)
+
+Proceed with update? [y/n/skip]
+```
+
+**Wait for user confirmation before modifying any files.**
+
+---
+
+### Step 3: Save New Raw Source (Versioned)
+
+Write fetched content to `resources/` with today's date:
+
+- Format: `resources/[topic]-[type]-YYYY-MM-DD.md`
+- Examples:
+  - `resources/cognee-docs-2026-03-16.md`
+  - `resources/ntfy-readme-2026-03-16.md`
+
+**Rules:**
+- Old raw files are NEVER deleted or overwritten
+- Use the same `[topic]` slug as the original raw source file
+- Include a header comment: `<!-- Refresh fetch: YYYY-MM-DD, previous: resources/[old-filename] -->`
+
+**Verify file exists before continuing:** `ls resources/[filename]`
+
+---
+
+### Step 4: Update Synthesis
+
+Based on change classification:
+
+**Minor changes:**
+- Surgical section updates — find the specific section, update in place
+- Version number bumps in overview/header
+- Add new subsections where content was added upstream
+- Do NOT rewrite existing analysis paragraphs
+
+**Major changes:**
+- Re-synthesize using existing structure as scaffolding
+- Preserve: analysis, opinions, cross-references, Bridge to Technical Work
+- Update: facts, feature lists, architecture descriptions, version info
+- Add new sections for genuinely new content
+
+**Always add an Update Log entry** (before the References section):
+
+```markdown
+### Update Log
+
+- **2026-03-16:** Refreshed from source. Version 0.5.0 → 0.6.2. Added Streaming Pipeline section. Updated storage architecture details. ([raw source](resources/cognee-docs-2026-03-16.md))
+```
+
+If an `### Update Log` section already exists, append to it.
+
+**Update frontmatter:**
+```yaml
+date: 2026-03-16          # update to today
+last_checked: 2026-03-16  # update to today
+refresh_status: changed   # set to changed
+```
+
+Keep `source` and `tags` unchanged unless the refresh reveals new relevant tags.
+
+---
+
+### Step 5: Update References Section
+
+Add the new raw source file to the `## References` → `### Raw Sources` list:
+
+```markdown
+- `resources/cognee-docs-2026-03-16.md` — Refresh fetch: updated docs content, 2026-03-16
+```
+
+Do NOT remove existing raw source entries — they form the version history.
+
+---
+
+### Step 6: Cross-Reference Check (Lightweight)
+
+**Only for major changes:**
+
+1. Search `research/INDEX.md` and `research/**/*.md` for references to the updated entry
+2. Check if any related syntheses cite outdated facts that this refresh corrected
+3. **Do NOT auto-modify related files** — just flag for user review:
+
+```
+Cross-reference alert:
+- research/agent-memory/membrain-vs-cognee-comparison.md references Cognee v0.5.0
+  → Cognee is now v0.6.2, comparison may need updating
+```
+
+**Skip this step entirely for minor changes.**
+
+---
+
+### Step 7: Rebuild INDEX.md
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/rebuild-research-index.py"
+```
+
+Run from the project root. Expected output: `Rebuilt INDEX.md: N entries`
+
+If the script fails, manually update the row in `research/INDEX.md` for the refreshed entry.
+
+**Do NOT skip this step. It is the final required action.**
+
+---
+
+## Backfill Mode (`--backfill`)
+
+One-time migration: add `source_type` to entries missing it.
+
+1. Scan all `research/**/*.md` files
+2. For each file missing `source_type` in frontmatter:
+   a. Read the `source` field
+   b. Auto-classify using the Source Type Classification Logic above
+   c. Display classification for user review:
+   ```
+   Backfill classifications:
+   | File | Source URL | Detected Type | Confidence |
+   |------|-----------|---------------|------------|
+   | cognee-architecture.md | https://docs.cognee.ai/ | docs | high |
+   | rowboat.md | https://github.com/rowboatlabs/rowboat | repo | high |
+   | agent-memory-landscape-analysis.md | (none) | internal | high |
+   | ai-routing-quick-reference.md | (none) | internal | high |
+   ...
+   ```
+   d. Flag borderline cases (confidence: `low`) for user confirmation
+   e. After user confirms, write `source_type` into each file's frontmatter
+3. Rebuild INDEX.md: `python3 "${CLAUDE_PLUGIN_ROOT}/scripts/rebuild-research-index.py"`
+
+**Backfill does NOT refresh content** — it only adds the `source_type` field.
+
+---
+
+## Audit Mode (`--audit`)
+
+Dry-run staleness report. No files are modified.
+
+1. Scan all `research/**/*.md` files
+2. Classify each by `source_type` (auto-detect if missing)
+3. Calculate staleness from `last_checked` (or `date` if `last_checked` is missing)
+4. Output report:
+
+```
+# Research Freshness Audit — 2026-03-16
+
+## Summary
+- Total synthesis files: 136
+- Refreshable (repo/docs): 59
+- Non-refreshable (blog/paper/internal/video): 77
+- Missing source_type field: 42 (run --backfill to fix)
+
+## Staleness Breakdown
+- Never checked: 59
+- Checked < 7 days ago: 0
+- Checked 7-30 days ago: 0
+- Checked 30+ days ago: 0
+
+## Refreshable Entries by Staleness
+| File | Source Type | Source | Last Checked | Days Stale |
+|------|------------|--------|-------------|------------|
+| cognee-architecture.md | docs | docs.cognee.ai | (never) | 33+ |
+| ntfy.md | docs | ntfy.sh | (never) | 5 |
+...
+
+## Dead Links
+(none detected — run refresh to verify)
+```
+
+---
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| 404 / dead link | Mark `dead-link`, preserve synthesis, report to user |
+| Repo archived | Mark `archived`, note in Update Log, preserve synthesis |
+| GitHub rate limit | `gh api rate_limit`, report quota, offer to continue or stop |
+| No changes detected | Mark `unchanged`, update `last_checked`, report "up to date" |
+| Context7 no coverage | Fall back to WebFetch |
+| Missing `source_type` | Auto-detect from URL, warn about `--backfill` |
+| WebFetch fails | Report error, skip entry, continue with next |
+| Frontmatter parse error | Report file, skip entry, continue with next |
+| No `source` URL in frontmatter | Skip entry (can't refresh without a source), report |
+
+---
+
+## Quick Reference
+
+### Single File Refresh
+1. Read frontmatter → check `source_type` (auto-detect if missing)
+2. Confirm with user
+3. Fetch current content (gh api for repos, Context7/WebFetch for docs)
+4. Compare with existing raw source in `resources/`
+5. Classify: unchanged / minor / major
+6. Report diff summary → wait for confirmation
+7. Save new raw source to `resources/[topic]-[type]-YYYY-MM-DD.md`
+8. Verify raw file exists
+9. Update synthesis (surgical for minor, re-scaffold for major)
+10. Add Update Log entry
+11. Update frontmatter (date, last_checked, refresh_status)
+12. Update References section
+13. Cross-reference check (major changes only)
+14. Rebuild INDEX.md
+
+### Category/All Refresh
+1. Scan files → filter to refreshable → display staleness table
+2. Confirm scope with user
+3. Process each entry through the single-file workflow above
+4. Final summary: N refreshed, N unchanged, N errors
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Overwrote existing raw source file | Always create a NEW file with today's date |
+| Refreshed a blog post or paper | Only `repo` and `docs` are refreshable |
+| Skipped user confirmation | Always show diff summary and wait for confirmation |
+| Replaced synthesis instead of updating | Preserve analysis; update facts only |
+| Deleted old raw source | Never delete — raw sources are the version history |
+| Skipped Step 7 (INDEX rebuild) | Always rebuild INDEX.md after any synthesis update |
+| Auto-modified cross-referenced files | Only FLAG related files — never auto-modify |
+| Used WebFetch for GitHub repos | Use `gh api` for repos — WebFetch is for docs fallback |
+| Refreshed without checking `pushed_at` | Fast-path skip if no pushes since `last_checked` |
+| Skipped `--backfill` warning | If files are missing `source_type`, suggest `--backfill` |
+| Changed `source` URL during refresh | Never change the source URL — it's the canonical reference |
+| Forgot Update Log entry | Every refresh that changes content MUST have an Update Log entry |
+
+---
+
+## Red Flags — STOP and Fix
+
+- About to overwrite an existing raw source file
+- About to refresh a blog, paper, or internal source
+- Modifying synthesis without user confirming the diff summary
+- No raw source saved before updating synthesis
+- Skipped INDEX.md rebuild
+- Auto-editing a file that wasn't the target of the refresh
+- No Update Log entry after a content change
+- `refresh_status` set to `changed` but no actual content updates made

--- a/plugins/research/skills/refresh-research/SKILL.md
+++ b/plugins/research/skills/refresh-research/SKILL.md
@@ -211,10 +211,11 @@ If an `### Update Log` section already exists, append to it.
 
 **Update frontmatter:**
 ```yaml
-date: 2026-03-16          # update to today
 last_checked: 2026-03-16  # update to today
 refresh_status: changed   # set to changed
 ```
+
+Leave `date` unchanged — it records when the topic was first researched, not when it was last refreshed.
 
 Keep `source` and `tags` unchanged unless the refresh reveals new relevant tags.
 
@@ -242,7 +243,7 @@ Do NOT remove existing raw source entries — they form the version history.
 
 ```
 Cross-reference alert:
-- research/agent-memory/membrain-vs-cognee-comparison.md references Cognee v0.5.0
+- research/agent-memory/tool-comparison.md references Cognee v0.5.0
   → Cognee is now v0.6.2, comparison may need updating
 ```
 

--- a/plugins/research/skills/research/README.md
+++ b/plugins/research/skills/research/README.md
@@ -5,7 +5,8 @@ A Claude Code plugin for systematically processing and indexing research materia
 ## Components
 
 - **`/research` skill** — the main workflow. Point it at a source, it extracts, preserves, and synthesizes.
-- **`rebuild-research-index.py`** — regenerates `research/INDEX.md` from synthesis file frontmatter. The skill runs this automatically after each session. You can also run it manually if files get out of sync.
+- **`/refresh-research` skill** — re-fetch refreshable sources (repos, docs), detect changes, and surgically update syntheses. Supports staleness thresholds, backfill, and audit-only dry runs.
+- **`rebuild-research-index.py`** — regenerates `research/INDEX.md` from synthesis file frontmatter. Both skills run this automatically. You can also run it manually if files get out of sync.
 
 ## Requirements
 
@@ -89,6 +90,18 @@ Scans `resources/` and `research/` to find raw files without syntheses, synthese
 python3 "${CLAUDE_PLUGIN_ROOT}/scripts/rebuild-research-index.py"
 ```
 
+### Keep sources fresh
+
+```
+/refresh-research --audit                      # See staleness report (no modifications)
+/refresh-research --backfill                   # One-time: classify sources by type
+/refresh-research --stale 30                   # Refresh entries not checked in 30+ days
+/refresh-research research/agent-memory/cognee.md  # Refresh a specific file
+/refresh-research agent-memory                 # Refresh all in a category
+```
+
+See the [refresh-research README](../refresh-research/README.md) for full details.
+
 ## Output Structure
 
 ```
@@ -97,7 +110,7 @@ your-project/
 │   ├── temporal-docs-2026-03-06.md        # Raw extracted content, preserved verbatim
 │   └── temporal-video-2026-03-06.md       # Raw content from YouTube video
 └── research/
-    ├── INDEX.md                           # Master index — all synthesized research
+    ├── INDEX.md                           # Master index — includes Type and Last Checked columns
     ├── ai-routing/
     │   └── temporal.md                    # One synthesis per topic, updated as sources accumulate
     ├── agent-memory/
@@ -134,6 +147,8 @@ Each synthesis is structured based on content type:
 - **Reference/Directory** (curated lists, tool indexes): what it is, curated contents, directly relevant items, references
 
 The "Bridge to Practical Application" section in non-technical syntheses makes connections explicit — how does this psychological insight or philosophical framework connect to what you're building? If no connection exists, that's stated rather than fabricated.
+
+**Synthesis frontmatter** includes `source_type` (auto-classified: `repo`, `docs`, `blog`, `paper`, `internal`, `video`) to support the `/refresh-research` workflow. After a refresh, `last_checked` and `refresh_status` fields are also present.
 
 **Length targets:** 2-5x the original source, not 200x. The goal is extracted insight, not padded summaries.
 

--- a/plugins/research/skills/research/SKILL.md
+++ b/plugins/research/skills/research/SKILL.md
@@ -349,7 +349,7 @@ Expected output: `Rebuilt INDEX.md: N entries`
 
 If the script fails, fall back to manually appending or updating a row in `research/INDEX.md`:
 ```
-| [Name] | [category] | YYYY-MM-DD | [URL] | `tag1`, `tag2` | `research/[category]/[name].md` |
+| [Name] | [category] | YYYY-MM-DD | [URL] | `tag1`, `tag2` | [source_type] | [last_checked] | `research/[category]/[name].md` |
 ```
 
 **Do NOT skip this step.** It is the final required action of every research protocol run.

--- a/plugins/research/skills/research/SKILL.md
+++ b/plugins/research/skills/research/SKILL.md
@@ -252,11 +252,13 @@ Extract KEY CONCEPTS. Don't invent content.
    tags: [tag1, tag2, tag3]
    date: YYYY-MM-DD
    source: https://original-url
+   source_type: docs
    ---
    ```
    - Tags: lowercase, hyphenated for multi-word (`vector-search`, `open-source`)
    - Target 3–8 tags per entry
    - Reuse existing tags before creating new ones — check INDEX.md tags column for vocabulary
+   - `source_type`: auto-classify from URL — `github.com` → `repo`; contains "docs" or `.io`/`.dev`/`.ai` → `docs`; `arxiv` or `.pdf` → `paper`; `blog`/`medium`/`substack` → `blog`; `youtube`/`youtu.be` → `video`; no URL → `internal`; else → `blog`
 
 **Tag Taxonomy (reuse aggressively):**
 
@@ -322,13 +324,14 @@ Write the synthesis file. It MUST start with a YAML frontmatter block:
 tags: [tag1, tag2, tag3]
 date: YYYY-MM-DD
 source: https://original-url
+source_type: docs
 ---
 
 # Title
 ...
 ```
 
-Tags were determined in Step 4. `date` is the extraction date. `source` is the original URL or path.
+Tags were determined in Step 4. `date` is the extraction date. `source` is the original URL or path. `source_type` was classified in Step 4.
 
 When **updating** an existing synthesis, ensure its frontmatter is present and tags are current — add any new tags the new source warrants.
 


### PR DESCRIPTION
## Summary
Adds a second skill (`/refresh-research`) to the research plugin that re-fetches refreshable sources (repos and docs), detects meaningful changes since initial capture, and surgically updates syntheses. Also adds `source_type` auto-classification to the existing `/research` skill and extends INDEX.md with Type and Last Checked columns.

## Changes
- **New `/refresh-research` skill** — SKILL.md (8-step refresh workflow with backfill, audit, and staleness modes) + README.md (usage docs with Related Skills section)
- **`/research` SKILL.md** — added `source_type: docs` to frontmatter templates in Steps 4 & 7, plus auto-classification one-liner
- **`rebuild-research-index.py`** — extracts `source_type` and `last_checked` from frontmatter; adds Type and Last Checked columns to INDEX.md table
- **`plugin.json`** — version bump 0.3.0 → 0.4.0, description updated to mention refresh capability
- **Plugin README** — added `/refresh-research` to Components, usage section, frontmatter field docs, INDEX.md column note

## Test Plan
- [x] `rebuild-research-index.py --dry-run` runs without errors (0 rows, correct header with new columns)
- [x] No personal workflow references (board, projects.md, knowledge/) in any harness-kit file
- [x] SKILL.md uses `${CLAUDE_PLUGIN_ROOT}` for script paths (not bare `scripts/`)
- [x] Diff between local and harness-kit SKILL.md shows only expected differences (path refs, dependencies frontmatter)
- [ ] CI checks pass

## Notes
- The `/refresh-research` skill was adapted from a local version — stripped of personal workflow extensions and uses plugin-relative paths
- `source_type` classification is added to `/research` so that `/refresh-research` can filter by refreshable types (repo, docs)