### PR TITLE
feat(desktop): design polish round 2 — title bar, comparator layout, observatory charts, permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@
 - **Desktop: Docs link** — sidebar footer now includes a persistent link to harnesskit.ai/docs (opens in external browser).
 - **Desktop: Draggable sidebar resize** — sidebar width is adjustable by dragging and persists across sessions (160–320px range).
 - **Desktop: Muted accent colors** — 5 new accent presets: Slate, Sage, Stone, Mauve, Steel.
+- **Desktop: Custom title bar** — macOS overlay title bar with collapsible sidebar toggle and back/forward navigation. Traffic lights overlay the web content; the entire bar is a drag region. Keyboard shortcuts: `Cmd+\` toggles the sidebar, `Cmd+[` navigates back, `Cmd+]` navigates forward. Sidebar collapsed state persists across sessions.
+- **Desktop: Comparator two-column layout** — setup form now fills available width in a responsive two-column grid (harness selector + directory on the left, prompt on the right). Maximum concurrent harnesses raised from 3 to 4.
 
 ### Changed
 
+- **Desktop: Observatory typography** — stat and chart card headers use `font-variant-caps: all-small-caps` instead of `text-transform: uppercase`, matching the sidebar and other labels. Area chart fill gradients are subtler (top stop halved); grid lines use `--separator` instead of `--border-base` so data pops more.
+- **Desktop: Permissions layout** — Tools, Paths, and Network sections merged into a single unified card with inset section dividers. Allow/Deny/Ask tool rows are stacked vertically with color-coded labels. Preset cards display a colored left border (green for Strict, blue for Standard, amber for Permissive) for at-a-glance identity.
 - Renamed `stage` plugin to `capture-session` for clarity — the slash command is now `/capture-session`. The staging file (`session-staging.md`) keeps its name.
 
 ---

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -13,14 +13,15 @@
     "withGlobalTauri": false,
     "windows": [
       {
-        "title": "Harness Kit",
+        "title": "",
         "width": 1200,
         "height": 800,
         "minWidth": 900,
         "minHeight": 600,
         "resizable": true,
         "fullscreen": false,
-        "decorations": true
+        "decorations": true,
+        "titleBarStyle": "Overlay"
       }
     ],
     "security": {

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -46,23 +46,23 @@
 }
 
 .dark {
-  /* Backgrounds */
-  --bg-base: #1c1c1e;
-  --bg-surface: #242426;
-  --bg-elevated: #2c2c2e;
-  --bg-sidebar: rgba(44, 44, 48, 0.78);
-  --bg-sidebar-solid: #1e1e20;
+  /* Backgrounds — warm-tinted (computed from oklch hue 55, chroma 0.006) */
+  --bg-base: #211f1c;
+  --bg-surface: #282622;
+  --bg-elevated: #322f2a;
+  --bg-sidebar: rgba(40, 38, 34, 0.78);
+  --bg-sidebar-solid: #23211d;
 
-  /* Foregrounds */
-  --fg-base: #f2f2f7;
-  --fg-muted: #98989f;
-  --fg-subtle: #636366;
-  --fg-placeholder: #48484a;
+  /* Foregrounds — warm shift */
+  --fg-base: #f2f1ed;
+  --fg-muted: #9a9590;
+  --fg-subtle: #6e6a64;
+  --fg-placeholder: #504d49;
 
-  /* Borders */
-  --border-base: rgba(255, 255, 255, 0.09);
-  --border-strong: rgba(255, 255, 255, 0.15);
-  --separator: rgba(255, 255, 255, 0.07);
+  /* Borders — warm off-white base */
+  --border-base: rgba(255, 248, 230, 0.09);
+  --border-strong: rgba(255, 248, 230, 0.15);
+  --separator: rgba(255, 248, 230, 0.07);
 
   /* Accent */
   --accent: #7b72f0;
@@ -70,9 +70,9 @@
   --accent-fg: #9d96f5;
   --accent-text: #9d96f5;
 
-  /* Interactive hover */
-  --hover-bg: rgba(255, 255, 255, 0.05);
-  --active-bg: rgba(255, 255, 255, 0.09);
+  /* Interactive hover — warm tint */
+  --hover-bg: rgba(255, 248, 230, 0.05);
+  --active-bg: rgba(255, 248, 230, 0.09);
 
   /* Shadows — stronger in dark mode */
   --shadow-sm: 0 1px 3px rgba(0,0,0,0.30), 0 1px 2px rgba(0,0,0,0.20);
@@ -161,7 +161,7 @@ body {
   border-radius: 3px;
 }
 .dark ::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.18);
+  background: rgba(255, 248, 230, 0.18);
 }
 
 /* ── Typography helpers ── */
@@ -220,9 +220,10 @@ body {
 }
 
 .sidebar-item.active {
-  background: var(--accent-light);
+  background: transparent;
   color: var(--accent-text);
   font-weight: 500;
+  box-shadow: inset 2px 0 0 var(--accent-text);
 }
 
 .sidebar-subitem {
@@ -248,6 +249,7 @@ body {
   background: var(--accent-light);
   color: var(--accent-text);
   font-weight: 500;
+  box-shadow: inset 2px 0 0 var(--accent-text);
 }
 
 /* ── Row list (macOS-style) ── */
@@ -575,6 +577,47 @@ body {
 
 .harness-card.at-max {
   cursor: not-allowed;
+}
+
+.preset-card {
+  transition: transform 0.15s cubic-bezier(0.25, 1, 0.5, 1),
+              border-color 0.15s cubic-bezier(0.25, 1, 0.5, 1),
+              box-shadow 0.15s cubic-bezier(0.25, 1, 0.5, 1);
+}
+.preset-card:hover {
+  transform: translateY(-1px);
+  border-color: var(--border-strong);
+  box-shadow: var(--shadow-sm);
+}
+
+/* ── Title bar ── */
+.titlebar {
+  height: 38px;
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  -webkit-app-region: drag;
+}
+
+.titlebar-btn {
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: none;
+  color: var(--fg-subtle);
+  cursor: pointer;
+  border-radius: 4px;
+  -webkit-app-region: no-drag;
+  padding: 0;
+  flex-shrink: 0;
+}
+
+.titlebar-btn:hover {
+  background: var(--hover-bg);
+  color: var(--fg-base);
 }
 
 /* ── Form elements ── */

--- a/apps/desktop/src/components/comparator/HarnessSelector.tsx
+++ b/apps/desktop/src/components/comparator/HarnessSelector.tsx
@@ -32,7 +32,7 @@ export default function HarnessSelector({
         const isSelected = selectedIds.has(h.id);
         const sel = selected.find((s) => s.harnessId === h.id);
         const models = MODEL_OPTIONS[h.id] || [];
-        const atMax = selected.length >= 3 && !isSelected;
+        const atMax = selected.length >= 4 && !isSelected;
 
         const cardClass = [
           "harness-card",

--- a/apps/desktop/src/hooks/useGlobalShortcuts.ts
+++ b/apps/desktop/src/hooks/useGlobalShortcuts.ts
@@ -12,9 +12,10 @@ export const NAV_PATHS = [
 
 interface Options {
   navigate: NavigateFunction;
+  toggleSidebar?: () => void;
 }
 
-export function useGlobalShortcuts({ navigate }: Options) {
+export function useGlobalShortcuts({ navigate, toggleSidebar }: Options) {
   useEffect(() => {
     function onKeyDown(e: KeyboardEvent) {
       if (!e.metaKey) return;
@@ -23,6 +24,27 @@ export function useGlobalShortcuts({ navigate }: Options) {
       if (e.key === ",") {
         e.preventDefault();
         navigate("/preferences");
+        return;
+      }
+
+      // ⌘\ or ⌘B — toggle sidebar
+      if (e.key === "\\" || e.key === "b") {
+        e.preventDefault();
+        toggleSidebar?.();
+        return;
+      }
+
+      // ⌘[ — navigate back
+      if (e.key === "[") {
+        e.preventDefault();
+        navigate(-1);
+        return;
+      }
+
+      // ⌘] — navigate forward
+      if (e.key === "]") {
+        e.preventDefault();
+        navigate(1);
         return;
       }
 
@@ -36,5 +58,5 @@ export function useGlobalShortcuts({ navigate }: Options) {
 
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
-  }, [navigate]);
+  }, [navigate, toggleSidebar]);
 }

--- a/apps/desktop/src/hooks/useGlobalShortcuts.ts
+++ b/apps/desktop/src/hooks/useGlobalShortcuts.ts
@@ -27,8 +27,8 @@ export function useGlobalShortcuts({ navigate, toggleSidebar }: Options) {
         return;
       }
 
-      // ⌘\ or ⌘B — toggle sidebar
-      if (e.key === "\\" || e.key === "b") {
+      // ⌘\ — toggle sidebar
+      if (e.key === "\\") {
         e.preventDefault();
         toggleSidebar?.();
         return;

--- a/apps/desktop/src/layouts/AppLayout.tsx
+++ b/apps/desktop/src/layouts/AppLayout.tsx
@@ -1,5 +1,5 @@
 import { Outlet, NavLink, useLocation, useNavigate } from "react-router-dom";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { open } from "@tauri-apps/plugin-shell";
 import { useGlobalShortcuts } from "../hooks/useGlobalShortcuts";
 import { useArrowNavigation } from "../hooks/useArrowNavigation";
@@ -99,7 +99,19 @@ export default function AppLayout() {
   const location = useLocation();
   const navigate = useNavigate();
 
-  useGlobalShortcuts({ navigate });
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
+    try { return localStorage.getItem("sidebar-collapsed") === "true"; } catch { return false; }
+  });
+
+  const toggleSidebar = useCallback(() => {
+    setSidebarCollapsed((v) => {
+      const next = !v;
+      try { localStorage.setItem("sidebar-collapsed", String(next)); } catch {}
+      return next;
+    });
+  }, []);
+
+  useGlobalShortcuts({ navigate, toggleSidebar });
   const { onMouseDown: onResizeMouseDown } = useSidebarResize();
 
   const [hiddenSections, setHiddenSectionsState] = useState(getHiddenSections);
@@ -127,133 +139,173 @@ export default function AppLayout() {
 
   return (
     <div
-      className="flex h-screen overflow-hidden"
+      className="flex flex-col h-screen overflow-hidden"
       style={{ background: "var(--bg-base)", color: "var(--fg-base)" }}
     >
-      {/* Sidebar */}
-      <aside
-        className="flex flex-col shrink-0 overflow-y-auto"
+      {/* Title bar */}
+      <div
+        className="titlebar"
         style={{
-          width: "var(--sidebar-width)",
+          paddingLeft: "78px",
+          gap: "4px",
           background: "var(--bg-sidebar)",
           backdropFilter: "blur(20px)",
           WebkitBackdropFilter: "blur(20px)",
-          borderRight: "1px solid var(--border-base)",
-          position: "fixed",
-          top: 0,
-          left: 0,
-          bottom: 0,
-          zIndex: 30,
+          borderBottom: "1px solid var(--separator)",
         }}
       >
-        {/* App name */}
+        <button className="titlebar-btn" onClick={toggleSidebar} title="Toggle sidebar (⌘\)">
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+            <rect x="1" y="1" width="14" height="14" rx="2" />
+            <line x1="5" y1="1" x2="5" y2="15" />
+          </svg>
+        </button>
+        <button className="titlebar-btn" onClick={() => navigate(-1)} title="Back (⌘[)">
+          <svg width="14" height="14" viewBox="0 0 20 20" fill="currentColor">
+            <path fillRule="evenodd" d="M12.79 5.23a.75.75 0 01-.02 1.06L8.832 10l3.938 3.71a.75.75 0 11-1.04 1.08l-4.5-4.25a.75.75 0 010-1.08l4.5-4.25a.75.75 0 011.06.02z" clipRule="evenodd" />
+          </svg>
+        </button>
+        <button className="titlebar-btn" onClick={() => navigate(1)} title="Forward (⌘])">
+          <svg width="14" height="14" viewBox="0 0 20 20" fill="currentColor">
+            <path fillRule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clipRule="evenodd" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Content area: sidebar + main */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Sidebar wrapper — controls collapse animation */}
         <div
-          className="flex items-center px-4"
-          style={{ height: "44px", borderBottom: "1px solid var(--separator)" }}
-        >
-          <span style={{ fontSize: "13px", fontWeight: 600, letterSpacing: "-0.1px", color: "var(--fg-base)" }}>
-            harness-kit
-          </span>
-        </div>
-
-        {/* Nav */}
-        <nav className="flex-1 py-2 px-2">
-          {visibleSections.map((section) => {
-            const active = isActive(section);
-            return (
-              <div key={section.id} className="mb-0.5">
-                <NavLink to={section.path} className={`sidebar-item${active ? " active" : ""}`}>
-                  {section.label}
-                </NavLink>
-
-                {active && section.children && (
-                  <SidebarSubnav children={section.children} />
-                )}
-              </div>
-            );
-          })}
-        </nav>
-
-        {/* Docs link — always visible */}
-        <div className="px-2 pb-1">
-          <button
-            onClick={() => open("https://harnesskit.ai/docs")}
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: "6px",
-              width: "100%",
-              padding: "6px 8px",
-              borderRadius: "6px",
-              border: "none",
-              background: "transparent",
-              color: "var(--fg-subtle)",
-              cursor: "pointer",
-              fontSize: "11px",
-              textAlign: "left",
-            }}
-          >
-            <svg width="13" height="13" viewBox="0 0 20 20" fill="currentColor">
-              <path d="M9 4.804A7.968 7.968 0 005.5 4c-1.255 0-2.443.29-3.5.804v10A7.969 7.969 0 015.5 14c1.669 0 3.218.51 4.5 1.385A7.962 7.962 0 0114.5 14c1.255 0 2.443.29 3.5.804v-10A7.968 7.968 0 0014.5 4c-1.255 0-2.443.29-3.5.804V12a1 1 0 11-2 0V4.804z" />
-            </svg>
-            Docs
-            <svg width="9" height="9" viewBox="0 0 20 20" fill="currentColor" style={{ marginLeft: "auto", opacity: 0.5 }}>
-              <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z" />
-              <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z" />
-            </svg>
-          </button>
-        </div>
-
-        {/* Bottom bar: gear button */}
-        <div
-          className="px-2 py-2"
-          style={{ borderTop: "1px solid var(--separator)" }}
-        >
-          <button
-            onClick={() => navigate("/preferences")}
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: "6px",
-              width: "100%",
-              padding: "6px 8px",
-              borderRadius: "6px",
-              border: "none",
-              background: prefsActive ? "var(--accent-light)" : "transparent",
-              color: prefsActive ? "var(--accent-text)" : "var(--fg-subtle)",
-              cursor: "pointer",
-              fontSize: "11px",
-              textAlign: "left",
-            }}
-          >
-            <svg width="13" height="13" viewBox="0 0 20 20" fill="currentColor">
-              <path fillRule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clipRule="evenodd" />
-            </svg>
-            Preferences
-          </button>
-        </div>
-
-        {/* Drag handle for sidebar resize */}
-        <div
-          onMouseDown={onResizeMouseDown}
           style={{
-            position: "absolute",
-            top: 0,
-            right: 0,
-            width: "4px",
-            height: "100%",
-            cursor: "col-resize",
-            zIndex: 40,
+            width: sidebarCollapsed ? 0 : "var(--sidebar-width)",
+            flexShrink: 0,
+            overflow: "hidden",
+            transition: "width 0.15s ease",
+            position: "relative",
           }}
-          onMouseEnter={(e) => (e.currentTarget.style.background = "var(--accent)")}
-          onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
-        />
-      </aside>
+        >
+          <aside
+            className="flex flex-col"
+            style={{
+              width: "var(--sidebar-width)",
+              height: "100%",
+              overflowY: "auto",
+              background: "var(--bg-sidebar)",
+              backdropFilter: "blur(20px)",
+              WebkitBackdropFilter: "blur(20px)",
+              borderRight: "1px solid var(--border-base)",
+            }}
+          >
+            {/* App name */}
+            <div
+              className="flex items-center px-4"
+              style={{ height: "44px", borderBottom: "1px solid var(--separator)" }}
+            >
+              <span style={{ fontSize: "13px", fontWeight: 600, letterSpacing: "-0.1px", color: "var(--fg-base)" }}>
+                harness-kit
+              </span>
+            </div>
 
-      {/* Main content */}
-      <main className="flex-1 overflow-y-auto" style={{ background: "var(--bg-base)", paddingLeft: "var(--sidebar-width)" }}>
-        <Outlet />
-      </main>
+            {/* Nav */}
+            <nav className="flex-1 py-2 px-2">
+              {visibleSections.map((section) => {
+                const active = isActive(section);
+                return (
+                  <div key={section.id} className="mb-0.5">
+                    <NavLink to={section.path} className={`sidebar-item${active ? " active" : ""}`}>
+                      {section.label}
+                    </NavLink>
+
+                    {active && section.children && (
+                      <SidebarSubnav children={section.children} />
+                    )}
+                  </div>
+                );
+              })}
+            </nav>
+
+            {/* Docs link — always visible */}
+            <div className="px-2 pb-1">
+              <button
+                onClick={() => open("https://harnesskit.ai/docs")}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "6px",
+                  width: "100%",
+                  padding: "6px 8px",
+                  borderRadius: "6px",
+                  border: "none",
+                  background: "transparent",
+                  color: "var(--fg-subtle)",
+                  cursor: "pointer",
+                  fontSize: "11px",
+                  textAlign: "left",
+                }}
+              >
+                <svg width="13" height="13" viewBox="0 0 20 20" fill="currentColor">
+                  <path d="M9 4.804A7.968 7.968 0 005.5 4c-1.255 0-2.443.29-3.5.804v10A7.969 7.969 0 015.5 14c1.669 0 3.218.51 4.5 1.385A7.962 7.962 0 0114.5 14c1.255 0 2.443.29 3.5.804v-10A7.968 7.968 0 0014.5 4c-1.255 0-2.443.29-3.5.804V12a1 1 0 11-2 0V4.804z" />
+                </svg>
+                Docs
+                <svg width="9" height="9" viewBox="0 0 20 20" fill="currentColor" style={{ marginLeft: "auto", opacity: 0.5 }}>
+                  <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z" />
+                  <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z" />
+                </svg>
+              </button>
+            </div>
+
+            {/* Bottom bar: gear button */}
+            <div
+              className="px-2 py-2"
+              style={{ borderTop: "1px solid var(--separator)" }}
+            >
+              <button
+                onClick={() => navigate("/preferences")}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "6px",
+                  width: "100%",
+                  padding: "6px 8px",
+                  borderRadius: "6px",
+                  border: "none",
+                  background: prefsActive ? "var(--accent-light)" : "transparent",
+                  color: prefsActive ? "var(--accent-text)" : "var(--fg-subtle)",
+                  cursor: "pointer",
+                  fontSize: "11px",
+                  textAlign: "left",
+                }}
+              >
+                <svg width="13" height="13" viewBox="0 0 20 20" fill="currentColor">
+                  <path fillRule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clipRule="evenodd" />
+                </svg>
+                Preferences
+              </button>
+            </div>
+          </aside>
+
+          {/* Drag handle for sidebar resize */}
+          <div
+            onMouseDown={onResizeMouseDown}
+            style={{
+              position: "absolute",
+              top: 0,
+              right: 0,
+              width: "4px",
+              height: "100%",
+              cursor: "col-resize",
+              zIndex: 40,
+            }}
+            onMouseEnter={(e) => (e.currentTarget.style.background = "var(--accent)")}
+            onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
+          />
+        </div>
+
+        {/* Main content */}
+        <main className="flex-1 overflow-y-auto" style={{ background: "var(--bg-base)" }}>
+          <Outlet />
+        </main>
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/layouts/__tests__/AppLayout.test.tsx
+++ b/apps/desktop/src/layouts/__tests__/AppLayout.test.tsx
@@ -54,11 +54,10 @@ function renderLayout() {
 // ── Tests ─────────────────────────────────────────────────────
 
 describe("sidebar layout — vibrancy regression guard", () => {
-  it("sidebar has position: fixed", () => {
+  it("sidebar is present", () => {
     renderLayout();
     const aside = document.querySelector("aside");
     expect(aside).not.toBeNull();
-    expect(aside!.style.position).toBe("fixed");
   });
 
   it("sidebar has backdropFilter with blur", () => {
@@ -67,10 +66,10 @@ describe("sidebar layout — vibrancy regression guard", () => {
     expect(aside!.style.backdropFilter).toMatch(/blur/);
   });
 
-  it("main content has paddingLeft set to sidebar-width variable", () => {
+  it("sidebar has fixed width equal to sidebar-width variable", () => {
     renderLayout();
-    const main = document.querySelector("main");
-    expect(main!.style.paddingLeft).toBe("var(--sidebar-width)");
+    const aside = document.querySelector("aside");
+    expect(aside!.style.width).toBe("var(--sidebar-width)");
   });
 });
 

--- a/apps/desktop/src/pages/comparator/ComparatorSetupPage.tsx
+++ b/apps/desktop/src/pages/comparator/ComparatorSetupPage.tsx
@@ -81,7 +81,7 @@ export default function ComparatorSetupPage() {
       setSelected((prev) => {
         const exists = prev.find((s) => s.harnessId === harnessId);
         if (exists) return prev.filter((s) => s.harnessId !== harnessId);
-        if (prev.length >= 3) return prev;
+        if (prev.length >= 4) return prev;
         return [...prev, { harnessId, model: MODEL_DEFAULTS[harnessId] || "" }];
       });
     },
@@ -112,7 +112,7 @@ export default function ComparatorSetupPage() {
   const canRun = prompt.trim().length > 0 && selected.length > 0;
 
   return (
-    <div style={{ padding: "20px 24px", maxWidth: "720px" }}>
+    <div style={{ padding: "20px 24px" }}>
       {/* Header */}
       <h1 className="text-title" style={{ margin: "0 0 4px" }}>
         New Comparison
@@ -137,119 +137,128 @@ export default function ComparatorSetupPage() {
         </div>
       )}
 
-      {/* Harness selector */}
-      <div style={{ marginBottom: "24px" }}>
-        <label className="text-label" style={{ display: "block", marginBottom: "8px" }}>
-          Select Tools (1-3)
-        </label>
-        {loading && <p className="text-caption">Detecting available tools...</p>}
-        {error && <p style={{ color: "var(--danger)", fontSize: "12px" }}>{error}</p>}
-        {!loading && <HarnessSelector harnesses={harnesses} selected={selected} onToggle={handleToggle} onModelChange={handleModelChange} />}
-      </div>
+      {/* Two-column form grid */}
+      <div style={{ display: "grid", gridTemplateColumns: "minmax(280px, 2fr) minmax(300px, 3fr)", gap: "32px", alignItems: "start" }}>
+        {/* Left: Harness selector + Working directory */}
+        <div>
+          {/* Harness selector */}
+          <div style={{ marginBottom: "24px" }}>
+            <label className="text-label" style={{ display: "block", marginBottom: "8px" }}>
+              Select Tools (1–4)
+            </label>
+            {loading && <p className="text-caption">Detecting available tools...</p>}
+            {error && <p style={{ color: "var(--danger)", fontSize: "12px" }}>{error}</p>}
+            {!loading && <HarnessSelector harnesses={harnesses} selected={selected} onToggle={handleToggle} onModelChange={handleModelChange} />}
+          </div>
 
-      {/* Working directory */}
-      <div style={{ marginBottom: "24px" }}>
-        <label className="text-label" style={{ display: "block", marginBottom: "8px" }}>
-          Working Directory
-        </label>
-        <input
-          type="text"
-          className="form-input"
-          value={workingDir}
-          onChange={(e) => setWorkingDir(e.target.value)}
-          placeholder="/path/to/project"
-        />
-        <p className="text-caption" style={{ marginTop: "4px" }}>
-          Optional. The directory each tool runs in.
-        </p>
+          {/* Working directory */}
+          <div style={{ marginBottom: "24px" }}>
+            <label className="text-label" style={{ display: "block", marginBottom: "8px" }}>
+              Working Directory
+            </label>
+            <input
+              type="text"
+              className="form-input"
+              value={workingDir}
+              onChange={(e) => setWorkingDir(e.target.value)}
+              placeholder="/path/to/project"
+            />
+            <p className="text-caption" style={{ marginTop: "4px" }}>
+              Optional. The directory each tool runs in.
+            </p>
 
-        {/* Git info */}
-        {gitChecking && (
-          <p className="text-caption" style={{ marginTop: "6px" }}>
-            Checking git status...
-          </p>
-        )}
-        {gitInfo && !gitChecking && (
-          <div style={{ marginTop: "8px" }}>
-            {gitInfo.isGitRepo ? (
-              <div
-                style={{
-                  padding: "8px 12px",
-                  borderRadius: "6px",
-                  background: "var(--bg-surface)",
-                  border: "1px solid var(--border-base)",
-                  fontSize: "11px",
-                }}
-              >
-                <div style={{ display: "flex", alignItems: "center", gap: "8px", marginBottom: "6px" }}>
-                  <span style={{ color: "var(--success)", fontWeight: 600 }}>Git repo</span>
-                  {gitInfo.branch && (
-                    <span style={{ color: "var(--fg-muted)" }}>
-                      branch: <code style={{ fontFamily: "ui-monospace, monospace" }}>{gitInfo.branch}</code>
-                    </span>
-                  )}
-                  {gitInfo.currentCommit && (
-                    <span style={{ color: "var(--fg-subtle)", fontFamily: "ui-monospace, monospace" }}>
-                      {gitInfo.currentCommit.slice(0, 8)}
-                    </span>
-                  )}
-                </div>
-                <label
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: "6px",
-                    cursor: "pointer",
-                    color: "var(--fg-muted)",
-                  }}
-                >
-                  <input
-                    type="checkbox"
-                    checked={pinToCommit}
-                    onChange={(e) => setPinToCommit(e.target.checked)}
-                    style={{ accentColor: "var(--accent)" }}
-                  />
-                  Pin to current commit (each tool runs in an isolated worktree)
-                </label>
-              </div>
-            ) : (
-              <p style={{ fontSize: "11px", color: "var(--fg-subtle)" }}>
-                Not a git repo — tools will share the working directory.
+            {/* Git info */}
+            {gitChecking && (
+              <p className="text-caption" style={{ marginTop: "6px" }}>
+                Checking git status...
               </p>
             )}
+            {gitInfo && !gitChecking && (
+              <div style={{ marginTop: "8px" }}>
+                {gitInfo.isGitRepo ? (
+                  <div
+                    style={{
+                      padding: "8px 12px",
+                      borderRadius: "6px",
+                      background: "var(--bg-surface)",
+                      border: "1px solid var(--border-base)",
+                      fontSize: "11px",
+                    }}
+                  >
+                    <div style={{ display: "flex", alignItems: "center", gap: "8px", marginBottom: "6px" }}>
+                      <span style={{ color: "var(--success)", fontWeight: 600 }}>Git repo</span>
+                      {gitInfo.branch && (
+                        <span style={{ color: "var(--fg-muted)" }}>
+                          branch: <code style={{ fontFamily: "ui-monospace, monospace" }}>{gitInfo.branch}</code>
+                        </span>
+                      )}
+                      {gitInfo.currentCommit && (
+                        <span style={{ color: "var(--fg-subtle)", fontFamily: "ui-monospace, monospace" }}>
+                          {gitInfo.currentCommit.slice(0, 8)}
+                        </span>
+                      )}
+                    </div>
+                    <label
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "6px",
+                        cursor: "pointer",
+                        color: "var(--fg-muted)",
+                      }}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={pinToCommit}
+                        onChange={(e) => setPinToCommit(e.target.checked)}
+                        style={{ accentColor: "var(--accent)" }}
+                      />
+                      Pin to current commit (each tool runs in an isolated worktree)
+                    </label>
+                  </div>
+                ) : (
+                  <p style={{ fontSize: "11px", color: "var(--fg-subtle)" }}>
+                    Not a git repo — tools will share the working directory.
+                  </p>
+                )}
+              </div>
+            )}
           </div>
-        )}
-      </div>
+        </div>
 
-      {/* Prompt */}
-      <div style={{ marginBottom: "24px" }}>
-        <label className="text-label" style={{ display: "block", marginBottom: "8px" }}>
-          Prompt
-        </label>
-        <textarea
-          className="form-textarea"
-          value={prompt}
-          onChange={(e) => setPrompt(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" && e.metaKey && canRun) handleRun();
-          }}
-          placeholder="Enter the prompt to send to each tool..."
-          rows={6}
-        />
-        <p className="text-caption" style={{ marginTop: "4px" }}>
-          Cmd+Enter to run
-        </p>
-      </div>
+        {/* Right: Prompt + Run button */}
+        <div>
+          {/* Prompt */}
+          <div style={{ marginBottom: "24px" }}>
+            <label className="text-label" style={{ display: "block", marginBottom: "8px" }}>
+              Prompt
+            </label>
+            <textarea
+              className="form-textarea"
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && e.metaKey && canRun) handleRun();
+              }}
+              placeholder="Enter the prompt to send to each tool..."
+              rows={6}
+            />
+            <p className="text-caption" style={{ marginTop: "4px" }}>
+              Cmd+Enter to run
+            </p>
+          </div>
 
-      {/* Run button */}
-      <button
-        className="btn btn-primary"
-        onClick={handleRun}
-        disabled={!canRun}
-        style={{ fontSize: "13px", padding: "8px 24px", borderRadius: "8px" }}
-      >
-        Run Comparison
-      </button>
+          {/* Run button */}
+          <button
+            className="btn btn-primary"
+            onClick={handleRun}
+            disabled={!canRun}
+            style={{ fontSize: "13px", padding: "8px 24px", borderRadius: "8px" }}
+          >
+            Run Comparison
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/pages/harness/PluginsPage.tsx
+++ b/apps/desktop/src/pages/harness/PluginsPage.tsx
@@ -24,8 +24,8 @@ function SourceBadge({ marketplace }: { marketplace?: string }) {
     return (
       <span style={{
         fontSize: "10px", fontWeight: 500, padding: "1px 7px", borderRadius: "10px",
-        background: "var(--bg-elevated)", color: "var(--fg-muted)",
-        border: "1px solid var(--border-base)", whiteSpace: "nowrap",
+        background: "rgba(217,119,6,0.10)", color: "var(--warning)",
+        border: "1px solid rgba(217,119,6,0.25)", whiteSpace: "nowrap",
       }}>
         local
       </span>
@@ -35,7 +35,7 @@ function SourceBadge({ marketplace }: { marketplace?: string }) {
     return (
       <span style={{
         fontSize: "10px", fontWeight: 500, padding: "1px 7px", borderRadius: "10px",
-        background: "rgba(59,130,246,0.12)", color: "var(--accent-text)",
+        background: "rgba(59,130,246,0.12)", color: "#3b82f6",
         border: "1px solid rgba(59,130,246,0.25)", whiteSpace: "nowrap",
       }}>
         official
@@ -45,8 +45,8 @@ function SourceBadge({ marketplace }: { marketplace?: string }) {
   return (
     <span style={{
       fontSize: "10px", fontWeight: 500, padding: "1px 7px", borderRadius: "10px",
-      background: "var(--accent-light)", color: "var(--accent-text)",
-      border: "1px solid var(--accent-border, var(--border-base))", whiteSpace: "nowrap",
+      background: "var(--bg-elevated)", color: "var(--fg-muted)",
+      border: "1px solid var(--border-base)", whiteSpace: "nowrap",
     }}>
       {marketplace}
     </span>
@@ -162,8 +162,8 @@ export default function PluginsPage() {
             display: "flex", alignItems: "center", gap: "12px",
             padding: "7px 14px",
             borderBottom: "1px solid var(--border-base)",
-            fontSize: "10px", fontWeight: 600, color: "var(--fg-subtle)",
-            textTransform: "uppercase", letterSpacing: "0.05em",
+            fontSize: "11px", fontWeight: 500, color: "var(--fg-subtle)",
+            fontVariantCaps: "all-small-caps", letterSpacing: "0.03em",
           }}>
             <span style={COL_NAME}>Plugin</span>
             <span style={COL_SOURCE}>Source</span>
@@ -216,7 +216,7 @@ export default function PluginsPage() {
                 </div>
 
                 {/* Version */}
-                <div style={{ ...COL_VERSION, fontFamily: "ui-monospace, monospace", fontSize: "11px" }}>
+                <div style={{ ...COL_VERSION, fontFamily: "ui-monospace, monospace", fontSize: "11px", fontVariantNumeric: "tabular-nums" }}>
                   {update ? (
                     <span>
                       <span style={{ color: "var(--fg-subtle)", textDecoration: "line-through" }}>

--- a/apps/desktop/src/pages/marketplace/BrowsePage.tsx
+++ b/apps/desktop/src/pages/marketplace/BrowsePage.tsx
@@ -404,10 +404,10 @@ export default function BrowsePage() {
                 )}
               </div>
               <div style={{ flexShrink: 0, marginLeft: "12px", textAlign: "right" }}>
-                <div style={{ fontSize: "11px", fontFamily: "ui-monospace, monospace", color: "var(--fg-subtle)" }}>
+                <div style={{ fontSize: "11px", fontFamily: "ui-monospace, monospace", color: "var(--fg-subtle)", fontVariantNumeric: "tabular-nums" }}>
                   v{plugin.version}
                 </div>
-                <div style={{ fontSize: "10px", color: "var(--fg-subtle)", marginTop: "1px" }}>
+                <div style={{ fontSize: "10px", color: "var(--fg-subtle)", marginTop: "1px", fontVariantNumeric: "tabular-nums" }}>
                   {plugin.install_count.toLocaleString()} installs
                 </div>
               </div>

--- a/apps/desktop/src/pages/observatory/DashboardPage.tsx
+++ b/apps/desktop/src/pages/observatory/DashboardPage.tsx
@@ -85,10 +85,10 @@ function StatCard({ label, value, sub }: { label: string; value: string; sub?: s
       borderRadius: "8px",
       padding: "12px 16px",
     }}>
-      <div style={{ fontSize: "20px", fontWeight: 600, letterSpacing: "-0.5px", color: "var(--fg-base)", lineHeight: 1.1 }}>
+      <div style={{ fontSize: "20px", fontWeight: 600, letterSpacing: "-0.5px", color: "var(--fg-base)", lineHeight: 1.1, fontVariantNumeric: "tabular-nums" }}>
         {value}
       </div>
-      <div style={{ fontSize: "10px", fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--fg-subtle)", marginTop: "4px" }}>
+      <div style={{ fontSize: "11px", fontWeight: 500, fontVariantCaps: "all-small-caps", letterSpacing: "0.03em", color: "var(--fg-subtle)", marginTop: "4px" }}>
         {label}
       </div>
       {sub && (
@@ -234,7 +234,7 @@ function ChartCard({
       padding: "14px 16px",
     }}>
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "10px" }}>
-        <p style={{ fontSize: "11px", fontWeight: 600, color: "var(--fg-muted)", margin: 0, textTransform: "uppercase", letterSpacing: "0.05em" }}>
+        <p style={{ fontSize: "12px", fontWeight: 500, fontVariantCaps: "all-small-caps", letterSpacing: "0.03em", color: "var(--fg-muted)", margin: 0 }}>
           {title}
         </p>
         {chartId && (
@@ -511,11 +511,11 @@ export default function DashboardPage() {
             <AreaChart data={activityChartData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
               <defs>
                 <linearGradient id="msgGrad" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor={accentColor} stopOpacity={0.25} />
-                  <stop offset="95%" stopColor={accentColor} stopOpacity={0.02} />
+                  <stop offset="5%" stopColor={accentColor} stopOpacity={0.12} />
+                  <stop offset="95%" stopColor={accentColor} stopOpacity={0} />
                 </linearGradient>
               </defs>
-              <CartesianGrid strokeDasharray="3 3" stroke="var(--border-base)" vertical={false} />
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--separator)" vertical={false} />
               <XAxis dataKey="date" tick={axisStyle} tickLine={false} axisLine={false} interval="preserveStartEnd" />
               <YAxis tick={axisStyle} tickLine={false} axisLine={false} />
               <Tooltip contentStyle={tooltipStyle} />
@@ -537,11 +537,11 @@ export default function DashboardPage() {
             <AreaChart data={sessionsChartData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
               <defs>
                 <linearGradient id="sessGrad" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor={accentColor} stopOpacity={0.2} />
-                  <stop offset="95%" stopColor={accentColor} stopOpacity={0.01} />
+                  <stop offset="5%" stopColor={accentColor} stopOpacity={0.10} />
+                  <stop offset="95%" stopColor={accentColor} stopOpacity={0} />
                 </linearGradient>
               </defs>
-              <CartesianGrid strokeDasharray="3 3" stroke="var(--border-base)" vertical={false} />
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--separator)" vertical={false} />
               <XAxis dataKey="date" tick={axisStyle} tickLine={false} axisLine={false} interval="preserveStartEnd" />
               <YAxis tick={axisStyle} tickLine={false} axisLine={false} />
               <Tooltip contentStyle={tooltipStyle} />
@@ -560,11 +560,11 @@ export default function DashboardPage() {
             <AreaChart data={toolCallsChartData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
               <defs>
                 <linearGradient id="tcGrad" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor={accentColor} stopOpacity={0.2} />
-                  <stop offset="95%" stopColor={accentColor} stopOpacity={0.01} />
+                  <stop offset="5%" stopColor={accentColor} stopOpacity={0.10} />
+                  <stop offset="95%" stopColor={accentColor} stopOpacity={0} />
                 </linearGradient>
               </defs>
-              <CartesianGrid strokeDasharray="3 3" stroke="var(--border-base)" vertical={false} />
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--separator)" vertical={false} />
               <XAxis dataKey="date" tick={axisStyle} tickLine={false} axisLine={false} interval="preserveStartEnd" />
               <YAxis tick={axisStyle} tickLine={false} axisLine={false} />
               <Tooltip contentStyle={tooltipStyle} />
@@ -585,7 +585,7 @@ export default function DashboardPage() {
           >
             <ResponsiveContainer width="100%" height={150}>
               <AreaChart data={dailyTokensChartData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="var(--border-base)" vertical={false} />
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--separator)" vertical={false} />
                 <XAxis dataKey="date" tick={axisStyle} tickLine={false} axisLine={false} interval="preserveStartEnd" />
                 <YAxis tick={axisStyle} tickLine={false} axisLine={false}
                   tickFormatter={(v: number) => v >= 1_000_000 ? `${(v/1_000_000).toFixed(1)}M` : v >= 1000 ? `${(v/1000).toFixed(0)}k` : String(v)} />
@@ -634,7 +634,7 @@ export default function DashboardPage() {
           {hourlyChartData.some((d) => d.count > 0) ? (
             <ResponsiveContainer width="100%" height={160}>
               <BarChart data={hourlyChartData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="var(--border-base)" vertical={false} />
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--separator)" vertical={false} />
                 <XAxis dataKey="hour" tick={axisStyle} tickLine={false} axisLine={false} interval={3} />
                 <YAxis tick={axisStyle} tickLine={false} axisLine={false} />
                 <Tooltip contentStyle={tooltipStyle} />

--- a/apps/desktop/src/pages/security/PermissionsPage.tsx
+++ b/apps/desktop/src/pages/security/PermissionsPage.tsx
@@ -296,6 +296,7 @@ export default function PermissionsPage() {
   }
 
   async function handleApplyPreset(preset: SecurityPreset) {
+    setSaving(true);
     try {
       await applySecurityPreset(preset.id);
       setPermissions(preset.permissions);
@@ -303,6 +304,8 @@ export default function PermissionsPage() {
       setConfirmPreset(null);
     } catch (e) {
       setError(String(e));
+    } finally {
+      setSaving(false);
     }
   }
 
@@ -382,13 +385,15 @@ export default function PermissionsPage() {
           <div style={{ display: "flex", gap: "8px" }}>
             <button
               onClick={() => handleApplyPreset(confirmPreset)}
+              disabled={saving}
               style={{
                 fontSize: "12px", padding: "5px 14px", borderRadius: "6px",
                 border: "none", background: "var(--accent)", color: "#fff",
-                cursor: "pointer", fontWeight: 500,
+                cursor: saving ? "default" : "pointer", fontWeight: 500,
+                opacity: saving ? 0.6 : 1,
               }}
             >
-              Apply
+              {saving ? "Applying…" : "Apply"}
             </button>
             <button
               onClick={() => setConfirmPreset(null)}

--- a/apps/desktop/src/pages/security/PermissionsPage.tsx
+++ b/apps/desktop/src/pages/security/PermissionsPage.tsx
@@ -208,6 +208,12 @@ function SuggestInput({
   );
 }
 
+const PRESET_COLORS: Record<string, string> = {
+  Strict: "#16a34a",
+  Standard: "#3b82f6",
+  Permissive: "#d97706",
+};
+
 export default function PermissionsPage() {
   const [permissions, setPermissions] = useState<PermissionsState | null>(null);
   const [presets, setPresets] = useState<SecurityPreset[]>([]);
@@ -323,38 +329,46 @@ export default function PermissionsPage() {
   }
 
   return (
-    <div style={{ padding: "20px 24px" }}>
+    <div style={{ padding: "20px 24px", maxWidth: "680px" }}>
       {/* Header */}
-      <div style={{ marginBottom: "16px" }}>
+      <div style={{ marginBottom: "20px" }}>
         <h1 style={{ fontSize: "17px", fontWeight: 600, letterSpacing: "-0.3px", color: "var(--fg-base)", margin: 0 }}>
           Permissions
         </h1>
         <p style={{ fontSize: "12px", color: "var(--fg-muted)", margin: "3px 0 0" }}>
-          Manage tool access, file paths, and network rules from ~/.claude/settings.json
+          Tool access, file paths, and network rules — written to ~/.claude/settings.json
         </p>
       </div>
 
-      {/* Preset bar */}
-      <div style={{ display: "flex", gap: "10px", marginBottom: "20px", flexWrap: "wrap" }}>
-        {presets.map((preset) => (
-          <button
-            key={preset.id}
-            onClick={() => setConfirmPreset(preset)}
-            style={{
-              flex: 1, minWidth: "140px", padding: "12px 14px",
-              background: "var(--bg-surface)", border: "1px solid var(--border-base)",
-              borderRadius: "8px", cursor: "pointer", textAlign: "left",
-            }}
-          >
-            <div style={{ fontSize: "13px", fontWeight: 600, color: "var(--fg-base)", marginBottom: "2px" }}>
-              {preset.name}
-            </div>
-            <div style={{ fontSize: "11px", color: "var(--fg-muted)", lineHeight: 1.3 }}>
-              {preset.description}
-            </div>
-          </button>
-        ))}
-      </div>
+      {/* Presets */}
+      {presets.length > 0 && (
+        <div style={{ marginBottom: "20px" }}>
+          <p style={{ fontSize: "11px", fontWeight: 500, fontVariantCaps: "all-small-caps", letterSpacing: "0.03em", color: "var(--fg-subtle)", margin: "0 0 8px" }}>
+            Quick preset
+          </p>
+          <div style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
+            {presets.map((preset) => (
+              <button
+                key={preset.id}
+                onClick={() => setConfirmPreset(preset)}
+                className="preset-card"
+                style={{
+                  padding: "8px 12px",
+                  background: "var(--bg-surface)",
+                  border: "1px solid var(--border-base)",
+                  borderLeft: `3px solid ${PRESET_COLORS[preset.name] ?? "var(--border-base)"}`,
+                  borderRadius: "6px",
+                  cursor: "pointer",
+                  textAlign: "left",
+                }}
+              >
+                <div style={{ fontSize: "12px", fontWeight: 600, color: "var(--fg-base)" }}>{preset.name}</div>
+                <div style={{ fontSize: "10px", color: "var(--fg-subtle)", marginTop: "2px", lineHeight: 1.3 }}>{preset.description}</div>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Confirm dialog */}
       {confirmPreset && (
@@ -392,105 +406,110 @@ export default function PermissionsPage() {
 
       {permissions && (
         <>
-          {/* Tools */}
+          {/* Unified card */}
           <div style={{
-            background: "var(--bg-surface)", border: "1px solid var(--border-base)",
-            borderRadius: "8px", padding: "14px 16px", marginBottom: "12px",
+            background: "var(--bg-surface)",
+            border: "1px solid var(--border-base)",
+            borderRadius: "10px",
+            overflow: "hidden",
+            marginBottom: "16px",
           }}>
-            <p style={{ fontSize: "11px", fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.05em", color: "var(--fg-subtle)", margin: "0 0 10px" }}>
-              Tools
-            </p>
-            {(() => {
-              const allTools = [...permissions.tools.allow, ...permissions.tools.deny, ...permissions.tools.ask];
-              return (
-                <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: "16px" }}>
-                  {/* Allow */}
-                  <div>
-                    <p style={{ fontSize: "11px", fontWeight: 600, color: "#16a34a", margin: "0 0 6px" }}>Allow</p>
-                    <div style={{ display: "flex", flexWrap: "wrap", gap: "4px" }}>
-                      {permissions.tools.allow.map((t) => (
-                        <Chip key={t} label={t} color="green" onRemove={() => removeFromList("allow", t)} />
-                      ))}
-                    </div>
-                    <SuggestInput onAdd={(v) => addToList("allow", v)} placeholder="Tool name" suggestions={TOOL_SUGGESTIONS} existing={allTools} />
+            {/* Tools */}
+            <div style={{ padding: "14px 16px" }}>
+              <p style={{ fontSize: "11px", fontWeight: 500, fontVariantCaps: "all-small-caps", letterSpacing: "0.03em", color: "var(--fg-subtle)", margin: "0 0 12px" }}>
+                Tools
+              </p>
+              {(() => {
+                const allTools = [...permissions.tools.allow, ...permissions.tools.deny, ...permissions.tools.ask];
+                const rows: { key: "allow" | "deny" | "ask"; label: string; color: string; chipColor: "green" | "red" | "amber" }[] = [
+                  { key: "allow", label: "Allow", color: "#16a34a", chipColor: "green" },
+                  { key: "deny",  label: "Deny",  color: "#dc2626", chipColor: "red"   },
+                  { key: "ask",   label: "Ask",   color: "#d97706", chipColor: "amber" },
+                ];
+                return (
+                  <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+                    {rows.map(({ key, label, color, chipColor }) => (
+                      <div key={key} style={{ display: "flex", gap: "10px" }}>
+                        <span style={{ fontSize: "11px", fontWeight: 600, color, minWidth: "38px", paddingTop: "5px" }}>{label}</span>
+                        <div style={{ flex: 1 }}>
+                          {permissions.tools[key].length > 0 && (
+                            <div style={{ display: "flex", flexWrap: "wrap", gap: "4px", marginBottom: "4px" }}>
+                              {permissions.tools[key].map((t) => (
+                                <Chip key={t} label={t} color={chipColor} onRemove={() => removeFromList(key, t)} />
+                              ))}
+                            </div>
+                          )}
+                          <SuggestInput
+                            onAdd={(v) => addToList(key, v)}
+                            placeholder={`Add ${label.toLowerCase()} rule…`}
+                            suggestions={TOOL_SUGGESTIONS}
+                            existing={allTools}
+                          />
+                        </div>
+                      </div>
+                    ))}
                   </div>
-                  {/* Deny */}
-                  <div>
-                    <p style={{ fontSize: "11px", fontWeight: 600, color: "#dc2626", margin: "0 0 6px" }}>Deny</p>
-                    <div style={{ display: "flex", flexWrap: "wrap", gap: "4px" }}>
-                      {permissions.tools.deny.map((t) => (
-                        <Chip key={t} label={t} color="red" onRemove={() => removeFromList("deny", t)} />
-                      ))}
-                    </div>
-                    <SuggestInput onAdd={(v) => addToList("deny", v)} placeholder="Tool name" suggestions={TOOL_SUGGESTIONS} existing={allTools} />
-                  </div>
-                  {/* Ask */}
-                  <div>
-                    <p style={{ fontSize: "11px", fontWeight: 600, color: "#d97706", margin: "0 0 6px" }}>Ask</p>
-                    <div style={{ display: "flex", flexWrap: "wrap", gap: "4px" }}>
-                      {permissions.tools.ask.map((t) => (
-                        <Chip key={t} label={t} color="amber" onRemove={() => removeFromList("ask", t)} />
-                      ))}
-                    </div>
-                    <SuggestInput onAdd={(v) => addToList("ask", v)} placeholder="Tool name" suggestions={TOOL_SUGGESTIONS} existing={allTools} />
-                  </div>
-                </div>
-              );
-            })()}
-          </div>
-
-          {/* Paths */}
-          <div style={{
-            background: "var(--bg-surface)", border: "1px solid var(--border-base)",
-            borderRadius: "8px", padding: "14px 16px", marginBottom: "12px",
-          }}>
-            <p style={{ fontSize: "11px", fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.05em", color: "var(--fg-subtle)", margin: "0 0 10px" }}>
-              Paths
-            </p>
-            {(() => {
-              const allPaths = [...permissions.paths.writable, ...permissions.paths.readonly];
-              return (
-                <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "16px" }}>
-                  <div>
-                    <p style={{ fontSize: "11px", fontWeight: 600, color: "#16a34a", margin: "0 0 6px" }}>Writable</p>
-                    <div style={{ display: "flex", flexWrap: "wrap", gap: "4px" }}>
-                      {permissions.paths.writable.map((p) => (
-                        <Chip key={p} label={p} color="green" onRemove={() => removeFromList("writable", p)} />
-                      ))}
-                    </div>
-                    <SuggestInput onAdd={(v) => addToList("writable", v)} placeholder="Path" suggestions={PATH_SUGGESTIONS} existing={allPaths} />
-                  </div>
-                  <div>
-                    <p style={{ fontSize: "11px", fontWeight: 600, color: "#d97706", margin: "0 0 6px" }}>Read-only</p>
-                    <div style={{ display: "flex", flexWrap: "wrap", gap: "4px" }}>
-                      {permissions.paths.readonly.map((p) => (
-                        <Chip key={p} label={p} color="amber" onRemove={() => removeFromList("readonly", p)} />
-                      ))}
-                    </div>
-                    <SuggestInput onAdd={(v) => addToList("readonly", v)} placeholder="Path" suggestions={PATH_SUGGESTIONS} existing={allPaths} />
-                  </div>
-                </div>
-              );
-            })()}
-          </div>
-
-          {/* Network */}
-          <div style={{
-            background: "var(--bg-surface)", border: "1px solid var(--border-base)",
-            borderRadius: "8px", padding: "14px 16px", marginBottom: "16px",
-          }}>
-            <p style={{ fontSize: "11px", fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.05em", color: "var(--fg-subtle)", margin: "0 0 10px" }}>
-              Network — Allowed Hosts
-            </p>
-            <div style={{ display: "flex", flexWrap: "wrap", gap: "4px" }}>
-              {permissions.network.allowedHosts.map((h) => (
-                <Chip key={h} label={h} color="green" onRemove={() => removeFromList("allowedHosts", h)} />
-              ))}
+                );
+              })()}
             </div>
-            <SuggestInput onAdd={(v) => addToList("allowedHosts", v)} placeholder="Hostname" suggestions={HOST_SUGGESTIONS} existing={permissions.network.allowedHosts} />
+
+            <div style={{ height: "1px", background: "var(--separator)", margin: "0 16px" }} />
+
+            {/* Paths */}
+            <div style={{ padding: "14px 16px" }}>
+              <p style={{ fontSize: "11px", fontWeight: 500, fontVariantCaps: "all-small-caps", letterSpacing: "0.03em", color: "var(--fg-subtle)", margin: "0 0 12px" }}>
+                Paths
+              </p>
+              {(() => {
+                const allPaths = [...permissions.paths.writable, ...permissions.paths.readonly];
+                return (
+                  <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "20px" }}>
+                    <div>
+                      <p style={{ fontSize: "11px", fontWeight: 600, color: "#16a34a", margin: "0 0 6px" }}>Writable</p>
+                      {permissions.paths.writable.length > 0 && (
+                        <div style={{ display: "flex", flexWrap: "wrap", gap: "4px", marginBottom: "4px" }}>
+                          {permissions.paths.writable.map((p) => (
+                            <Chip key={p} label={p} color="green" onRemove={() => removeFromList("writable", p)} />
+                          ))}
+                        </div>
+                      )}
+                      <SuggestInput onAdd={(v) => addToList("writable", v)} placeholder="Add path…" suggestions={PATH_SUGGESTIONS} existing={allPaths} />
+                    </div>
+                    <div>
+                      <p style={{ fontSize: "11px", fontWeight: 600, color: "#d97706", margin: "0 0 6px" }}>Read-only</p>
+                      {permissions.paths.readonly.length > 0 && (
+                        <div style={{ display: "flex", flexWrap: "wrap", gap: "4px", marginBottom: "4px" }}>
+                          {permissions.paths.readonly.map((p) => (
+                            <Chip key={p} label={p} color="amber" onRemove={() => removeFromList("readonly", p)} />
+                          ))}
+                        </div>
+                      )}
+                      <SuggestInput onAdd={(v) => addToList("readonly", v)} placeholder="Add path…" suggestions={PATH_SUGGESTIONS} existing={allPaths} />
+                    </div>
+                  </div>
+                );
+              })()}
+            </div>
+
+            <div style={{ height: "1px", background: "var(--separator)", margin: "0 16px" }} />
+
+            {/* Network */}
+            <div style={{ padding: "14px 16px" }}>
+              <p style={{ fontSize: "11px", fontWeight: 500, fontVariantCaps: "all-small-caps", letterSpacing: "0.03em", color: "var(--fg-subtle)", margin: "0 0 12px" }}>
+                Network — Allowed Hosts
+              </p>
+              {permissions.network.allowedHosts.length > 0 && (
+                <div style={{ display: "flex", flexWrap: "wrap", gap: "4px", marginBottom: "4px" }}>
+                  {permissions.network.allowedHosts.map((h) => (
+                    <Chip key={h} label={h} color="green" onRemove={() => removeFromList("allowedHosts", h)} />
+                  ))}
+                </div>
+              )}
+              <SuggestInput onAdd={(v) => addToList("allowedHosts", v)} placeholder="Add host…" suggestions={HOST_SUGGESTIONS} existing={permissions.network.allowedHosts} />
+            </div>
           </div>
 
-          {/* Save button */}
+          {/* Save */}
           <button
             onClick={handleSave}
             disabled={!dirty || saving}
@@ -503,7 +522,7 @@ export default function PermissionsPage() {
               opacity: saving ? 0.6 : 1,
             }}
           >
-            {saving ? "Saving..." : "Save Permissions"}
+            {saving ? "Saving…" : "Save Permissions"}
           </button>
         </>
       )}


### PR DESCRIPTION
## Summary

Four areas of the desktop app that still read as "AI-generated amateur" have been redesigned with production-quality intent. The biggest change is the custom macOS title bar — the app now feels native rather than like a website in a window. Observatory chart typography is more refined, the comparator form uses available space, and the permissions layout is consolidated and scannable.

## Changes

- **Custom title bar** — macOS overlay title bar (`titleBarStyle: "Overlay"`) replaces the native title bar text. Full-width drag region with traffic light inset; three toolbar buttons: sidebar toggle, back, forward. Sidebar collapses with `width: 0` + `overflow: hidden` animation; state persists to localStorage. Keyboard shortcuts: `Cmd+\` toggle sidebar, `Cmd+[` back, `Cmd+]` forward.
- **Comparator setup — two-column layout** — setup form fills available width with a responsive `minmax` CSS Grid (harness selector + directory left, prompt right). Max concurrent harnesses raised 3 → 4.
- **Observatory charts — typography + softer fills** — stat and chart card headers use `font-variant-caps: all-small-caps` instead of `text-transform: uppercase`. Area chart gradient top stops halved; `CartesianGrid` stroke changed from `--border-base` to `--separator` (lighter).
- **Permissions — unified card** — Tools, Paths, and Network sections merged into one card with inset separator lines instead of three separate cards. Allow/Deny/Ask rows stacked vertically with color-coded labels. Preset cards get a colored left border (green/blue/amber) for at-a-glance identity.
- **CHANGELOG.md** — 0.2.1 Unreleased section updated with all four changes.

## Test Plan

- [ ] Local tests pass (no test suite — validated via build)
- [ ] CI checks pass
- [ ] macOS title bar: traffic lights overlay at correct inset, drag region moves window, sidebar toggle collapses/expands with animation, back/forward navigate history
- [ ] `Cmd+\`, `Cmd+[`, `Cmd+]` keyboard shortcuts work
- [ ] Comparator: form fills width in two columns, up to 4 harnesses selectable
- [ ] Observatory: card headers render as small-caps (not ALL CAPS), area fills are subtle, grid lines lighter
- [ ] Permissions: Tools section shows Allow/Deny/Ask as stacked rows, preset cards have colored left borders

## Notes

- `titleBarStyle` must be `"Overlay"` (PascalCase) — Tauri v2 JSON schema rejects lowercase `"overlay"`
- Setting `"title": ""` in tauri.conf.json prevents the native window title from rendering over the custom toolbar
- Sidebar uses a two-div approach: outer `overflow: hidden` + width transition, inner `<aside>` with fixed `var(--sidebar-width)` — this lets the drag handle stay anchored while the sidebar scrolls independently
- Tauri config changes require a full restart (`pnpm dev:desktop`) — HMR does not pick them up