### PR TITLE
feat(ci): validate plugin.json against Protocol schema

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -88,7 +88,7 @@ jobs:
               print(f'All {len(on_disk)} plugins registered: {sorted(on_disk)}')
           "
 
-      - name: Validate developed_with field
+      - name: Validate x-developed-with field
         run: |
           python3 -c "
           import json, sys, glob
@@ -97,18 +97,18 @@ jobs:
 
           for manifest_path in glob.glob('plugins/*/.claude-plugin/plugin.json'):
               manifest = json.load(open(manifest_path))
-              dw = manifest.get('developed_with')
+              dw = manifest.get('x-developed-with')
               if dw is not None:
                   if not isinstance(dw, str) or not dw.strip():
-                      errors.append(f'{manifest_path}: developed_with must be non-empty string if present, got {dw!r}')
+                      errors.append(f'{manifest_path}: x-developed-with must be non-empty string if present, got {dw!r}')
 
           if errors:
-              print('developed_with validation errors:')
+              print('x-developed-with validation errors:')
               for e in errors:
                   print(f'  {e}')
               sys.exit(1)
           else:
-              print('developed_with field valid (optional).')
+              print('x-developed-with field valid (optional).')
           "
 
       - name: Validate requires.env schema
@@ -142,6 +142,41 @@ jobs:
               sys.exit(1)
           else:
               print('requires.env schema valid.')
+          "
+
+      - name: Validate plugin.json against Protocol schema
+        run: |
+          pip install -q jsonschema 2>/dev/null
+
+          SCHEMA_URL="https://raw.githubusercontent.com/harnessprotocol/harness-protocol/main/schema/draft/plugin.schema.json"
+          curl -sf "$SCHEMA_URL" -o /tmp/plugin.schema.json || {
+            echo "::error::Failed to fetch plugin schema from $SCHEMA_URL"
+            exit 1
+          }
+
+          python3 -c "
+          import json, sys, glob
+          from jsonschema import Draft202012Validator
+
+          schema = json.load(open('/tmp/plugin.schema.json'))
+          validator = Draft202012Validator(schema)
+          errors = []
+
+          for path in sorted(glob.glob('plugins/*/.claude-plugin/plugin.json')):
+              name = path.split('/')[1]
+              manifest = json.load(open(path))
+              for err in validator.iter_errors(manifest):
+                  loc = ' → '.join(str(p) for p in err.absolute_path) or '(root)'
+                  errors.append(f'{name}: [{loc}] {err.message}')
+                  print(f'::error file={path}::{err.message}')
+
+          if errors:
+              print(f'\nSchema validation failed ({len(errors)} error(s)):')
+              for e in errors:
+                  print(f'  {e}')
+              sys.exit(1)
+          else:
+              print('All plugin.json files valid against Protocol schema.')
           "
 
   core-build-test:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -146,10 +146,13 @@ jobs:
 
       - name: Validate plugin.json against Protocol schema
         run: |
-          pip install -q jsonschema 2>/dev/null
+          pip install -q 'jsonschema>=4.18,<5' || {
+            echo "::error::Failed to install jsonschema"
+            exit 1
+          }
 
           SCHEMA_URL="https://raw.githubusercontent.com/harnessprotocol/harness-protocol/main/schema/draft/plugin.schema.json"
-          curl -sf "$SCHEMA_URL" -o /tmp/plugin.schema.json || {
+          curl -sf --max-time 30 "$SCHEMA_URL" -o /tmp/plugin.schema.json || {
             echo "::error::Failed to fetch plugin schema from $SCHEMA_URL"
             exit 1
           }

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -145,15 +145,11 @@ jobs:
           "
 
       - name: Validate plugin.json against Protocol schema
+        # Schema is bundled at schema/plugin.schema.json — sync from harness-protocol
+        # repo (schema/draft/plugin.schema.json) when the upstream schema changes.
         run: |
           pip install -q 'jsonschema>=4.18,<5' || {
             echo "::error::Failed to install jsonschema"
-            exit 1
-          }
-
-          SCHEMA_URL="https://raw.githubusercontent.com/harnessprotocol/harness-protocol/main/schema/draft/plugin.schema.json"
-          curl -sf --max-time 30 "$SCHEMA_URL" -o /tmp/plugin.schema.json || {
-            echo "::error::Failed to fetch plugin schema from $SCHEMA_URL"
             exit 1
           }
 
@@ -161,7 +157,7 @@ jobs:
           import json, sys, glob
           from jsonschema import Draft202012Validator
 
-          schema = json.load(open('/tmp/plugin.schema.json'))
+          schema = json.load(open('schema/plugin.schema.json'))
           validator = Draft202012Validator(schema)
           errors = []
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ harness-kit/
 │   └── marketplace.json          ← marketplace catalog
 ├── .github/
 │   └── workflows/
-│       └── validate.yml          ← CI: manifest parsing + version alignment
+│       └── validate.yml          ← CI: manifest parsing, version alignment, schema validation
 ├── plugins/                      ← one directory per plugin (marketplace)
 │   ├── research/
 │   │   ├── .claude-plugin/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,7 +175,7 @@ Five checks run on every PR via `validate.yml`:
 | JSON manifests valid | `marketplace.json` and all `plugin.json` files parse without error |
 | Version alignment | `version` in `plugin.json` and `marketplace.json` must match exactly |
 | All plugins registered | Every `plugins/<name>/` directory has a matching `marketplace.json` entry |
-| `developed_with` field | Must be a non-empty string if present (optional field) |
+| `x-developed-with` field | Must be a non-empty string if present (optional field) |
 | `requires.env` schema | Each env entry has `name`, `description`, and valid `required`/`sensitive` booleans |
 
 Plus four build jobs: `core-build-test`, `desktop-build-test`, `board-build`, `docs-build`. All must pass before merge. If they fail: fix manifests or source, push, CI re-runs automatically.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,7 +168,7 @@ chore: set initial version to v0.1.0
 
 ## CI
 
-Five checks run on every PR via `validate.yml`:
+Six checks run on every PR via `validate.yml`:
 
 | Check | What it validates |
 |-------|------------------|
@@ -177,6 +177,7 @@ Five checks run on every PR via `validate.yml`:
 | All plugins registered | Every `plugins/<name>/` directory has a matching `marketplace.json` entry |
 | `x-developed-with` field | Must be a non-empty string if present (optional field) |
 | `requires.env` schema | Each env entry has `name`, `description`, and valid `required`/`sensitive` booleans |
+| Protocol schema | All `plugin.json` files validate against the Protocol's `plugin.schema.json` |
 
 Plus four build jobs: `core-build-test`, `desktop-build-test`, `board-build`, `docs-build`. All must pass before merge. If they fail: fix manifests or source, push, CI re-runs automatically.
 

--- a/plugins/docgen/.claude-plugin/plugin.json
+++ b/plugins/docgen/.claude-plugin/plugin.json
@@ -4,5 +4,5 @@
   "version": "0.2.0",
   "category": "documentation",
   "tags": ["documentation", "readme", "api-docs", "changelog", "architecture"],
-  "developed_with": "claude-sonnet-4"
+  "x-developed-with": "claude-sonnet-4"
 }

--- a/plugins/explain/.claude-plugin/plugin.json
+++ b/plugins/explain/.claude-plugin/plugin.json
@@ -4,5 +4,5 @@
   "version": "0.2.0",
   "category": "code-quality",
   "tags": ["code-explanation", "learning", "walkthrough", "codebase-understanding"],
-  "developed_with": "claude-sonnet-4"
+  "x-developed-with": "claude-sonnet-4"
 }

--- a/plugins/frontend-design/.claude-plugin/plugin.json
+++ b/plugins/frontend-design/.claude-plugin/plugin.json
@@ -4,5 +4,5 @@
   "version": "0.1.0",
   "category": "design",
   "tags": ["design", "frontend", "css", "typography", "color", "ui", "ux"],
-  "developed_with": "claude-sonnet-4-6"
+  "x-developed-with": "claude-sonnet-4-6"
 }

--- a/plugins/review/.claude-plugin/plugin.json
+++ b/plugins/review/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "version": "0.3.0",
   "category": "code-quality",
   "tags": ["code-review", "pull-request", "static-analysis", "github"],
-  "developed_with": "claude-sonnet-4",
+  "x-developed-with": "claude-sonnet-4",
   "requires": {
     "env": [
       {

--- a/schema/plugin.schema.json
+++ b/schema/plugin.schema.json
@@ -1,0 +1,193 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnessprotocol.io/schema/v1/plugin.schema.json",
+  "title": "Harness Protocol v1 — Plugin Manifest",
+  "description": "Schema for plugin.json manifests. Plugin authors use this to declare their plugin's identity, capabilities, and requirements.",
+  "type": "object",
+  "required": ["name", "description", "version"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?$",
+      "description": "Plugin identifier in lowercase kebab-case. Must match the directory name used when the plugin is installed. Max 64 characters."
+    },
+    "description": {
+      "type": "string",
+      "maxLength": 256,
+      "description": "One-sentence description of what this plugin does. Used in harness.yaml listings and discovery."
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+      "description": "Plugin version following semver 2.0.0. Used for version constraint resolution when harness.yaml specifies a 'version' range."
+    },
+    "author": {
+      "type": "object",
+      "required": ["name"],
+      "description": "Plugin author information.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Author display name."
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Author URL."
+        }
+      },
+      "additionalProperties": false
+    },
+    "license": {
+      "type": "string",
+      "description": "SPDX license expression. Examples: 'Apache-2.0', 'MIT'. Recommended for public plugins."
+    },
+    "category": {
+      "type": "string",
+      "pattern": "^[a-z0-9]([a-z0-9-]{0,30}[a-z0-9])?$",
+      "maxLength": 32,
+      "description": "Plugin category for discovery and marketplace organization. Lowercase kebab-case. Max 32 characters."
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "maxLength": 32
+      },
+      "maxItems": 10,
+      "uniqueItems": true,
+      "description": "Discovery and classification tags. Max 10 tags, each max 32 characters. Used for search and filtering."
+    },
+    "skills": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Names of skills this plugin provides. Each skill corresponds to a SKILL.md file. Used for documentation and discovery — not for validation."
+    },
+    "agents": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Names of sub-agents this plugin provides. Each agent corresponds to an agent definition file. Used for documentation and discovery."
+    },
+    "requires": {
+      "type": "object",
+      "description": "Plugin requirements that must be satisfied for the plugin to function.",
+      "properties": {
+        "env": {
+          "type": "array",
+          "description": "Environment variables this plugin needs. Uses the same env item schema as harness.yaml env[]. Implementations SHOULD surface these to users during install.",
+          "items": {
+            "type": "object",
+            "required": ["name", "description"],
+            "description": "An environment variable requirement.",
+            "properties": {
+              "name": {
+                "type": "string",
+                "pattern": "^[A-Z_][A-Z0-9_]*$",
+                "description": "Variable name in SCREAMING_SNAKE_CASE."
+              },
+              "description": {
+                "type": "string",
+                "description": "REQUIRED. Human-readable explanation of what this variable is for."
+              },
+              "required": {
+                "type": "boolean",
+                "default": false,
+                "description": "Whether the plugin will fail without this variable."
+              },
+              "sensitive": {
+                "type": "boolean",
+                "default": true,
+                "description": "Whether this variable contains sensitive data. Default: true. When true, 'default' is FORBIDDEN."
+              },
+              "when": {
+                "type": "string",
+                "description": "Human-readable description of when this variable is needed. Displayed to users when prompting. Implementations MAY evaluate it as a condition expression to suppress prompting when false; when not evaluated, it is shown as informational text."
+              },
+              "default": {
+                "type": "string",
+                "description": "Default value. FORBIDDEN when sensitive is true."
+              }
+            },
+            "if": {
+              "required": ["sensitive"],
+              "properties": {
+                "sensitive": {
+                  "const": false
+                }
+              }
+            },
+            "then": {},
+            "else": {
+              "properties": {
+                "default": false
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "min-protocol": {
+          "type": "string",
+          "pattern": "^(0|[1-9]\\d*)$",
+          "description": "Minimum Harness Protocol version required. Example: '1'. Implementations that encounter a plugin requiring a higher protocol version MUST warn the user."
+        }
+      },
+      "additionalProperties": false
+    },
+    "loading": {
+      "type": "string",
+      "enum": ["eager", "deferred"],
+      "default": "eager",
+      "description": "The plugin author's recommended loading mode. 'eager' loads all tools and context at session start (default). 'deferred' recommends loading on first invocation, reducing initial context size. Harness authors may override this in their plugins[] declaration."
+    },
+    "config-schema": {
+      "type": "object",
+      "description": "JSON Schema for the plugin's config object (the 'config' field in harness.yaml plugins[]). When present, implementations SHOULD validate harness.yaml plugin config against this schema.",
+      "additionalProperties": true
+    },
+    "mcp": {
+      "type": "object",
+      "description": "MCP server bundled with this plugin. The implementation starts this server alongside the plugin and registers its tools under a namespace derived from the plugin name.",
+      "required": ["server"],
+      "properties": {
+        "server": {
+          "type": "object",
+          "description": "Server declaration. Only stdio transport is supported for plugin-bundled servers.",
+          "required": ["transport", "command"],
+          "properties": {
+            "transport": {
+              "type": "string",
+              "const": "stdio",
+              "description": "Transport type. Plugin-bundled MCP servers use stdio (local subprocess)."
+            },
+            "command": {
+              "type": "string",
+              "description": "Executable to launch. Supports ${CLAUDE_PLUGIN_ROOT} for plugin-relative paths."
+            },
+            "args": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Command-line arguments. Values may reference ${CLAUDE_PLUGIN_ROOT}."
+            },
+            "env": {
+              "type": "object",
+              "description": "Additional environment variables for the server process.",
+              "additionalProperties": { "type": "string" }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "patternProperties": {
+    "^x-": {
+      "description": "Implementation-specific extension field. Implementations MUST ignore unrecognized x- fields."
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary

- Adds a CI step to `validate.yml` that fetches the Protocol's `plugin.schema.json` and validates all 15 plugin manifests using `jsonschema` `Draft202012Validator`, catching schema drift between Kit and Protocol on every PR
- Renames `developed_with` → `x-developed-with` in 4 plugins (docgen, explain, frontend-design, review) to conform to the schema's `additionalProperties: false` + `patternProperties: {"^x-": ...}`
- Updates the existing "Validate developed_with" step to check `x-developed-with`

## Test plan

- [x] Validated all 15 plugin.json files locally against Protocol schema — all pass
- [x] Verified `if/then/else` construct correctly catches `sensitive` + `default` mutual exclusion violations
- [ ] CI workflow passes in GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>