### PR TITLE
feat(desktop): add Harness File page as first-class section

### DIFF
--- a/apps/desktop/src-tauri/src/commands/harness_file.rs
+++ b/apps/desktop/src-tauri/src/commands/harness_file.rs
@@ -19,24 +19,25 @@ pub fn read_harness_file() -> Result<HarnessFileResult, String> {
     ];
 
     for path in &candidates {
-        if path.exists() {
-            let canonical = path
-                .canonicalize()
-                .map_err(|e| format!("Invalid path: {}", e))?;
-            if !canonical.starts_with(&home) {
-                return Err("Access denied: path is outside home directory".to_string());
-            }
-            let content = std::fs::read_to_string(&canonical)
-                .map_err(|e| format!("Failed to read {}: {}", canonical.display(), e))?;
-            // Return a ~-relative path so the frontend can display it cross-platform
-            let relative = canonical.strip_prefix(&home).unwrap_or(&canonical);
-            let path_str = format!("~/{}", relative.to_string_lossy());
-            return Ok(HarnessFileResult {
-                found: true,
-                content: Some(content),
-                path: Some(path_str),
-            });
+        // Use canonicalize() as the existence check — eliminates the TOCTOU
+        // window that would exist between a separate exists() call and read.
+        let canonical = match path.canonicalize() {
+            Ok(p) => p,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(format!("Invalid path: {}", e)),
+        };
+        if !canonical.starts_with(&home) {
+            return Err("Access denied: path is outside home directory".to_string());
         }
+        let relative = canonical.strip_prefix(&home).unwrap_or(&canonical);
+        let display_path = format!("~/{}", relative.to_string_lossy());
+        let content = std::fs::read_to_string(&canonical)
+            .map_err(|e| format!("Failed to read {}: {}", display_path, e))?;
+        return Ok(HarnessFileResult {
+            found: true,
+            content: Some(content),
+            path: Some(display_path),
+        });
     }
 
     Ok(HarnessFileResult {

--- a/apps/desktop/src-tauri/src/commands/harness_file.rs
+++ b/apps/desktop/src-tauri/src/commands/harness_file.rs
@@ -1,0 +1,47 @@
+#[derive(serde::Serialize)]
+pub struct HarnessFileResult {
+    pub found: bool,
+    pub content: Option<String>,
+    pub path: Option<String>,
+}
+
+#[tauri::command]
+pub fn read_harness_file() -> Result<HarnessFileResult, String> {
+    let home = dirs::home_dir()
+        .ok_or_else(|| "Could not resolve home directory".to_string())?;
+
+    // Search priority:
+    // 1. ~/.claude/harness.yaml
+    // 2. ~/harness.yaml
+    let candidates = [
+        home.join(".claude").join("harness.yaml"),
+        home.join("harness.yaml"),
+    ];
+
+    for path in &candidates {
+        if path.exists() {
+            let canonical = path
+                .canonicalize()
+                .map_err(|e| format!("Invalid path: {}", e))?;
+            if !canonical.starts_with(&home) {
+                return Err("Access denied: path is outside home directory".to_string());
+            }
+            let content = std::fs::read_to_string(&canonical)
+                .map_err(|e| format!("Failed to read {}: {}", canonical.display(), e))?;
+            // Return a ~-relative path so the frontend can display it cross-platform
+            let relative = canonical.strip_prefix(&home).unwrap_or(&canonical);
+            let path_str = format!("~/{}", relative.to_string_lossy());
+            return Ok(HarnessFileResult {
+                found: true,
+                content: Some(content),
+                path: Some(path_str),
+            });
+        }
+    }
+
+    Ok(HarnessFileResult {
+        found: false,
+        content: None,
+        path: None,
+    })
+}

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -13,3 +13,4 @@ pub mod evaluation;
 pub mod export;
 pub mod types;
 pub mod history;
+pub mod harness_file;

--- a/apps/desktop/src-tauri/src/commands/plugin_explorer.rs
+++ b/apps/desktop/src-tauri/src/commands/plugin_explorer.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 use std::fs;
-use std::io::{Read, Write};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 

--- a/apps/desktop/src-tauri/src/commands/plugin_explorer.rs
+++ b/apps/desktop/src-tauri/src/commands/plugin_explorer.rs
@@ -494,11 +494,13 @@ fn update_installed_plugins_json(name: &str, version: &str, install_path: &str) 
             .map_err(|e| format!("Failed to create plugins directory: {}", e))?;
     }
 
-    let mut file = fs::File::create(&path)
+    let serialized = serde_json::to_string_pretty(&data)
+        .map_err(|e| format!("Failed to serialize plugins data: {}", e))?;
+    let tmp_path = path.with_extension("json.tmp");
+    fs::write(&tmp_path, &serialized)
         .map_err(|e| format!("Failed to write installed_plugins.json: {}", e))?;
-    file.write_all(serde_json::to_string_pretty(&data)
-        .map_err(|e| format!("Failed to serialize plugins data: {}", e))?.as_bytes())
-        .map_err(|e| format!("Failed to write: {}", e))?;
+    fs::rename(&tmp_path, &path)
+        .map_err(|e| format!("Failed to finalize installed_plugins.json: {}", e))?;
 
     Ok(())
 }

--- a/apps/desktop/src-tauri/src/commands/plugins.rs
+++ b/apps/desktop/src-tauri/src/commands/plugins.rs
@@ -251,10 +251,17 @@ pub fn uninstall_plugin(name: String) -> Result<(), String> {
         .ok_or_else(|| "Could not resolve home directory".to_string())?
         .join("plugins");
 
-    // Remove plugin directory
+    // Remove plugin directory — canonicalize before removal to block symlink traversal
     let plugin_dir = plugins_dir.join(&name);
     if plugin_dir.exists() {
-        std::fs::remove_dir_all(&plugin_dir)
+        let canonical = plugin_dir.canonicalize()
+            .map_err(|e| format!("Invalid plugin path: {}", e))?;
+        let canonical_plugins = plugins_dir.canonicalize()
+            .map_err(|e| format!("Invalid plugins dir: {}", e))?;
+        if !canonical.starts_with(&canonical_plugins) {
+            return Err("Access denied: plugin path outside plugins directory".to_string());
+        }
+        std::fs::remove_dir_all(&canonical)
             .map_err(|e| format!("Failed to remove plugin directory: {}", e))?;
     }
 
@@ -281,8 +288,12 @@ pub fn uninstall_plugin(name: String) -> Result<(), String> {
             }
         }
 
-        std::fs::write(&json_path, serde_json::to_string_pretty(&data).unwrap())
-            .map_err(|e| format!("Failed to update installed_plugins.json: {}", e))?;
+        let serialized = serde_json::to_string_pretty(&data).unwrap();
+        let tmp_path = json_path.with_extension("json.tmp");
+        std::fs::write(&tmp_path, &serialized)
+            .map_err(|e| format!("Failed to write installed_plugins.json: {}", e))?;
+        std::fs::rename(&tmp_path, &json_path)
+            .map_err(|e| format!("Failed to finalize installed_plugins.json: {}", e))?;
     }
 
     Ok(())

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -39,6 +39,8 @@ pub fn run() {
             commands::hooks::read_hooks,
             // Claude.md
             commands::claude_md::read_claude_md,
+            // Harness File
+            commands::harness_file::read_harness_file,
             // Settings
             commands::settings::list_claude_dir,
             // Observatory

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import AppLayout from "./layouts/AppLayout";
 import PreferencesPage from "./pages/PreferencesPage";
 import { getDefaultSection } from "./lib/preferences";
+import HarnessFilePage from "./pages/harness/HarnessFilePage";
 import PluginsPage from "./pages/harness/PluginsPage";
 import HooksPage from "./pages/harness/HooksPage";
 import SettingsPage from "./pages/harness/SettingsPage";
@@ -33,6 +34,7 @@ export default function App() {
         <Route path="/" element={<AppLayout />}>
           {/* Harness Manager */}
           <Route index element={<DefaultRedirect />} />
+          <Route path="harness/file" element={<HarnessFilePage />} />
           <Route path="harness/plugins" element={<PluginsPage />} />
           <Route path="harness/hooks" element={<HooksPage />} />
           <Route path="harness/claude-md" element={<ClaudeMdPage />} />

--- a/apps/desktop/src/components/MarkdownPanel.tsx
+++ b/apps/desktop/src/components/MarkdownPanel.tsx
@@ -101,6 +101,7 @@ export default function MarkdownPanel({
           borderRadius: "8px",
           padding: "14px 16px",
           overflow: fill ? "auto" : undefined,
+          overflowX: "auto",
           minHeight: 0,
         }}
       >

--- a/apps/desktop/src/layouts/AppLayout.tsx
+++ b/apps/desktop/src/layouts/AppLayout.tsx
@@ -19,8 +19,9 @@ export const NAV_SECTIONS: NavSection[] = [
   {
     id: "harness",
     label: "Harness",
-    path: "/harness/plugins",
+    path: "/harness/file",
     children: [
+      { label: "Harness File", path: "/harness/file" },
       { label: "Plugins", path: "/harness/plugins" },
       { label: "Hooks", path: "/harness/hooks" },
       { label: "CLAUDE.md", path: "/harness/claude-md" },

--- a/apps/desktop/src/lib/tauri.ts
+++ b/apps/desktop/src/lib/tauri.ts
@@ -88,6 +88,18 @@ export async function readClaudeMd(path: string): Promise<string> {
   return invoke<string>("read_claude_md", { path });
 }
 
+// ── Harness File commands ─────────────────────────────────────
+
+export interface HarnessFileResult {
+  found: boolean;
+  content: string | null;
+  path: string | null;
+}
+
+export async function readHarnessFile(): Promise<HarnessFileResult> {
+  return invoke<HarnessFileResult>("read_harness_file");
+}
+
 // ── Settings / directory commands ────────────────────────────
 
 export async function listClaudeDir(): Promise<string[]> {

--- a/apps/desktop/src/pages/harness/HarnessFilePage.tsx
+++ b/apps/desktop/src/pages/harness/HarnessFilePage.tsx
@@ -49,13 +49,13 @@ export default function HarnessFilePage() {
   }, [content]);
 
   const validation = useMemo<ValidationResult | null>(() => {
-    if (!content) return null;
+    if (!content || parsed.parseError) return null;
     try {
       return validateHarnessYaml(content);
     } catch {
       return null;
     }
-  }, [content]);
+  }, [content, parsed.parseError]);
 
   const tabBtn = (active: boolean): React.CSSProperties => ({
     fontSize: "10px",

--- a/apps/desktop/src/pages/harness/HarnessFilePage.tsx
+++ b/apps/desktop/src/pages/harness/HarnessFilePage.tsx
@@ -1,0 +1,240 @@
+import { useEffect, useMemo, useState } from "react";
+import { readHarnessFile } from "../../lib/tauri";
+import { parseHarness, validateHarnessYaml } from "@harness-kit/core";
+import type { HarnessConfig, ValidationResult } from "@harness-kit/core";
+import ValidationBanner from "./harness-file/ValidationBanner";
+import MetadataSection from "./harness-file/MetadataSection";
+import PluginsSection from "./harness-file/PluginsSection";
+import McpServersSection from "./harness-file/McpServersSection";
+import EnvSection from "./harness-file/EnvSection";
+import InstructionsSection from "./harness-file/InstructionsSection";
+import PermissionsSection from "./harness-file/PermissionsSection";
+import ExtendsSection from "./harness-file/ExtendsSection";
+
+const EXAMPLE_YAML = `version: "1"
+metadata:
+  name: my-harness
+  description: My personal harness configuration.
+plugins:
+  - name: research
+    source: harnessprotocol/harness-kit`;
+
+export default function HarnessFilePage() {
+  const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [found, setFound] = useState(false);
+  const [content, setContent] = useState<string | null>(null);
+  const [filePath, setFilePath] = useState<string | null>(null);
+  const [view, setView] = useState<"formatted" | "raw">("formatted");
+
+  useEffect(() => {
+    readHarnessFile()
+      .then((result) => {
+        setFound(result.found);
+        setContent(result.content);
+        setFilePath(result.path);
+      })
+      .catch((e) => setFetchError(String(e)))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const parsed = useMemo<{ config: HarnessConfig; parseError: string | null }>(() => {
+    if (!content) return { config: {} as HarnessConfig, parseError: null };
+    try {
+      const { config } = parseHarness(content);
+      return { config, parseError: null };
+    } catch (e) {
+      return { config: {} as HarnessConfig, parseError: String(e) };
+    }
+  }, [content]);
+
+  const validation = useMemo<ValidationResult | null>(() => {
+    if (!content) return null;
+    try {
+      return validateHarnessYaml(content);
+    } catch {
+      return null;
+    }
+  }, [content]);
+
+  const tabBtn = (active: boolean): React.CSSProperties => ({
+    fontSize: "10px",
+    fontWeight: active ? 600 : 400,
+    padding: "3px 8px",
+    borderRadius: "4px",
+    border: "none",
+    background: active ? "var(--bg-elevated)" : "transparent",
+    color: active ? "var(--fg-base)" : "var(--fg-subtle)",
+    cursor: "pointer",
+    boxShadow: active ? "var(--shadow-sm)" : "none",
+    transition: "all 0.1s",
+  });
+
+  return (
+    <div style={{ padding: "20px 24px" }}>
+      {/* Header */}
+      <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", marginBottom: "16px" }}>
+        <div>
+          <h1 style={{ fontSize: "17px", fontWeight: 600, letterSpacing: "-0.3px", color: "var(--fg-base)", margin: 0 }}>
+            Harness File
+          </h1>
+          <p style={{ fontSize: "12px", color: "var(--fg-muted)", margin: "3px 0 0" }}>
+            The single source of truth for your AI assistant configuration.
+          </p>
+        </div>
+
+        {found && filePath && (
+          <div style={{ display: "flex", alignItems: "center", gap: "10px", flexShrink: 0, marginLeft: "16px" }}>
+            <code style={{ fontSize: "11px", color: "var(--fg-subtle)", fontFamily: "ui-monospace, monospace" }}>
+              {filePath}
+            </code>
+            <div style={{
+              display: "flex",
+              gap: "2px",
+              background: "var(--bg-base)",
+              border: "1px solid var(--border-base)",
+              borderRadius: "6px",
+              padding: "2px",
+            }}>
+              <button onClick={() => setView("formatted")} style={tabBtn(view === "formatted")}>
+                Formatted
+              </button>
+              <button onClick={() => setView("raw")} style={tabBtn(view === "raw")}>
+                Raw
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Loading */}
+      {loading && (
+        <p style={{ fontSize: "13px", color: "var(--fg-subtle)" }}>Loading…</p>
+      )}
+
+      {/* Fetch error */}
+      {fetchError && (
+        <div style={{
+          background: "var(--bg-surface)",
+          border: "1px solid var(--border-base)",
+          borderRadius: "8px",
+          padding: "10px 14px",
+          fontSize: "13px",
+          color: "var(--danger)",
+        }}>
+          {fetchError}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!loading && !fetchError && !found && (
+        <div style={{
+          background: "var(--bg-surface)",
+          border: "1px solid var(--border-base)",
+          borderRadius: "8px",
+          padding: "32px 24px",
+          textAlign: "center",
+          maxWidth: "540px",
+        }}>
+          <div style={{ fontSize: "28px", marginBottom: "12px" }}>🧰</div>
+          <h2 style={{ fontSize: "15px", fontWeight: 600, color: "var(--fg-base)", margin: "0 0 6px" }}>
+            No harness.yaml found
+          </h2>
+          <p style={{ fontSize: "13px", color: "var(--fg-muted)", margin: "0 0 16px", lineHeight: "1.5" }}>
+            A <code style={{ fontFamily: "ui-monospace, monospace", fontSize: "12px" }}>harness.yaml</code> file
+            is the single source of truth for your AI assistant configuration. It declares plugins, MCP servers,
+            environment variables, instructions, and permissions — all in one portable file.
+          </p>
+          <p style={{ fontSize: "12px", color: "var(--fg-subtle)", margin: "0 0 12px" }}>
+            Place it at <code style={{ fontFamily: "ui-monospace, monospace" }}>~/.claude/harness.yaml</code> or <code style={{ fontFamily: "ui-monospace, monospace" }}>~/harness.yaml</code>
+          </p>
+          <pre style={{
+            textAlign: "left",
+            background: "var(--bg-elevated)",
+            border: "1px solid var(--border-base)",
+            borderRadius: "6px",
+            padding: "12px 14px",
+            fontSize: "11px",
+            fontFamily: "ui-monospace, monospace",
+            color: "var(--fg-muted)",
+            margin: "0 auto",
+            lineHeight: "1.6",
+            whiteSpace: "pre-wrap",
+          }}>
+            {EXAMPLE_YAML}
+          </pre>
+        </div>
+      )}
+
+      {/* Found — content */}
+      {!loading && !fetchError && found && content && (
+        <>
+          {/* Parse error */}
+          {parsed.parseError && (
+            <div style={{
+              background: "var(--bg-surface)",
+              border: "1px solid var(--border-base)",
+              borderRadius: "8px",
+              padding: "10px 14px",
+              fontSize: "13px",
+              color: "var(--danger)",
+              marginBottom: "16px",
+            }}>
+              {parsed.parseError}
+            </div>
+          )}
+
+          {view === "formatted" ? (
+            <div style={{ display: "flex", flexDirection: "column", gap: "20px" }}>
+              {/* Validation banner */}
+              {validation && <ValidationBanner result={validation} />}
+
+              {/* Sections — only render when data is present */}
+              {parsed.config.metadata && (
+                <MetadataSection metadata={parsed.config.metadata} />
+              )}
+              {parsed.config.plugins && parsed.config.plugins.length > 0 && (
+                <PluginsSection plugins={parsed.config.plugins} />
+              )}
+              {parsed.config["mcp-servers"] && Object.keys(parsed.config["mcp-servers"]).length > 0 && (
+                <McpServersSection servers={parsed.config["mcp-servers"]} />
+              )}
+              {parsed.config.env && parsed.config.env.length > 0 && (
+                <EnvSection env={parsed.config.env} />
+              )}
+              {parsed.config.instructions && (
+                <InstructionsSection instructions={parsed.config.instructions} />
+              )}
+              {parsed.config.permissions && (
+                <PermissionsSection permissions={parsed.config.permissions} />
+              )}
+              {parsed.config.extends && parsed.config.extends.length > 0 && (
+                <ExtendsSection extends_={parsed.config.extends} />
+              )}
+            </div>
+          ) : (
+            <div style={{
+              background: "var(--bg-surface)",
+              border: "1px solid var(--border-base)",
+              borderRadius: "8px",
+              padding: "14px 16px",
+              overflowX: "auto",
+            }}>
+              <pre style={{
+                margin: 0,
+                fontFamily: "ui-monospace, monospace",
+                fontSize: "11px",
+                lineHeight: "1.6",
+                color: "var(--fg-muted)",
+                whiteSpace: "pre-wrap",
+                wordBreak: "break-word",
+              }}>
+                {content}
+              </pre>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/pages/harness/harness-file/EnvSection.tsx
+++ b/apps/desktop/src/pages/harness/harness-file/EnvSection.tsx
@@ -48,14 +48,16 @@ export default function EnvSection({ env }: EnvSectionProps) {
                   <span style={sensitiveBadgeStyle}>sensitive</span>
                 )}
               </div>
-              <p style={{
-                fontSize: "11px",
-                color: "var(--fg-muted)",
-                margin: "2px 0 0",
-              }}>
-                {decl.description}
-              </p>
-              {decl.default !== undefined && (
+              {decl.description && (
+                <p style={{
+                  fontSize: "11px",
+                  color: "var(--fg-muted)",
+                  margin: "2px 0 0",
+                }}>
+                  {decl.description}
+                </p>
+              )}
+              {decl.default !== undefined && !decl.sensitive && (
                 <p style={{
                   fontSize: "11px",
                   fontStyle: "italic",

--- a/apps/desktop/src/pages/harness/harness-file/EnvSection.tsx
+++ b/apps/desktop/src/pages/harness/harness-file/EnvSection.tsx
@@ -1,0 +1,74 @@
+import type { CSSProperties } from "react";
+import type { EnvDeclaration } from "@harness-kit/core";
+import SectionCard from "./SectionCard";
+
+interface EnvSectionProps {
+  env: EnvDeclaration[];
+}
+
+const requiredBadgeStyle: CSSProperties = {
+  fontSize: "10px",
+  padding: "1px 6px",
+  borderRadius: "10px",
+  background: "rgba(220,53,69,0.1)",
+  color: "var(--danger)",
+};
+
+const sensitiveBadgeStyle: CSSProperties = {
+  fontSize: "10px",
+  padding: "1px 6px",
+  borderRadius: "10px",
+  background: "var(--bg-elevated)",
+  color: "var(--fg-muted)",
+};
+
+export default function EnvSection({ env }: EnvSectionProps) {
+  return (
+    <SectionCard
+      label="Environment"
+      explanation="Variables that plugins and MCP servers depend on."
+      count={env.length}
+    >
+      <div className="row-list">
+        {env.map((decl) => (
+          <div key={decl.name} className="row-list-item">
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ display: "flex", alignItems: "center", gap: "6px", flexWrap: "wrap" }}>
+                <code style={{
+                  fontFamily: "ui-monospace, monospace",
+                  fontSize: "12px",
+                  color: "var(--fg-base)",
+                }}>
+                  {decl.name}
+                </code>
+                {decl.required && (
+                  <span style={requiredBadgeStyle}>required</span>
+                )}
+                {decl.sensitive && (
+                  <span style={sensitiveBadgeStyle}>sensitive</span>
+                )}
+              </div>
+              <p style={{
+                fontSize: "11px",
+                color: "var(--fg-muted)",
+                margin: "2px 0 0",
+              }}>
+                {decl.description}
+              </p>
+              {decl.default !== undefined && (
+                <p style={{
+                  fontSize: "11px",
+                  fontStyle: "italic",
+                  color: "var(--fg-subtle)",
+                  margin: "2px 0 0",
+                }}>
+                  default: {decl.default}
+                </p>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </SectionCard>
+  );
+}

--- a/apps/desktop/src/pages/harness/harness-file/ExtendsSection.tsx
+++ b/apps/desktop/src/pages/harness/harness-file/ExtendsSection.tsx
@@ -1,0 +1,52 @@
+import type { CSSProperties } from "react";
+import SectionCard from "./SectionCard";
+
+interface ExtendEntry {
+  source: string;
+  version?: string;
+}
+
+interface ExtendsSectionProps {
+  extends_: ExtendEntry[];
+}
+
+const versionBadgeStyle: CSSProperties = {
+  fontSize: "10px",
+  padding: "1px 6px",
+  borderRadius: "10px",
+  background: "var(--bg-elevated)",
+  color: "var(--fg-subtle)",
+  flexShrink: 0,
+};
+
+export default function ExtendsSection({ extends_ }: ExtendsSectionProps) {
+  return (
+    <SectionCard
+      label="Extends"
+      explanation="Other harness profiles this one inherits from."
+      count={extends_.length}
+    >
+      <div className="row-list">
+        {extends_.map((entry, i) => (
+          <div key={`${entry.source}-${i}`} className="row-list-item">
+            <code style={{
+              fontFamily: "ui-monospace, monospace",
+              fontSize: "12px",
+              color: "var(--fg-base)",
+              flex: 1,
+              minWidth: 0,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}>
+              {entry.source}
+            </code>
+            {entry.version && (
+              <span style={versionBadgeStyle}>{entry.version}</span>
+            )}
+          </div>
+        ))}
+      </div>
+    </SectionCard>
+  );
+}

--- a/apps/desktop/src/pages/harness/harness-file/InstructionsSection.tsx
+++ b/apps/desktop/src/pages/harness/harness-file/InstructionsSection.tsx
@@ -1,0 +1,78 @@
+import type { CSSProperties } from "react";
+import type { HarnessInstructions } from "@harness-kit/core";
+import SectionCard from "./SectionCard";
+
+interface InstructionsSectionProps {
+  instructions: HarnessInstructions;
+}
+
+const subLabelStyle: CSSProperties = {
+  fontSize: "10px",
+  fontWeight: 600,
+  letterSpacing: "0.06em",
+  textTransform: "uppercase",
+  color: "var(--fg-subtle)",
+  marginBottom: "4px",
+};
+
+const preStyle: CSSProperties = {
+  margin: "4px 0 12px",
+  fontFamily: "ui-monospace, monospace",
+  fontSize: "11px",
+  lineHeight: "1.6",
+  color: "var(--fg-muted)",
+  whiteSpace: "pre-wrap",
+  background: "var(--bg-elevated)",
+  padding: "8px 10px",
+  borderRadius: "6px",
+};
+
+const importModeBadgeStyle: CSSProperties = {
+  fontSize: "10px",
+  padding: "1px 6px",
+  borderRadius: "10px",
+  background: "var(--bg-elevated)",
+  color: "var(--fg-subtle)",
+  display: "inline-block",
+  marginBottom: "10px",
+};
+
+const slots: Array<{ key: "operational" | "behavioral" | "identity"; label: string }> = [
+  { key: "operational", label: "Operational" },
+  { key: "behavioral", label: "Behavioral" },
+  { key: "identity", label: "Identity" },
+];
+
+export default function InstructionsSection({ instructions }: InstructionsSectionProps) {
+  const hasContent = slots.some(({ key }) => instructions[key] != null);
+
+  return (
+    <SectionCard
+      label="Instructions"
+      explanation="Text injected into CLAUDE.md, AGENT.md, or equivalent at harness import time."
+    >
+      {instructions["import-mode"] && (
+        <span style={importModeBadgeStyle}>
+          import-mode: {instructions["import-mode"]}
+        </span>
+      )}
+
+      {hasContent ? (
+        slots.map(({ key, label }) => {
+          const content = instructions[key];
+          if (content == null) return null;
+          return (
+            <div key={key}>
+              <div style={subLabelStyle}>{label}</div>
+              <pre style={preStyle}>{content}</pre>
+            </div>
+          );
+        })
+      ) : (
+        <p style={{ fontSize: "12px", color: "var(--fg-subtle)", margin: 0 }}>
+          No instruction content.
+        </p>
+      )}
+    </SectionCard>
+  );
+}

--- a/apps/desktop/src/pages/harness/harness-file/McpServersSection.tsx
+++ b/apps/desktop/src/pages/harness/harness-file/McpServersSection.tsx
@@ -1,0 +1,59 @@
+import type { CSSProperties } from "react";
+import type { McpServer } from "@harness-kit/core";
+import SectionCard from "./SectionCard";
+
+interface McpServersSectionProps {
+  servers: Record<string, McpServer>;
+}
+
+const transportBadgeStyle: CSSProperties = {
+  fontSize: "10px",
+  padding: "1px 6px",
+  borderRadius: "10px",
+  background: "var(--accent-light)",
+  color: "var(--accent-text)",
+  flexShrink: 0,
+};
+
+export default function McpServersSection({ servers }: McpServersSectionProps) {
+  const entries = Object.entries(servers);
+
+  return (
+    <SectionCard
+      label="MCP Servers"
+      explanation="External tool servers connected via Model Context Protocol."
+      count={entries.length}
+    >
+      <div className="row-list">
+        {entries.map(([name, server]) => (
+          <div key={name} className="row-list-item">
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                <code style={{
+                  fontFamily: "ui-monospace, monospace",
+                  fontSize: "12px",
+                  color: "var(--fg-base)",
+                }}>
+                  {name}
+                </code>
+                <span style={transportBadgeStyle}>{server.transport}</span>
+              </div>
+              <p style={{
+                fontSize: "11px",
+                color: "var(--fg-muted)",
+                margin: "2px 0 0",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}>
+                {server.transport === "stdio"
+                  ? server.command
+                  : server.url}
+              </p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </SectionCard>
+  );
+}

--- a/apps/desktop/src/pages/harness/harness-file/MetadataSection.tsx
+++ b/apps/desktop/src/pages/harness/harness-file/MetadataSection.tsx
@@ -1,0 +1,75 @@
+import type { CSSProperties } from "react";
+import type { HarnessMetadata } from "@harness-kit/core";
+import SectionCard from "./SectionCard";
+
+interface MetadataSectionProps {
+  metadata: HarnessMetadata;
+}
+
+const pillStyle: CSSProperties = {
+  fontSize: "10px",
+  padding: "1px 7px",
+  borderRadius: "10px",
+  background: "var(--bg-elevated)",
+  color: "var(--fg-subtle)",
+  lineHeight: "16px",
+};
+
+export default function MetadataSection({ metadata }: MetadataSectionProps) {
+  return (
+    <SectionCard
+      label="Metadata"
+      explanation="Identity and ownership of this harness profile."
+    >
+      <code style={{
+        fontFamily: "ui-monospace, monospace",
+        fontSize: "15px",
+        fontWeight: 500,
+        color: "var(--fg-base)",
+        display: "block",
+      }}>
+        {metadata.name}
+      </code>
+
+      {metadata.description && (
+        <p style={{
+          fontSize: "12px",
+          fontStyle: "italic",
+          color: "var(--fg-muted)",
+          margin: "4px 0 0",
+        }}>
+          {metadata.description}
+        </p>
+      )}
+
+      {(metadata.version || metadata.license) && (
+        <div style={{ display: "flex", gap: "6px", marginTop: "8px", flexWrap: "wrap" }}>
+          {metadata.version && (
+            <span style={pillStyle}>v{metadata.version}</span>
+          )}
+          {metadata.license && (
+            <span style={pillStyle}>{metadata.license}</span>
+          )}
+        </div>
+      )}
+
+      {metadata.author && (
+        <p style={{
+          fontSize: "11px",
+          color: "var(--fg-subtle)",
+          margin: "6px 0 0",
+        }}>
+          by {metadata.author.name}
+        </p>
+      )}
+
+      {metadata.tags && metadata.tags.length > 0 && (
+        <div style={{ display: "flex", gap: "5px", marginTop: "8px", flexWrap: "wrap" }}>
+          {metadata.tags.map((tag) => (
+            <span key={tag} style={pillStyle}>{tag}</span>
+          ))}
+        </div>
+      )}
+    </SectionCard>
+  );
+}

--- a/apps/desktop/src/pages/harness/harness-file/PermissionsSection.tsx
+++ b/apps/desktop/src/pages/harness/harness-file/PermissionsSection.tsx
@@ -65,15 +65,11 @@ export default function PermissionsSection({ permissions }: PermissionsSectionPr
   const hasTools = tools && (tools.allow?.length || tools.deny?.length || tools.ask?.length);
   const hasPaths = paths && (paths.writable?.length || paths.readonly?.length);
   const hasNetwork = network?.["allowed-hosts"]?.length;
-  let isFirst = true;
 
-  const getSubLabelStyle = () => {
-    if (isFirst) {
-      isFirst = false;
-      return firstSubLabelStyle;
-    }
-    return subLabelStyle;
-  };
+  // Determine which sub-section renders first so we can zero its top margin.
+  const firstSection = hasTools ? "tools" : hasPaths ? "paths" : "network";
+  const labelStyle = (section: string): CSSProperties =>
+    section === firstSection ? firstSubLabelStyle : subLabelStyle;
 
   return (
     <SectionCard
@@ -82,7 +78,7 @@ export default function PermissionsSection({ permissions }: PermissionsSectionPr
     >
       {hasTools && (
         <div>
-          <div style={getSubLabelStyle()}>Tools</div>
+          <div style={labelStyle("tools")}>Tools</div>
           {tools?.allow && tools.allow.length > 0 && (
             <div style={pillRowStyle}>
               {tools.allow.map((t) => (
@@ -109,7 +105,7 @@ export default function PermissionsSection({ permissions }: PermissionsSectionPr
 
       {hasPaths && (
         <div>
-          <div style={getSubLabelStyle()}>Paths</div>
+          <div style={labelStyle("paths")}>Paths</div>
           {paths?.writable && paths.writable.length > 0 && (
             <div style={{ marginBottom: "6px" }}>
               {paths.writable.map((p) => (
@@ -129,7 +125,7 @@ export default function PermissionsSection({ permissions }: PermissionsSectionPr
 
       {hasNetwork && (
         <div>
-          <div style={getSubLabelStyle()}>Network</div>
+          <div style={labelStyle("network")}>Network</div>
           {network?.["allowed-hosts"]?.map((host) => (
             <code key={host} style={monoPathStyle}>{host}</code>
           ))}

--- a/apps/desktop/src/pages/harness/harness-file/PermissionsSection.tsx
+++ b/apps/desktop/src/pages/harness/harness-file/PermissionsSection.tsx
@@ -1,0 +1,146 @@
+import type { CSSProperties } from "react";
+import type { HarnessPermissions } from "@harness-kit/core";
+import SectionCard from "./SectionCard";
+
+interface PermissionsSectionProps {
+  permissions: HarnessPermissions;
+}
+
+const subLabelStyle: CSSProperties = {
+  fontSize: "10px",
+  fontWeight: 600,
+  letterSpacing: "0.06em",
+  textTransform: "uppercase",
+  color: "var(--fg-subtle)",
+  marginBottom: "6px",
+  marginTop: "12px",
+};
+
+const firstSubLabelStyle: CSSProperties = {
+  ...subLabelStyle,
+  marginTop: 0,
+};
+
+const allowBadgeStyle: CSSProperties = {
+  fontSize: "11px",
+  padding: "1px 8px",
+  borderRadius: "10px",
+  background: "rgba(40,167,69,0.12)",
+  color: "#28a745",
+};
+
+const denyBadgeStyle: CSSProperties = {
+  fontSize: "11px",
+  padding: "1px 8px",
+  borderRadius: "10px",
+  background: "rgba(220,53,69,0.12)",
+  color: "var(--danger)",
+};
+
+const askBadgeStyle: CSSProperties = {
+  fontSize: "11px",
+  padding: "1px 8px",
+  borderRadius: "10px",
+  background: "rgba(255,193,7,0.15)",
+  color: "#856404",
+};
+
+const pillRowStyle: CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: "4px",
+  marginBottom: "8px",
+};
+
+const monoPathStyle: CSSProperties = {
+  fontFamily: "ui-monospace, monospace",
+  fontSize: "11px",
+  color: "var(--fg-muted)",
+  display: "block",
+  padding: "1px 0",
+};
+
+export default function PermissionsSection({ permissions }: PermissionsSectionProps) {
+  const { tools, paths, network } = permissions;
+  const hasTools = tools && (tools.allow?.length || tools.deny?.length || tools.ask?.length);
+  const hasPaths = paths && (paths.writable?.length || paths.readonly?.length);
+  const hasNetwork = network?.["allowed-hosts"]?.length;
+  let isFirst = true;
+
+  const getSubLabelStyle = () => {
+    if (isFirst) {
+      isFirst = false;
+      return firstSubLabelStyle;
+    }
+    return subLabelStyle;
+  };
+
+  return (
+    <SectionCard
+      label="Permissions"
+      explanation="Tool access controls, writable paths, and network rules."
+    >
+      {hasTools && (
+        <div>
+          <div style={getSubLabelStyle()}>Tools</div>
+          {tools?.allow && tools.allow.length > 0 && (
+            <div style={pillRowStyle}>
+              {tools.allow.map((t) => (
+                <span key={t} style={allowBadgeStyle}>{t}</span>
+              ))}
+            </div>
+          )}
+          {tools?.deny && tools.deny.length > 0 && (
+            <div style={pillRowStyle}>
+              {tools.deny.map((t) => (
+                <span key={t} style={denyBadgeStyle}>{t}</span>
+              ))}
+            </div>
+          )}
+          {tools?.ask && tools.ask.length > 0 && (
+            <div style={pillRowStyle}>
+              {tools.ask.map((t) => (
+                <span key={t} style={askBadgeStyle}>{t}</span>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {hasPaths && (
+        <div>
+          <div style={getSubLabelStyle()}>Paths</div>
+          {paths?.writable && paths.writable.length > 0 && (
+            <div style={{ marginBottom: "6px" }}>
+              {paths.writable.map((p) => (
+                <code key={p} style={{ ...monoPathStyle, color: "#28a745" }}>{p}</code>
+              ))}
+            </div>
+          )}
+          {paths?.readonly && paths.readonly.length > 0 && (
+            <div style={{ marginBottom: "6px" }}>
+              {paths.readonly.map((p) => (
+                <code key={p} style={monoPathStyle}>{p}</code>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {hasNetwork && (
+        <div>
+          <div style={getSubLabelStyle()}>Network</div>
+          {network?.["allowed-hosts"]?.map((host) => (
+            <code key={host} style={monoPathStyle}>{host}</code>
+          ))}
+        </div>
+      )}
+
+      {!hasTools && !hasPaths && !hasNetwork && (
+        <p style={{ fontSize: "12px", color: "var(--fg-subtle)", margin: 0 }}>
+          No permissions configured.
+        </p>
+      )}
+    </SectionCard>
+  );
+}

--- a/apps/desktop/src/pages/harness/harness-file/PluginsSection.tsx
+++ b/apps/desktop/src/pages/harness/harness-file/PluginsSection.tsx
@@ -1,0 +1,67 @@
+import type { CSSProperties } from "react";
+import type { HarnessPlugin } from "@harness-kit/core";
+import SectionCard from "./SectionCard";
+
+interface PluginsSectionProps {
+  plugins: HarnessPlugin[];
+}
+
+const versionBadgeStyle: CSSProperties = {
+  fontSize: "10px",
+  padding: "1px 6px",
+  borderRadius: "10px",
+  background: "var(--bg-elevated)",
+  color: "var(--fg-subtle)",
+  flexShrink: 0,
+};
+
+export default function PluginsSection({ plugins }: PluginsSectionProps) {
+  return (
+    <SectionCard
+      label="Plugins"
+      explanation="Skills and agents installed from plugin sources."
+      count={plugins.length}
+    >
+      <div className="row-list">
+        {plugins.map((plugin, i) => (
+          <div key={`${plugin.name}-${i}`} className="row-list-item">
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                <code style={{
+                  fontFamily: "ui-monospace, monospace",
+                  fontSize: "12px",
+                  color: "var(--fg-base)",
+                }}>
+                  {plugin.name}
+                </code>
+                <span style={{
+                  fontSize: "11px",
+                  color: "var(--fg-muted)",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                  flex: 1,
+                }}>
+                  {plugin.source}
+                </span>
+              </div>
+              {plugin.description && (
+                <p style={{
+                  fontSize: "11px",
+                  fontStyle: "italic",
+                  color: "var(--fg-muted)",
+                  margin: "2px 0 0",
+                }}>
+                  {plugin.description}
+                </p>
+              )}
+            </div>
+            {plugin.version && (
+              <span style={versionBadgeStyle}>{plugin.version}</span>
+            )}
+          </div>
+        ))}
+      </div>
+    </SectionCard>
+  );
+}

--- a/apps/desktop/src/pages/harness/harness-file/SectionCard.tsx
+++ b/apps/desktop/src/pages/harness/harness-file/SectionCard.tsx
@@ -1,0 +1,59 @@
+import type { CSSProperties } from "react";
+
+interface SectionCardProps {
+  label: string;
+  explanation: string;
+  count?: number;
+  children: React.ReactNode;
+}
+
+const labelStyle: CSSProperties = {
+  fontSize: "10px",
+  fontWeight: 600,
+  letterSpacing: "0.06em",
+  textTransform: "uppercase",
+  color: "var(--fg-subtle)",
+  display: "flex",
+  alignItems: "center",
+  gap: "6px",
+};
+
+const countBadgeStyle: CSSProperties = {
+  fontSize: "10px",
+  fontWeight: 500,
+  padding: "0 6px",
+  borderRadius: "10px",
+  background: "var(--bg-elevated)",
+  color: "var(--fg-subtle)",
+  lineHeight: "16px",
+};
+
+const explanationStyle: CSSProperties = {
+  fontSize: "11px",
+  fontStyle: "italic",
+  color: "var(--fg-muted)",
+  margin: "2px 0 0",
+};
+
+const cardStyle: CSSProperties = {
+  background: "var(--bg-surface)",
+  border: "1px solid var(--border-base)",
+  borderRadius: "8px",
+  padding: "12px",
+  marginTop: "8px",
+};
+
+export default function SectionCard({ label, explanation, count, children }: SectionCardProps) {
+  return (
+    <div>
+      <div style={labelStyle}>
+        <span>{label}</span>
+        {count !== undefined && (
+          <span style={countBadgeStyle}>{count}</span>
+        )}
+      </div>
+      <p style={explanationStyle}>{explanation}</p>
+      <div style={cardStyle}>{children}</div>
+    </div>
+  );
+}

--- a/apps/desktop/src/pages/harness/harness-file/ValidationBanner.tsx
+++ b/apps/desktop/src/pages/harness/harness-file/ValidationBanner.tsx
@@ -1,0 +1,77 @@
+import type { CSSProperties } from "react";
+import type { ValidationResult } from "@harness-kit/core";
+
+interface ValidationBannerProps {
+  result: ValidationResult;
+}
+
+export default function ValidationBanner({ result }: ValidationBannerProps) {
+  if (result.valid && !result.isLegacyFormat) {
+    const style: CSSProperties = {
+      background: "var(--accent-light)",
+      color: "var(--accent-text)",
+      borderRadius: "8px",
+      padding: "10px 12px",
+      fontSize: "13px",
+      display: "flex",
+      alignItems: "center",
+      gap: "6px",
+    };
+    return (
+      <div style={style}>
+        <span>✓</span>
+        <span>Valid harness.yaml</span>
+      </div>
+    );
+  }
+
+  if (result.isLegacyFormat) {
+    const style: CSSProperties = {
+      background: "var(--bg-surface)",
+      color: "var(--fg-muted)",
+      border: "1px solid var(--border-base)",
+      borderRadius: "8px",
+      padding: "10px 12px",
+      fontSize: "13px",
+    };
+    return (
+      <div style={style}>
+        Legacy format detected — consider upgrading to Protocol v1
+      </div>
+    );
+  }
+
+  const MAX_SHOWN = 5;
+  const shown = result.errors.slice(0, MAX_SHOWN);
+  const overflow = result.errors.length - MAX_SHOWN;
+
+  const style: CSSProperties = {
+    background: "var(--bg-surface)",
+    color: "var(--danger)",
+    border: "1px solid var(--border-base)",
+    borderRadius: "8px",
+    padding: "10px 12px",
+    fontSize: "13px",
+  };
+
+  const listStyle: CSSProperties = {
+    margin: "6px 0 0",
+    paddingLeft: "16px",
+    fontSize: "12px",
+    lineHeight: "1.6",
+  };
+
+  return (
+    <div style={style}>
+      <span style={{ fontWeight: 600 }}>Validation errors:</span>
+      <ul style={listStyle}>
+        {shown.map((err, i) => (
+          <li key={i}>{err.message}</li>
+        ))}
+        {overflow > 0 && (
+          <li style={{ color: "var(--fg-muted)" }}>+{overflow} more</li>
+        )}
+      </ul>
+    </div>
+  );
+}

--- a/apps/desktop/src/pages/marketplace/BrowsePage.tsx
+++ b/apps/desktop/src/pages/marketplace/BrowsePage.tsx
@@ -186,6 +186,24 @@ export default function BrowsePage() {
     };
   }
 
+  function typeChipStyle(active: boolean) {
+    return {
+      fontSize: "10px",
+      fontWeight: active ? 500 : 400,
+      padding: "2px 7px",
+      borderRadius: "4px",
+      border: "1px solid var(--border-base)",
+      background: active ? "var(--accent-light)" : "transparent",
+      color: active ? "var(--accent-text)" : "var(--fg-subtle)",
+      cursor: "pointer",
+      transition: "background 0.1s, color 0.1s",
+      whiteSpace: "nowrap" as const,
+      flexShrink: 0,
+      letterSpacing: "0.04em",
+      textTransform: "uppercase" as const,
+    };
+  }
+
   function sortTabStyle(active: boolean) {
     return {
       fontSize: "11px",
@@ -299,14 +317,14 @@ export default function BrowsePage() {
         </div>
       )}
 
-      {/* Type pills */}
-      <div style={{ display: "flex", gap: "6px", flexWrap: "wrap", marginBottom: "14px" }}>
+      {/* Type chips */}
+      <div style={{ display: "flex", gap: "5px", flexWrap: "wrap", marginBottom: "14px" }}>
         {COMPONENT_TYPES.map((t) => (
           <button
             key={t}
             onClick={() => toggleType(t)}
             aria-pressed={selectedType === t}
-            style={pillStyle(selectedType === t)}
+            style={typeChipStyle(selectedType === t)}
           >
             {t}
           </button>

--- a/apps/desktop/src/pages/marketplace/BrowsePage.tsx
+++ b/apps/desktop/src/pages/marketplace/BrowsePage.tsx
@@ -14,6 +14,7 @@ type SortBy = "installs" | "recent";
 
 const COMPONENT_TYPES: ComponentType[] = [
   "skill",
+  "plugin",
   "agent",
   "hook",
   "script",
@@ -45,14 +46,16 @@ function TrustBadge({ tier }: { tier: Component["trust_tier"] }) {
 }
 
 function TypeBadge({ type }: { type: ComponentType }) {
+  const isPlugin = type === "plugin";
   return (
     <span style={{
       fontSize: "10px",
       fontWeight: 400,
       padding: "1px 6px",
       borderRadius: "10px",
-      border: "1px solid var(--border-base)",
-      color: "var(--fg-subtle)",
+      background: isPlugin ? "rgba(139,92,246,0.08)" : undefined,
+      border: isPlugin ? "1px solid rgba(139,92,246,0.2)" : "1px solid var(--border-base)",
+      color: isPlugin ? "#a78bfa" : "var(--fg-subtle)",
       textTransform: "capitalize",
     }}>
       {type}
@@ -373,7 +376,8 @@ export default function BrowsePage() {
               className="row-list-item"
               onClick={() => navigate(`/marketplace/${plugin.slug}`)}
               style={{
-                justifyContent: "space-between",
+                display: "flex",
+                alignItems: "center",
                 width: "100%",
                 background: "none",
                 border: "none",
@@ -382,13 +386,9 @@ export default function BrowsePage() {
               }}
             >
               <div style={{ minWidth: 0, flex: 1 }}>
-                <div style={{ display: "flex", alignItems: "center", gap: "6px", flexWrap: "wrap" }}>
-                  <span style={{ fontSize: "13px", fontWeight: 500, color: "var(--fg-base)" }}>
-                    {plugin.name}
-                  </span>
-                  <TrustBadge tier={plugin.trust_tier} />
-                  <TypeBadge type={plugin.type} />
-                </div>
+                <span style={{ fontSize: "13px", fontWeight: 500, color: "var(--fg-base)" }}>
+                  {plugin.name}
+                </span>
                 {plugin.description && (
                   <p style={{
                     fontSize: "11px",
@@ -402,6 +402,10 @@ export default function BrowsePage() {
                     {plugin.description}
                   </p>
                 )}
+              </div>
+              <div style={{ flexShrink: 0, display: "flex", gap: "6px", minWidth: "120px", justifyContent: "flex-end", alignItems: "center" }}>
+                <TrustBadge tier={plugin.trust_tier} />
+                <TypeBadge type={plugin.type} />
               </div>
               <div style={{ flexShrink: 0, marginLeft: "12px", textAlign: "right" }}>
                 <div style={{ fontSize: "11px", fontFamily: "ui-monospace, monospace", color: "var(--fg-subtle)", fontVariantNumeric: "tabular-nums" }}>

--- a/apps/desktop/src/pages/marketplace/PluginDetailPage.tsx
+++ b/apps/desktop/src/pages/marketplace/PluginDetailPage.tsx
@@ -6,6 +6,31 @@ import type { Component } from "@harness-kit/shared";
 
 type RelatedComponent = Pick<Component, "id" | "slug" | "name" | "install_count">;
 
+interface SkillSection {
+  id: string;
+  name: string;
+  content: string;
+}
+
+function parseSkillSections(skillMd: string): SkillSection[] {
+  // Split only where the separator is followed by frontmatter (---\n), not a markdown hr
+  const sections = skillMd.split(/\n\n---\n\n(?=---\n)/);
+  return sections.map((content, i) => {
+    let name = `Skill ${i + 1}`;
+    const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+    if (fmMatch) {
+      const nameMatch = fmMatch[1].match(/^name:\s*(.+)$/m);
+      if (nameMatch) {
+        name = nameMatch[1].trim()
+          .split(/[-_]/)
+          .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+          .join(" ");
+      }
+    }
+    return { id: `skill-section-${i}`, name, content };
+  });
+}
+
 function TrustBadge({ tier }: { tier: Component["trust_tier"] }) {
   const colors: Record<Component["trust_tier"], { bg: string; color: string }> = {
     official: { bg: "rgba(59,130,246,0.12)", color: "#3b82f6" },
@@ -169,6 +194,8 @@ export default function PluginDetailPage() {
       })
     : null;
 
+  const skillSections = component.skill_md ? parseSkillSections(component.skill_md) : [];
+
 
   return (
     <div style={{ padding: "20px 24px" }}>
@@ -235,9 +262,14 @@ export default function PluginDetailPage() {
             </div>
           )}
 
-          {component.skill_md && (
-            <MarkdownPanel content={component.skill_md} title="Skill Definition" />
+          {skillSections.length === 1 && (
+            <MarkdownPanel content={skillSections[0].content} title="Skill Definition" />
           )}
+          {skillSections.length > 1 && skillSections.map((sec) => (
+            <div key={sec.id} id={sec.id}>
+              <MarkdownPanel content={sec.content} title={sec.name} />
+            </div>
+          ))}
 
           {component.readme_md && (
             <MarkdownPanel content={component.readme_md} title="Documentation" />
@@ -245,8 +277,36 @@ export default function PluginDetailPage() {
         </div>
 
         {/* ── Sidebar ── */}
-        <aside style={{ width: "200px", flexShrink: 0 }}>
+        <aside style={{ width: "200px", flexShrink: 0, position: "sticky", top: "20px", alignSelf: "flex-start" }}>
           <div style={{ display: "flex", flexDirection: "column", gap: "10px" }}>
+            {/* TOC — only for multi-skill packages */}
+            {skillSections.length > 1 && (
+              <SidebarCard>
+                <SidebarLabel>Contents</SidebarLabel>
+                <ul style={{ margin: 0, padding: 0, listStyle: "none", display: "flex", flexDirection: "column", gap: "2px" }}>
+                  {skillSections.map((sec) => (
+                    <li key={sec.id}>
+                      <button
+                        onClick={() => document.getElementById(sec.id)?.scrollIntoView({ behavior: "smooth", block: "start" })}
+                        style={{
+                          background: "none",
+                          border: "none",
+                          padding: "2px 0",
+                          cursor: "pointer",
+                          fontSize: "12px",
+                          color: "var(--accent-text)",
+                          textAlign: "left",
+                          width: "100%",
+                        }}
+                      >
+                        {sec.name}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </SidebarCard>
+            )}
+
             {/* Install command */}
             <SidebarCard>
               <SidebarLabel>Install</SidebarLabel>

--- a/apps/desktop/src/pages/marketplace/__tests__/BrowsePage.test.tsx
+++ b/apps/desktop/src/pages/marketplace/__tests__/BrowsePage.test.tsx
@@ -11,7 +11,7 @@ const mockComponents: Component[] = [
     id: "comp-1",
     slug: "research",
     name: "Research",
-    type: "skill",
+    type: "plugin",
     description: "Process any source into a knowledge base",
     trust_tier: "official",
     version: "0.3.0",
@@ -242,7 +242,8 @@ describe("BrowsePage — configured", () => {
     it("shows type badges", async () => {
       renderBrowse();
       await screen.findByText("Research");
-      // "skill" appears as a badge (multiple — badge + pill)
+      // "plugin" badge appears for Research (comp-1), "skill" badge for Explain (comp-2)
+      expect(screen.getAllByText("plugin").length).toBeGreaterThan(0);
       expect(screen.getAllByText("skill").length).toBeGreaterThan(0);
       expect(screen.getAllByText("agent").length).toBeGreaterThan(0);
     });

--- a/apps/desktop/src/pages/marketplace/__tests__/BrowsePage.test.tsx
+++ b/apps/desktop/src/pages/marketplace/__tests__/BrowsePage.test.tsx
@@ -363,6 +363,19 @@ describe("BrowsePage — configured", () => {
       expect(screen.getByText("Data Lineage")).toBeInTheDocument();
     });
 
+    it("filters to plugin-type components when plugin pill is clicked", async () => {
+      renderBrowse();
+      await screen.findByText("Research");
+
+      fireEvent.click(screen.getByRole("button", { name: "plugin" }));
+
+      await waitFor(() => {
+        expect(screen.queryByText("Explain")).not.toBeInTheDocument();
+        expect(screen.queryByText("Data Lineage")).not.toBeInTheDocument();
+      });
+      expect(screen.getByText("Research")).toBeInTheDocument();
+    });
+
     it("clears type filter on second click", async () => {
       renderBrowse();
       await screen.findByText("Research");

--- a/apps/desktop/src/pages/marketplace/__tests__/PluginDetailPage.test.tsx
+++ b/apps/desktop/src/pages/marketplace/__tests__/PluginDetailPage.test.tsx
@@ -275,7 +275,7 @@ describe("PluginDetailPage — configured", () => {
       mockSupabase = makeMockClient();
     });
 
-    it("renders SKILL.md section heading", async () => {
+    it("renders SKILL.md section heading for single-skill package", async () => {
       renderDetail();
       expect(await screen.findByText("Skill Definition")).toBeInTheDocument();
     });
@@ -303,6 +303,27 @@ describe("PluginDetailPage — configured", () => {
       });
       renderDetail();
       await screen.findByText("Research");
+      expect(screen.queryByText("Skill Definition")).not.toBeInTheDocument();
+    });
+
+    it("renders TOC and named sections for multi-skill packages", async () => {
+      const multiSkillMd = [
+        "---\nname: harness-compile\ndescription: Compile stuff.\n---\n\n# Harness Compile\n\nCompile content.",
+        "---\nname: harness-export\ndescription: Export stuff.\n---\n\n# Harness Export\n\nExport content.",
+      ].join("\n\n---\n\n");
+
+      mockSupabase = makeMockClient({
+        component: { ...mockComponent, skill_md: multiSkillMd },
+      });
+      renderDetail();
+      await screen.findByText("Research");
+
+      // TOC Contents label and skill links
+      expect(screen.getByText("Contents")).toBeInTheDocument();
+      expect(screen.getAllByText("Harness Compile").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Harness Export").length).toBeGreaterThan(0);
+
+      // Single-skill heading should not appear
       expect(screen.queryByText("Skill Definition")).not.toBeInTheDocument();
     });
 

--- a/marketplace/app/api/sync/route.ts
+++ b/marketplace/app/api/sync/route.ts
@@ -151,8 +151,8 @@ export async function POST(request: NextRequest) {
   const results: Array<{ name: string; status: string }> = [];
 
   for (const plugin of manifest.plugins) {
-    // Resolve source path: "./research" -> "plugins/research"
-    const pluginDir = `plugins/${plugin.source.replace("./", "")}`;
+    // Resolve source path: "./plugins/research" -> "plugins/research"
+    const pluginDir = plugin.source.replace("./", "");
 
     // Try to fetch SKILL.md and README.md
     const skillMd = await fetchRepoFile(

--- a/marketplace/app/api/sync/route.ts
+++ b/marketplace/app/api/sync/route.ts
@@ -39,6 +39,45 @@ async function verifySignature(
   return result === 0;
 }
 
+/** List the top-level entries in a repo directory. Returns null on failure. */
+async function fetchRepoDirEntries(
+  dirPath: string,
+): Promise<{ name: string; type: string }[] | null> {
+  const url = `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/contents/${dirPath}`;
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github.v3+json",
+    "User-Agent": "harness-kit-marketplace",
+  };
+  const token = process.env.GITHUB_TOKEN;
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const res = await fetch(url, { headers });
+  if (!res.ok) return null;
+  const data = await res.json();
+  return Array.isArray(data) ? data : null;
+}
+
+/** Derive "skill" vs "plugin" by inspecting the plugin directory on GitHub. */
+async function derivePluginType(
+  pluginDir: string,
+): Promise<"skill" | "plugin"> {
+  const entries = await fetchRepoDirEntries(pluginDir);
+  if (!entries) return "skill";
+
+  const topNames = new Set(entries.filter((e) => e.type === "dir").map((e) => e.name));
+  if (topNames.has("agents") || topNames.has("scripts") || topNames.has("hooks")) {
+    return "plugin";
+  }
+
+  // Count skill subdirectories
+  const skillsEntries = await fetchRepoDirEntries(`${pluginDir}/skills`);
+  if (skillsEntries) {
+    const skillDirCount = skillsEntries.filter((e) => e.type === "dir").length;
+    if (skillDirCount > 1) return "plugin";
+  }
+
+  return "skill";
+}
+
 /** Fetch a file from the GitHub repo. */
 async function fetchRepoFile(path: string): Promise<string | null> {
   const url = `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/contents/${path}`;
@@ -123,10 +162,11 @@ export async function POST(request: NextRequest) {
       `${pluginDir}/skills/${plugin.name}/README.md`,
     );
 
+    const componentType = await derivePluginType(pluginDir);
+
     // Auto-extract tags from plugin manifest + description
     const autoTags = new Set(plugin.tags ?? []);
-    // Add type-based tag
-    autoTags.add("skill");
+    autoTags.add(componentType);
 
     // Upsert component
     const { error } = await supabase
@@ -135,7 +175,7 @@ export async function POST(request: NextRequest) {
         {
           slug: plugin.name,
           name: plugin.name,
-          type: "skill",
+          type: componentType,
           description: plugin.description,
           trust_tier: "official",
           version: plugin.version,

--- a/marketplace/supabase/migrations/00004_add_plugin_type.sql
+++ b/marketplace/supabase/migrations/00004_add_plugin_type.sql
@@ -1,0 +1,4 @@
+-- Add "plugin" to the components type enum
+alter table components drop constraint components_type_check;
+alter table components add constraint components_type_check
+  check (type in ('skill', 'plugin', 'agent', 'hook', 'script', 'knowledge', 'rules'));

--- a/marketplace/supabase/seed.ts
+++ b/marketplace/supabase/seed.ts
@@ -85,6 +85,31 @@ function readSkillMds(pluginName: string): string | null {
 }
 
 /**
+ * Derives whether a plugin should be classified as "skill" or "plugin".
+ * A plugin is a "skill" only if it has exactly one skill directory and no agents,
+ * scripts, or hooks directories. Everything else is a "plugin".
+ */
+function derivePluginType(pluginName: string): "skill" | "plugin" {
+  const pluginDir = path.join(PLUGINS_DIR, pluginName);
+  const skillsDir = path.join(pluginDir, "skills");
+
+  let skillCount = 0;
+  if (fs.existsSync(skillsDir)) {
+    skillCount = fs
+      .readdirSync(skillsDir, { withFileTypes: true })
+      .filter((d) => d.isDirectory()).length;
+  }
+
+  const hasAgents = fs.existsSync(path.join(pluginDir, "agents"));
+  const hasScripts = fs.existsSync(path.join(pluginDir, "scripts"));
+  const hasHooks = fs.existsSync(path.join(pluginDir, "hooks"));
+
+  return skillCount > 1 || hasAgents || hasScripts || hasHooks
+    ? "plugin"
+    : "skill";
+}
+
+/**
  * Reads and concatenates all README.md files found under a plugin's skills/ directory.
  */
 function readReadmeMds(pluginName: string): string | null {
@@ -175,7 +200,7 @@ async function seedComponents(
     const component = {
       slug: plugin.name,
       name: displayName,
-      type: "skill" as const,
+      type: derivePluginType(plugin.name),
       description: plugin.description,
       trust_tier: "official" as const,
       version: plugin.version,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -2,6 +2,7 @@
 
 export type ComponentType =
   | "skill"
+  | "plugin"
   | "agent"
   | "hook"
   | "script"

--- a/website/content/docs/concepts/harness-protocol.md
+++ b/website/content/docs/concepts/harness-protocol.md
@@ -13,8 +13,12 @@ harness-kit is the **reference implementation** of the Harness Protocol. The rel
 
 Conformance does not require harness-kit. Any tool that correctly validates and applies `harness.yaml` according to the specification is a conformant implementation.
 
+## Desktop App
+
+The harness-kit desktop app treats `harness.yaml` as a first-class element. The **Harness File** page (the default landing page under the Harness section) reads `~/.claude/harness.yaml` or `~/harness.yaml` and displays a structured, annotated breakdown of each section — plugins, MCP servers, env declarations, instructions, permissions, and extends — with a raw YAML toggle.
+
 ## Links
 
 - [Harness Protocol spec](https://harnessprotocol.io) — full specification, including architecture, field reference, security model, and plugin manifest format
-- [JSON Schema](https://harnessprotocol.io) — machine-readable validation schema
+- [JSON Schema](https://harnessprotocol.ai/schema/v1/harness.schema.json) — machine-readable validation schema
 - [harness-kit](https://github.com/harnessprotocol/harness-kit) — reference implementation

--- a/website/content/docs/faq.md
+++ b/website/content/docs/faq.md
@@ -73,7 +73,7 @@ MCP servers give your AI new tools — database access, web search, external API
 
 ## What is the harness.yaml file?
 
-A list of your installed plugins with their sources and versions. Export it with `/harness-export`, commit it, and restore it anywhere with `/harness-import` or `harness-restore.sh`. See [`harness.yaml.example`](https://github.com/harnessprotocol/harness-kit/blob/main/harness.yaml.example) for the format.
+A portable snapshot of your complete AI assistant setup. It captures plugins (with sources and versions), MCP server configurations, environment variable declarations, instructions injected into `CLAUDE.md` or `AGENT.md`, and permissions. Export it with `/harness-export`, commit it to your dotfiles, and restore it anywhere with `/harness-import` or `harness-restore.sh`. See [`harness.yaml.example`](https://github.com/harnessprotocol/harness-kit/blob/main/harness.yaml.example) for the format.
 
 ## I already have prompts in my CLAUDE.md. Should I move them?
 

--- a/website/content/docs/getting-started/architecture.mdx
+++ b/website/content/docs/getting-started/architecture.mdx
@@ -172,7 +172,7 @@ Your entire harness — plugins, versions, sources — serializes into a single 
   <text x="268" y="162" fontFamily="monospace, Menlo, Consolas" fontSize="10" fill="#666">- explain@0.2.0</text>
   <text x="268" y="176" fontFamily="monospace, Menlo, Consolas" fontSize="10" fill="#666">- data-lineage@0.2.0</text>
   <text x="268" y="190" fontFamily="monospace, Menlo, Consolas" fontSize="10" fill="#666">- review@0.2.0</text>
-  <text x="258" y="210" fontFamily="monospace, Menlo, Consolas" fontSize="10" fill="#888">mcp_servers:</text>
+  <text x="258" y="210" fontFamily="monospace, Menlo, Consolas" fontSize="10" fill="#888">mcp-servers:</text>
   <text x="268" y="226" fontFamily="monospace, Menlo, Consolas" fontSize="10" fill="#666">- memory, filesystem</text>
 
   {/* — SHARE METHODS — */}

--- a/website/content/docs/plugins/productivity/harness-share.mdx
+++ b/website/content/docs/plugins/productivity/harness-share.mdx
@@ -80,7 +80,7 @@ Inventories skills, MCP configs, and instruction blocks on each platform, report
 ## Output Format
 
 ```yaml
-$schema: https://harnessprotocol.io/schema/v1/harness.schema.json
+$schema: https://harnessprotocol.ai/schema/v1/harness.schema.json
 version: "1"
 
 metadata:


### PR DESCRIPTION
## Summary

Adds a **Harness File** page as the first item under the Harness section, making it the default landing page. The page reads `harness.yaml` from `~/.claude/harness.yaml` or `~/harness.yaml` and displays a structured, annotated breakdown of each section with inline explanations — or a raw YAML view via toggle.

## Changes

- **Rust**: new `read_harness_file` Tauri command — searches `~/.claude/harness.yaml` then `~/harness.yaml`, enforces home-dir boundary, returns `~`-relative display path (cross-platform)
- **Tauri binding**: `readHarnessFile()` + `HarnessFileResult` interface in `tauri.ts`
- **HarnessFilePage**: loading / error / empty-state / found states; Formatted ↔ Raw toggle
- **9 section components**: `SectionCard`, `ValidationBanner`, `MetadataSection`, `PluginsSection`, `McpServersSection`, `EnvSection`, `InstructionsSection`, `PermissionsSection`, `ExtendsSection`
- **Nav**: "Harness File" inserted as first child under Harness; default section path changed to `/harness/file`
- **Routing**: `<Route path="harness/file">` added to App.tsx

## Test Plan

- [x] Local tests pass (247/247)
- [ ] CI checks pass
- [ ] Open app → sidebar shows "Harness File" as first item under Harness
- [ ] With `~/.claude/harness.yaml` present: formatted view shows sections, validation banner, raw toggle works
- [ ] Without harness.yaml: empty state with explanation and example snippet
- [ ] Test with `harness.yaml.example` (copy to `~/.claude/harness.yaml`) to see all sections

## Notes

- `parseHarness` does an unchecked cast of raw YAML, so section components defensively guard optional fields even when the core type declares them required — this is intentional
- The `PermissionsSection` uses a positional first-section check for margin; could be refactored with an index approach in a follow-up