### PR TITLE
feat(board): run board server as persistent macOS launchd service

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -150,7 +150,7 @@
       "name": "board",
       "source": "./plugins/board",
       "description": "Lightweight Kanban board with real-time Claude ↔ web UI two-way sync via MCP.",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "author": { "name": "harnessprotocol" },
       "license": "Apache-2.0",
       "category": "productivity",

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ packages/core/dist/
 
 # CLI
 apps/cli/dist/
+
+# Board server
+packages/board-server/dist/

--- a/apps/desktop/src-tauri/build.rs
+++ b/apps/desktop/src-tauri/build.rs
@@ -1,15 +1,3 @@
 fn main() {
-    // Derive repo root: CARGO_MANIFEST_DIR = apps/desktop/src-tauri
-    // 3 parents up reaches the repo root
-    let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let repo_root = manifest_dir
-        .parent().unwrap() // apps/desktop
-        .parent().unwrap() // apps
-        .parent().unwrap(); // repo root
-    let board_server_dir = repo_root.join("packages").join("board-server");
-
-    println!("cargo:rustc-env=BOARD_SERVER_DIR={}", board_server_dir.display());
-    println!("cargo:rerun-if-changed=build.rs");
-
     tauri_build::build()
 }

--- a/apps/desktop/src-tauri/src/board_server.rs
+++ b/apps/desktop/src-tauri/src/board_server.rs
@@ -1,60 +1,17 @@
 use std::net::TcpListener;
-use std::process::{Child, Command};
-use std::sync::Mutex;
 
-const BOARD_SERVER_DIR: &str = env!("BOARD_SERVER_DIR");
 const PORT: u16 = 4800;
 
-pub struct BoardServerState {
-    child: Mutex<Option<Child>>,
-}
+pub struct BoardServerState;
 
 impl BoardServerState {
     pub fn new() -> Self {
-        Self {
-            child: Mutex::new(None),
-        }
+        Self
     }
 
-    pub fn start(&self) {
-        if port_in_use(PORT) {
-            eprintln!("[board-server] port {} already in use — skipping spawn", PORT);
-            return;
-        }
-
-        let dist = std::path::Path::new(BOARD_SERVER_DIR)
-            .join("dist")
-            .join("index.js");
-
-        if !dist.exists() {
-            eprintln!(
-                "[board-server] dist/index.js not found at {:?} — skipping spawn",
-                dist
-            );
-            return;
-        }
-
-        match Command::new("node")
-            .arg(&dist)
-            .current_dir(BOARD_SERVER_DIR)
-            .spawn()
-        {
-            Ok(child) => {
-                eprintln!("[board-server] spawned (pid {})", child.id());
-                *self.child.lock().unwrap() = Some(child);
-            }
-            Err(e) => {
-                eprintln!("[board-server] failed to spawn node: {}", e);
-            }
-        }
-    }
-
-    pub fn stop(&self) {
-        if let Some(mut child) = self.child.lock().unwrap().take() {
-            let _ = child.kill();
-            let _ = child.wait();
-            eprintln!("[board-server] stopped");
-        }
+    /// Returns true if the board server appears to be running.
+    pub fn check(&self) -> bool {
+        port_in_use(PORT)
     }
 }
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -78,15 +78,14 @@ pub fn run() {
         ])
         .setup(|app| {
             let state = app.state::<BoardServerState>();
-            state.start();
+            if state.check() {
+                eprintln!("[board-server] running on :{}", 4800);
+            } else {
+                eprintln!("[board-server] not running — install with: pnpm board:install");
+            }
             Ok(())
         })
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
-        .run(|handle, event| {
-            if let tauri::RunEvent::Exit = event {
-                let state = handle.state::<BoardServerState>();
-                state.stop();
-            }
-        });
+        .run(|_handle, _event| {});
 }

--- a/apps/desktop/src/hooks/__tests__/useBoardServerReady.test.ts
+++ b/apps/desktop/src/hooks/__tests__/useBoardServerReady.test.ts
@@ -19,6 +19,7 @@ describe('useBoardServerReady', () => {
     vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})));
     const { result } = renderHook(() => useBoardServerReady());
     expect(result.current.ready).toBe(false);
+    expect(result.current.timedOut).toBe(false);
   });
 
   it('sets ready=true when /health returns ok', async () => {
@@ -28,6 +29,7 @@ describe('useBoardServerReady', () => {
     await act(async () => { await Promise.resolve(); });
 
     expect(result.current.ready).toBe(true);
+    expect(result.current.timedOut).toBe(false);
     expect(fetch).toHaveBeenCalledWith(HEALTH_URL, expect.objectContaining({ signal: expect.any(AbortSignal) }));
   });
 
@@ -38,6 +40,7 @@ describe('useBoardServerReady', () => {
     await act(async () => { await Promise.resolve(); });
 
     expect(result.current.ready).toBe(false);
+    expect(result.current.timedOut).toBe(false);
   });
 
   it('retries every 2 seconds until server is ready', async () => {
@@ -52,14 +55,17 @@ describe('useBoardServerReady', () => {
     // First call (immediate)
     await act(async () => { await Promise.resolve(); });
     expect(result.current.ready).toBe(false);
+    expect(result.current.timedOut).toBe(false);
 
     // After 2s
     await act(async () => { vi.advanceTimersByTime(2000); await Promise.resolve(); });
     expect(result.current.ready).toBe(false);
+    expect(result.current.timedOut).toBe(false);
 
     // After another 2s — now ok
     await act(async () => { vi.advanceTimersByTime(2000); await Promise.resolve(); });
     expect(result.current.ready).toBe(true);
+    expect(result.current.timedOut).toBe(false);
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
@@ -70,6 +76,7 @@ describe('useBoardServerReady', () => {
     const { result } = renderHook(() => useBoardServerReady());
     await act(async () => { await Promise.resolve(); });
     expect(result.current.ready).toBe(true);
+    expect(result.current.timedOut).toBe(false);
 
     const callCount = fetchMock.mock.calls.length;
     await act(async () => { vi.advanceTimersByTime(10000); await Promise.resolve(); });
@@ -84,5 +91,38 @@ describe('useBoardServerReady', () => {
     unmount();
 
     expect(clearIntervalSpy).toHaveBeenCalled();
+  });
+
+  it('sets timedOut=true after 5 failed polls and stops polling', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('refused'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useBoardServerReady());
+
+    // Poll 1 (immediate)
+    await act(async () => { await Promise.resolve(); });
+    expect(result.current.timedOut).toBe(false);
+
+    // Poll 2
+    await act(async () => { vi.advanceTimersByTime(2000); await Promise.resolve(); });
+    expect(result.current.timedOut).toBe(false);
+
+    // Poll 3
+    await act(async () => { vi.advanceTimersByTime(2000); await Promise.resolve(); });
+    expect(result.current.timedOut).toBe(false);
+
+    // Poll 4
+    await act(async () => { vi.advanceTimersByTime(2000); await Promise.resolve(); });
+    expect(result.current.timedOut).toBe(false);
+
+    // Poll 5 — timedOut flips
+    await act(async () => { vi.advanceTimersByTime(2000); await Promise.resolve(); });
+    expect(result.current.timedOut).toBe(true);
+    expect(result.current.ready).toBe(false);
+
+    const callCount = fetchMock.mock.calls.length;
+    // Polling should stop after timedOut
+    await act(async () => { vi.advanceTimersByTime(10000); await Promise.resolve(); });
+    expect(fetchMock.mock.calls.length).toBe(callCount);
   });
 });

--- a/apps/desktop/src/hooks/useBoardServerReady.ts
+++ b/apps/desktop/src/hooks/useBoardServerReady.ts
@@ -1,5 +1,7 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { BOARD_SERVER_BASE } from '../lib/board-api';
+
+const MAX_POLLS = 5;
 
 function fetchWithTimeout(url: string, ms: number): Promise<Response> {
   const controller = new AbortController();
@@ -7,25 +9,37 @@ function fetchWithTimeout(url: string, ms: number): Promise<Response> {
   return fetch(url, { signal: controller.signal }).finally(() => clearTimeout(timer));
 }
 
-export function useBoardServerReady(): { ready: boolean } {
+export function useBoardServerReady(): { ready: boolean; timedOut: boolean } {
   const [ready, setReady] = useState(false);
+  const [timedOut, setTimedOut] = useState(false);
+  const pollCount = useRef(0);
 
   useEffect(() => {
-    // Once ready, stop polling. The effect re-runs when ready flips true,
-    // which clears the interval via the cleanup return below.
-    if (ready) return;
+    if (ready || timedOut) return;
 
     let mounted = true;
     const check = () => {
       fetchWithTimeout(`${BOARD_SERVER_BASE}/health`, 1500)
-        .then(res => { if (mounted && res.ok) setReady(true); })
-        .catch(() => { /* not yet ready — next poll will retry */ });
+        .then(res => {
+          if (!mounted) return;
+          if (res.ok) {
+            setReady(true);
+          } else {
+            pollCount.current += 1;
+            if (pollCount.current >= MAX_POLLS) setTimedOut(true);
+          }
+        })
+        .catch(() => {
+          if (!mounted) return;
+          pollCount.current += 1;
+          if (pollCount.current >= MAX_POLLS) setTimedOut(true);
+        });
     };
 
     check();
     const id = setInterval(check, 2000);
     return () => { mounted = false; clearInterval(id); };
-  }, [ready]);
+  }, [ready, timedOut]);
 
-  return { ready };
+  return { ready, timedOut };
 }

--- a/apps/desktop/src/pages/board/BoardKanbanPage.tsx
+++ b/apps/desktop/src/pages/board/BoardKanbanPage.tsx
@@ -46,7 +46,7 @@ function resolveTargetStatus(overId: string, allTasks: Task[]): TaskStatus | nul
 export default function BoardKanbanPage() {
   const { slug } = useParams<{ slug: string }>();
   const projectSlug = slug!;
-  const { ready } = useBoardServerReady();
+  const { ready, timedOut } = useBoardServerReady();
   const { project, loading, error, refetch } = useBoardData(projectSlug, ready);
 
   const [activeTask, setActiveTask] = useState<Task | null>(null);
@@ -120,6 +120,30 @@ export default function BoardKanbanPage() {
     if (refreshed) setSelectedTask(refreshed);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [project]);
+
+  if (timedOut) {
+    return (
+      <div className="board-scope" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', flexDirection: 'column', gap: 12 }}>
+        <span style={{ color: 'var(--text-secondary)', fontSize: 14, fontWeight: 600 }}>
+          Board server is not running
+        </span>
+        <span style={{ color: 'var(--text-muted)', fontSize: 13 }}>
+          Install the background service to get started:
+        </span>
+        <code style={{
+          background: 'var(--bg-elevated)',
+          border: '1px solid var(--border)',
+          borderRadius: 6,
+          padding: '8px 16px',
+          fontSize: 13,
+          color: 'var(--text-secondary)',
+          fontFamily: 'monospace',
+        }}>
+          pnpm board:install
+        </code>
+      </div>
+    );
+  }
 
   if (!ready || loading) {
     return (

--- a/apps/desktop/src/pages/board/BoardProjectsPage.tsx
+++ b/apps/desktop/src/pages/board/BoardProjectsPage.tsx
@@ -6,7 +6,7 @@ import { useBoardServerReady } from '../../hooks/useBoardServerReady';
 
 export default function BoardProjectsPage() {
   const navigate = useNavigate();
-  const { ready } = useBoardServerReady();
+  const { ready, timedOut } = useBoardServerReady();
   const [loading, setLoading] = useState(true);
   const [projects, setProjects] = useState<Project[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -32,6 +32,30 @@ export default function BoardProjectsPage() {
         setLoading(false);
       });
   }, [ready, navigate]);
+
+  if (timedOut) {
+    return (
+      <div className="board-scope" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', flexDirection: 'column', gap: 12 }}>
+        <span style={{ color: 'var(--text-secondary)', fontSize: 14, fontWeight: 600 }}>
+          Board server is not running
+        </span>
+        <span style={{ color: 'var(--text-muted)', fontSize: 13 }}>
+          Install the background service to get started:
+        </span>
+        <code style={{
+          background: 'var(--bg-elevated)',
+          border: '1px solid var(--border)',
+          borderRadius: 6,
+          padding: '8px 16px',
+          fontSize: 13,
+          color: 'var(--text-secondary)',
+          fontFamily: 'monospace',
+        }}>
+          pnpm board:install
+        </code>
+      </div>
+    );
+  }
 
   if (!ready || loading) {
     return (

--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
     "build": "pnpm -r build",
     "build:core": "pnpm --filter @harness-kit/core build",
     "build:cli": "pnpm --filter @harness-kit/cli build",
-    "test:core": "pnpm --filter @harness-kit/core test"
+    "test:core": "pnpm --filter @harness-kit/core test",
+    "board:install": "pnpm --filter board-server launchd:install",
+    "board:uninstall": "pnpm --filter board-server launchd:uninstall",
+    "board:status": "pnpm --filter board-server launchd:status",
+    "board:logs": "pnpm --filter board-server launchd:logs",
+    "board:restart": "pnpm --filter board-server launchd:restart"
   }
 }

--- a/packages/board-server/launchd/com.harness-kit.board-server.plist
+++ b/packages/board-server/launchd/com.harness-kit.board-server.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.harness-kit.board-server</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>__NODE_PATH__</string>
+    <string>__SERVER_DIR__/dist/index.js</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>__SERVER_DIR__</string>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+
+  <key>ThrottleInterval</key>
+  <integer>5</integer>
+
+  <key>StandardOutPath</key>
+  <string>__LOG_DIR__/board-server.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>__LOG_DIR__/board-server.log</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>BOARD_PORT</key>
+    <string>4800</string>
+  </dict>
+</dict>
+</plist>

--- a/packages/board-server/package.json
+++ b/packages/board-server/package.json
@@ -8,7 +8,12 @@
     "build": "tsc",
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
-    "mcp": "tsx src/mcp/server.ts"
+    "mcp": "tsx src/mcp/server.ts",
+    "launchd:install": "bash scripts/launchd-ctl.sh install",
+    "launchd:uninstall": "bash scripts/launchd-ctl.sh uninstall",
+    "launchd:status": "bash scripts/launchd-ctl.sh status",
+    "launchd:logs": "bash scripts/launchd-ctl.sh logs",
+    "launchd:restart": "bash scripts/launchd-ctl.sh restart"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/board-server/scripts/launchd-ctl.sh
+++ b/packages/board-server/scripts/launchd-ctl.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# launchd-ctl.sh — manage the board-server launchd Launch Agent
+set -euo pipefail
+
+LABEL="com.harness-kit.board-server"
+PLIST_NAME="${LABEL}.plist"
+LAUNCH_AGENTS_DIR="${HOME}/Library/LaunchAgents"
+PLIST_DEST="${LAUNCH_AGENTS_DIR}/${PLIST_NAME}"
+PLIST_TEMPLATE="$(cd "$(dirname "$0")/../launchd" && pwd)/${PLIST_NAME}"
+LOG_DIR="${HOME}/.harness-kit"
+BOARD_PORT="${BOARD_PORT:-4800}"
+
+# Validate BOARD_PORT is a plain integer to prevent URL injection in curl calls
+if ! [[ "$BOARD_PORT" =~ ^[0-9]+$ ]]; then
+  echo "Error: BOARD_PORT must be a number, got: ${BOARD_PORT}" >&2
+  exit 1
+fi
+
+# Resolve the board-server package directory (2 levels up from scripts/)
+SERVER_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Cache UID once to avoid repeated id -u calls and TOCTOU window
+GUI_DOMAIN="gui/$(id -u)"
+
+cmd="${1:-help}"
+
+usage() {
+  echo "Usage: launchd-ctl.sh <install|uninstall|status|logs|restart>"
+  echo ""
+  echo "  install    Register and start the board-server Launch Agent"
+  echo "  uninstall  Stop and remove the Launch Agent"
+  echo "  status     Show service status and health"
+  echo "  logs       Tail the board-server log"
+  echo "  restart    Restart the service"
+}
+
+install_service() {
+  local node_path
+  node_path="$(which node 2>/dev/null || true)"
+  if [[ -z "$node_path" ]]; then
+    echo "Error: node not found in PATH. Install Node.js and ensure it is on your PATH." >&2
+    exit 1
+  fi
+
+  if [[ ! -f "${SERVER_DIR}/dist/index.js" ]]; then
+    echo "Error: dist/index.js not found at ${SERVER_DIR}/dist/index.js" >&2
+    echo "Run 'pnpm build:board-server' first." >&2
+    exit 1
+  fi
+
+  mkdir -p "${LAUNCH_AGENTS_DIR}"
+  mkdir -p "${LOG_DIR}"
+
+  # Substitute placeholders — use python3 for safe literal replacement
+  # (avoids sed delimiter injection if paths contain special characters)
+  python3 -c "
+import sys
+t = open(sys.argv[1]).read()
+t = t.replace('__NODE_PATH__', sys.argv[2])
+t = t.replace('__SERVER_DIR__', sys.argv[3])
+t = t.replace('__LOG_DIR__', sys.argv[4])
+sys.stdout.write(t)
+" "$PLIST_TEMPLATE" "$node_path" "$SERVER_DIR" "$LOG_DIR" > "$PLIST_DEST"
+
+  echo "Installed plist to ${PLIST_DEST}"
+
+  # Bootstrap the service
+  launchctl bootstrap "${GUI_DOMAIN}" "${PLIST_DEST}" 2>/dev/null || true
+  launchctl enable "${GUI_DOMAIN}/${LABEL}" 2>/dev/null || true
+  launchctl kickstart "${GUI_DOMAIN}/${LABEL}" 2>/dev/null || true
+
+  echo "Service started. Waiting for health check..."
+  for i in $(seq 1 20); do
+    if curl -sf "http://localhost:${BOARD_PORT}/health" > /dev/null 2>&1; then
+      echo "Board server is running on :${BOARD_PORT}"
+      exit 0
+    fi
+    sleep 0.5
+  done
+  echo "Warning: health check timed out — check logs with: launchd-ctl.sh logs"
+}
+
+uninstall_service() {
+  if launchctl print "${GUI_DOMAIN}/${LABEL}" > /dev/null 2>&1; then
+    launchctl bootout "${GUI_DOMAIN}/${LABEL}" 2>/dev/null || true
+    echo "Service stopped."
+  fi
+  if [[ -f "${PLIST_DEST}" ]]; then
+    rm "${PLIST_DEST}"
+    echo "Removed ${PLIST_DEST}"
+  else
+    echo "Plist not found — nothing to remove."
+  fi
+}
+
+status_service() {
+  echo "=== launchctl ==="
+  launchctl print "${GUI_DOMAIN}/${LABEL}" 2>/dev/null || echo "(not loaded)"
+  echo ""
+  echo "=== health ==="
+  if curl -sf "http://localhost:${BOARD_PORT}/health" > /dev/null 2>&1; then
+    curl -s "http://localhost:${BOARD_PORT}/health"
+    echo ""
+  else
+    echo "Not responding on :${BOARD_PORT}"
+  fi
+}
+
+logs_service() {
+  local log_file="${LOG_DIR}/board-server.log"
+  if [[ -f "$log_file" ]]; then
+    tail -f "$log_file"
+  else
+    echo "Log file not found: $log_file"
+    echo "Has the service been installed and run yet?"
+    exit 1
+  fi
+}
+
+restart_service() {
+  launchctl kickstart -k "${GUI_DOMAIN}/${LABEL}"
+  echo "Restarted ${LABEL}"
+}
+
+case "$cmd" in
+  install)   install_service ;;
+  uninstall) uninstall_service ;;
+  status)    status_service ;;
+  logs)      logs_service ;;
+  restart)   restart_service ;;
+  help|--help|-h) usage ;;
+  *) echo "Unknown command: $cmd"; usage; exit 1 ;;
+esac

--- a/packages/board-server/src/index.ts
+++ b/packages/board-server/src/index.ts
@@ -6,6 +6,16 @@ const PORT = Number(process.env.BOARD_PORT ?? 4800);
 
 const app = createHttpApp();
 const httpServer = http.createServer(app);
+
+// Register before WsHub so this listener fires before ws re-emits on WebSocketServer
+httpServer.on('error', (err: NodeJS.ErrnoException) => {
+  if (err.code === 'EADDRINUSE') {
+    console.error(`[board-server] port ${PORT} already in use — exiting cleanly`);
+    process.exit(0); // Clean exit so launchd KeepAlive does NOT restart
+  }
+  throw err;
+});
+
 const hub = new WsHub(httpServer);
 
 httpServer.listen(PORT, () => {

--- a/plugins/board/.claude-plugin/plugin.json
+++ b/plugins/board/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "board",
   "description": "Harness Board — a lightweight Kanban board with real-time Claude ↔ web UI two-way sync",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "category": "productivity",
   "tags": ["kanban", "tasks", "project-management", "mcp", "board"],
   "mcp": {

--- a/plugins/board/scripts/start-board.sh
+++ b/plugins/board/scripts/start-board.sh
@@ -1,26 +1,25 @@
 #!/usr/bin/env bash
-# start-board.sh — Start the Harness Board server if not running, then open the UI
+# start-board.sh — Open the board UI (board server runs as a launchd service)
 set -euo pipefail
 
 BOARD_PORT="${BOARD_PORT:-4800}"
 BOARD_UI_PORT="${BOARD_UI_PORT:-3002}"
-SERVER_DIR="$(cd "$(dirname "$0")/../../../packages/board-server" && pwd)"
 
 # Check if server is already running
 if curl -sf "http://localhost:${BOARD_PORT}/health" > /dev/null 2>&1; then
-  echo "Board server already running on :${BOARD_PORT}"
+  echo "Board server running on :${BOARD_PORT}"
 else
-  echo "Starting board server on :${BOARD_PORT}..."
-  cd "$SERVER_DIR"
-  node dist/index.js &
-  # Wait up to 5 seconds for server to come up
-  for i in $(seq 1 10); do
-    if curl -sf "http://localhost:${BOARD_PORT}/health" > /dev/null 2>&1; then
-      echo "Board server ready"
-      break
-    fi
-    sleep 0.5
-  done
+  echo ""
+  echo "Board server is not running on :${BOARD_PORT}."
+  echo ""
+  echo "To install it as a persistent background service (starts at login):"
+  echo ""
+  echo "  pnpm board:install"
+  echo ""
+  echo "This registers a macOS Launch Agent that runs automatically and restarts"
+  echo "on crash. Run it once — it will persist across reboots."
+  echo ""
+  exit 1
 fi
 
 # Open the board UI in the default browser

--- a/plugins/board/skills/board/SKILL.md
+++ b/plugins/board/skills/board/SKILL.md
@@ -26,10 +26,11 @@ A lightweight Kanban board with real-time two-way sync between Claude and a web 
 ## Usage Patterns
 
 ### `/board` — Open the board UI
-Start the board server if not running, then open the web UI:
+Open the board web UI (requires the board server to be running as a background service):
 ```bash
 bash ${CLAUDE_PLUGIN_ROOT}/scripts/start-board.sh
 ```
+If the server is not running, the script prints instructions to install it as a persistent launchd service with `pnpm board:install`.
 
 ### `/board create <title>` — Create a task
 1. Call `list_tasks` to find the active project and epic


### PR DESCRIPTION
## Summary

The board server was previously spawned by the Tauri desktop app, which meant it was unavailable when the app was closed (breaking MCP tools) and had a cold-start delay on every app launch. macOS GUI apps also don't inherit the shell PATH, so `node` was never found when opening from Finder or Raycast.

This PR moves the board server to a macOS launchd Launch Agent — always on, starts at login, restarts on crash, fully independent of the desktop app.

## Changes

**Board server infrastructure**
- `packages/board-server/launchd/com.harness-kit.board-server.plist` — new launchd plist template with `__NODE_PATH__`, `__SERVER_DIR__`, `__LOG_DIR__` placeholder tokens
- `packages/board-server/scripts/launchd-ctl.sh` — lifecycle script: `install`, `uninstall`, `status`, `logs`, `restart`
- `packages/board-server/package.json` + root `package.json` — `board:install`, `board:uninstall`, `board:status`, `board:logs`, `board:restart` scripts
- `packages/board-server/src/index.ts` — EADDRINUSE handler registered **before** `new WsHub()` so it fires before ws re-emits on WebSocketServer; exits with code 0 (no launchd restart loop)

**Rust desktop app (simplified)**
- `build.rs` — removed `BOARD_SERVER_DIR` env injection (no longer referenced)
- `board_server.rs` — stripped to a zero-state struct with `check() -> bool`; no more `Child`, `Command`, `Mutex`
- `lib.rs` — `.setup()` logs whether server is running; `.run()` empty closure (no more child kill on exit)

**Frontend UX**
- `useBoardServerReady.ts` — adds `timedOut: boolean`, flips after 5 failed polls (~10s), stops polling
- `BoardProjectsPage.tsx` + `BoardKanbanPage.tsx` — show "Board server is not running / `pnpm board:install`" when timed out, "Connecting..." while polling
- `useBoardServerReady.test.ts` — `timedOut: false` assertions on all happy-path tests; new test: `timedOut=true` after 5 rejections and polling stops

**Security hardening in launchd-ctl.sh**
- Replaced `sed` delimiter substitution with `python3` literal replace (avoids injection if node path contains `|` or `/`)
- Added `BOARD_PORT` numeric guard to prevent URL injection in `curl` calls
- Cached `GUI_DOMAIN="gui/$(id -u)"` once instead of calling `id -u` on every `launchctl` invocation

**Other**
- `plugins/board/scripts/start-board.sh` — no longer spawns `node &`; prints `pnpm board:install` instructions if server not running
- `plugins/board/skills/board/SKILL.md` — updated `/board` description to reflect persistent service model
- `.gitignore` — added `packages/board-server/dist/`

## Test Plan

- [x] `pnpm build:board-server` — TypeScript compiles clean
- [x] `pnpm --filter harness-kit-desktop test` — 192/192 pass
- [x] `cargo check` — Rust compiles without `BOARD_SERVER_DIR` errors
- [x] `pnpm board:install` — plist installed, service starts, `/health` returns ok
- [x] `pnpm board:status` — shows `state = running`, `active count = 1`, health ok
- [x] `pnpm board:restart` — restarts cleanly, health ok after
- [x] `pnpm board:uninstall` — service stops, plist removed, port 4800 goes dark
- [x] Second `node dist/index.js` attempt while service running — prints "port already in use", exits 0 (no launchd restart loop)
- [x] Security: python3 substitution verified working; BOARD_PORT guard in place

## Notes

- macOS only — the launchd path is explicit. Linux users of the board server can still run it directly with `pnpm start`.
- The `KeepAlive.SuccessfulExit = false` in the plist means launchd only restarts on non-zero exits (crashes), not on the clean EADDRINUSE exit.
- The desktop app no longer manages the board server lifecycle at all — it only checks the port on startup and logs a hint if the service isn't installed.