### PR TITLE
feat(marketplace): redesign landing page with brand alignment

### DIFF
--- a/apps/marketplace/app/components/CategoryIcon.tsx
+++ b/apps/marketplace/app/components/CategoryIcon.tsx
@@ -1,0 +1,80 @@
+export function CategoryIcon({ slug }: { slug: string }) {
+  const svgProps = {
+    xmlns: "http://www.w3.org/2000/svg",
+    viewBox: "0 0 24 24",
+    width: 20,
+    height: 20,
+    fill: "none" as const,
+    stroke: "currentColor",
+    strokeWidth: 1.5,
+    strokeLinecap: "round" as const,
+    strokeLinejoin: "round" as const,
+    "aria-hidden": true as const,
+  };
+
+  switch (slug) {
+    case "research-knowledge":
+      return (
+        <svg {...svgProps}>
+          <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" />
+          <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
+        </svg>
+      );
+    case "code-quality":
+      return (
+        <svg {...svgProps}>
+          <polyline points="16 18 22 12 16 6" />
+          <polyline points="8 6 2 12 8 18" />
+        </svg>
+      );
+    case "data-engineering":
+      return (
+        <svg {...svgProps}>
+          <ellipse cx="12" cy="5" rx="9" ry="3" />
+          <path d="M3 5v14c0 1.66 4.03 3 9 3s9-1.34 9-3V5" />
+          <path d="M3 12c0 1.66 4.03 3 9 3s9-1.34 9-3" />
+        </svg>
+      );
+    case "documentation":
+      return (
+        <svg {...svgProps}>
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+          <polyline points="14 2 14 8 20 8" />
+          <line x1="16" y1="13" x2="8" y2="13" />
+          <line x1="16" y1="17" x2="8" y2="17" />
+          <polyline points="10 9 9 9 8 9" />
+        </svg>
+      );
+    case "devops":
+      return (
+        <svg {...svgProps}>
+          <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z" />
+          <path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z" />
+          <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0" />
+          <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5" />
+        </svg>
+      );
+    case "productivity":
+      return (
+        <svg {...svgProps}>
+          <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
+        </svg>
+      );
+    case "design":
+      return (
+        <svg {...svgProps}>
+          <circle cx="13.5" cy="6.5" r=".5" fill="currentColor" />
+          <circle cx="17.5" cy="10.5" r=".5" fill="currentColor" />
+          <circle cx="8.5" cy="7.5" r=".5" fill="currentColor" />
+          <circle cx="6.5" cy="12.5" r=".5" fill="currentColor" />
+          <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z" />
+        </svg>
+      );
+    default:
+      return (
+        <svg {...svgProps}>
+          <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
+        </svg>
+      );
+  }
+}

--- a/apps/marketplace/app/components/HeroSearch.tsx
+++ b/apps/marketplace/app/components/HeroSearch.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export function HeroSearch() {
+  const [query, setQuery] = useState("");
+  const router = useRouter();
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const q = query.trim();
+    router.push(q ? `/plugins?q=${encodeURIComponent(q)}` : "/plugins");
+  }
+
+  return (
+    <form
+      action="/plugins"
+      method="GET"
+      onSubmit={handleSubmit}
+      className="relative mx-auto max-w-xl"
+    >
+      <label htmlFor="hero-search" className="sr-only">
+        Search plugins
+      </label>
+      <div className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-gray-500">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          width={18}
+          height={18}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <circle cx="11" cy="11" r="8" />
+          <line x1="21" y1="21" x2="16.65" y2="16.65" />
+        </svg>
+      </div>
+      <input
+        id="hero-search"
+        name="q"
+        type="search"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search plugins, skills, agents..."
+        className="w-full rounded-xl border border-[#2a2a2e] bg-[#141416] py-3.5 pl-12 pr-4 text-base text-gray-100 placeholder-gray-500 outline-none transition-colors duration-200 focus:border-violet-500/50"
+        autoComplete="off"
+        spellCheck="false"
+      />
+      <button type="submit" className="sr-only">
+        Search
+      </button>
+    </form>
+  );
+}

--- a/apps/marketplace/app/components/StatsBar.tsx
+++ b/apps/marketplace/app/components/StatsBar.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from "react";
+
+function Stat({ value, label }: { value: string; label: ReactNode }) {
+  return (
+    <div className="flex items-baseline gap-1.5 text-sm">
+      <span className="font-display text-base font-semibold text-gray-100">
+        {value}
+      </span>
+      <span className="text-gray-400">{label}</span>
+    </div>
+  );
+}
+
+export function StatsBar({
+  pluginCount,
+  totalInstalls,
+  categoryCount,
+}: {
+  pluginCount: number;
+  totalInstalls: number;
+  categoryCount: number;
+}) {
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-6 text-sm sm:gap-10">
+      <Stat value={pluginCount.toString()} label="plugins" />
+      <Stat value={totalInstalls.toLocaleString()} label="installs" />
+      <Stat value={categoryCount.toString()} label="categories" />
+      <div className="flex items-center gap-1.5 text-sm text-gray-400">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          width={14}
+          height={14}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <line x1="6" y1="3" x2="6" y2="15" />
+          <circle cx="18" cy="6" r="3" />
+          <circle cx="6" cy="18" r="3" />
+          <path d="M18 9a9 9 0 0 1-9 9" />
+        </svg>
+        Open source
+      </div>
+    </div>
+  );
+}

--- a/apps/marketplace/app/components/TrustBadge.tsx
+++ b/apps/marketplace/app/components/TrustBadge.tsx
@@ -1,0 +1,14 @@
+export function TrustBadge({ tier }: { tier: string }) {
+  const colors: Record<string, string> = {
+    official: "bg-violet-500/20 text-violet-400 border-violet-500/30",
+    verified: "bg-emerald-500/20 text-emerald-400 border-emerald-500/30",
+    community: "bg-gray-500/20 text-gray-400 border-gray-500/30",
+  };
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${colors[tier] ?? colors.community}`}
+    >
+      {tier}
+    </span>
+  );
+}

--- a/apps/marketplace/app/globals.css
+++ b/apps/marketplace/app/globals.css
@@ -1,1 +1,51 @@
 @import "tailwindcss";
+
+/* ─── Typography ──────────────────────────────────────────────── */
+body {
+  font-family: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
+}
+
+.font-display {
+  font-family: var(--font-display), ui-sans-serif, system-ui, sans-serif;
+}
+
+h1, h2, h3 {
+  letter-spacing: -0.03em;
+}
+
+/* ─── Animations ──────────────────────────────────────────────── */
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-fade-in {
+  animation: fadeInUp 0.5s ease-out both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-in {
+    animation: none;
+  }
+
+  * {
+    animation-duration: 0ms !important;
+    transition-duration: 0ms !important;
+  }
+}
+
+/* ─── Effects ─────────────────────────────────────────────────── */
+.glass {
+  backdrop-filter: blur(12px);
+  background: hsla(230, 15%, 8%, 0.7);
+}
+
+.glow-purple {
+  box-shadow: 0 0 40px -10px hsla(256, 80%, 60%, 0.3);
+}

--- a/apps/marketplace/app/layout.tsx
+++ b/apps/marketplace/app/layout.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
+import { Inter, Space_Grotesk } from "next/font/google";
+import Link from "next/link";
 import "./globals.css";
 
-const inter = Inter({ subsets: ["latin"] });
+const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
+const spaceGrotesk = Space_Grotesk({ subsets: ["latin"], variable: "--font-display" });
 
 export const metadata: Metadata = {
   title: "Harness Kit Marketplace",
@@ -16,33 +18,54 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className="dark">
-      <body
-        className={`${inter.className} bg-[#0a0a0a] text-gray-100 antialiased`}
-      >
-        <nav className="sticky top-0 z-50 border-b border-[#2a2a2a] bg-[#0a0a0a]/80 backdrop-blur-sm">
+    <html lang="en" className={`dark ${inter.variable} ${spaceGrotesk.variable}`}>
+      <body className="bg-[#0c0c0e] text-gray-100 antialiased">
+        <nav className="sticky top-0 z-50 border-b border-[#1e1e22] bg-[#0c0c0e]/80 backdrop-blur-xl">
           <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
-            <a href="/" className="text-lg font-semibold tracking-tight">
-              Harness Kit
-            </a>
+            <Link href="/" className="flex items-center gap-2.5">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 32 32"
+                className="size-7 shrink-0"
+              >
+                <rect width="32" height="32" rx="6" fill="#0d0d12" />
+                <text
+                  x="16"
+                  y="22"
+                  textAnchor="middle"
+                  fontFamily="system-ui, sans-serif"
+                  fontWeight="700"
+                  fontSize="16"
+                  fill="#8b7aff"
+                >
+                  hk
+                </text>
+              </svg>
+              <span className="font-display font-bold tracking-tight">
+                Harness Kit
+              </span>
+              <span className="text-xs font-medium text-violet-400">
+                Marketplace
+              </span>
+            </Link>
             <div className="flex items-center gap-6 text-sm text-gray-400">
-              <a
+              <Link
                 href="/plugins"
-                className="transition-colors hover:text-gray-100"
+                className="cursor-pointer transition-colors hover:text-gray-100"
               >
                 Plugins
-              </a>
-              <a
+              </Link>
+              <Link
                 href="/profiles"
-                className="transition-colors hover:text-gray-100"
+                className="cursor-pointer transition-colors hover:text-gray-100"
               >
                 Profiles
-              </a>
+              </Link>
               <a
                 href="https://github.com/harnessprotocol/harness-kit"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="transition-colors hover:text-gray-100"
+                className="cursor-pointer transition-colors hover:text-gray-100"
               >
                 GitHub
               </a>
@@ -50,6 +73,110 @@ export default function RootLayout({
           </div>
         </nav>
         <main className="mx-auto max-w-7xl px-6 py-12">{children}</main>
+        <footer className="relative mt-12 border-t border-[#1e1e22]">
+          <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-violet-500/20 to-transparent" />
+          <div className="mx-auto max-w-5xl px-6 py-12">
+            <div className="grid gap-8 sm:grid-cols-3">
+              {/* Brand */}
+              <div>
+                <div className="mb-3 flex items-center gap-2">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 32 32"
+                    className="size-6 shrink-0"
+                  >
+                    <rect width="32" height="32" rx="6" fill="#0d0d12" />
+                    <text
+                      x="16"
+                      y="22"
+                      textAnchor="middle"
+                      fontFamily="system-ui, sans-serif"
+                      fontWeight="700"
+                      fontSize="16"
+                      fill="#8b7aff"
+                    >
+                      hk
+                    </text>
+                  </svg>
+                  <span className="font-display font-semibold text-gray-100">
+                    Harness Kit
+                  </span>
+                </div>
+                <p className="text-sm leading-relaxed text-gray-400">
+                  Skills, agents, and configuration for Claude Code.
+                </p>
+              </div>
+
+              {/* Resources */}
+              <div>
+                <h3 className="mb-3 text-sm font-semibold text-gray-100">
+                  Resources
+                </h3>
+                <ul className="space-y-2 text-sm text-gray-400">
+                  <li>
+                    <Link
+                      href="/plugins"
+                      className="cursor-pointer transition-colors hover:text-gray-100"
+                    >
+                      Plugins
+                    </Link>
+                  </li>
+                  <li>
+                    <Link
+                      href="/profiles"
+                      className="cursor-pointer transition-colors hover:text-gray-100"
+                    >
+                      Profiles
+                    </Link>
+                  </li>
+                  <li>
+                    <a
+                      href="https://github.com/harnessprotocol/harness-kit"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="cursor-pointer transition-colors hover:text-gray-100"
+                    >
+                      GitHub
+                    </a>
+                  </li>
+                </ul>
+              </div>
+
+              {/* Legal */}
+              <div>
+                <h3 className="mb-3 text-sm font-semibold text-gray-100">
+                  Legal
+                </h3>
+                <ul className="space-y-2 text-sm text-gray-400">
+                  <li>
+                    <a
+                      href="https://github.com/harnessprotocol/harness-kit/blob/main/LICENSE"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="cursor-pointer transition-colors hover:text-gray-100"
+                    >
+                      Apache-2.0 License
+                    </a>
+                  </li>
+                  <li>
+                    <a
+                      href="https://harnessprotocol.ai"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="cursor-pointer transition-colors hover:text-gray-100"
+                    >
+                      Harness Protocol
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="mt-8 border-t border-[#1e1e22] pt-6 text-center text-xs text-gray-500">
+              © {new Date().getFullYear()} Harness Kit Contributors
+            </div>
+          </div>
+        </footer>
       </body>
     </html>
   );

--- a/apps/marketplace/app/page.tsx
+++ b/apps/marketplace/app/page.tsx
@@ -1,6 +1,10 @@
 import Link from "next/link";
 import { supabase } from "@/lib/supabase";
 import type { Component } from "@/lib/types";
+import { HeroSearch } from "@/app/components/HeroSearch";
+import { StatsBar } from "@/app/components/StatsBar";
+import { CategoryIcon } from "@/app/components/CategoryIcon";
+import { TrustBadge } from "@/app/components/TrustBadge";
 
 const CATEGORIES = [
   {
@@ -40,52 +44,59 @@ const CATEGORIES = [
   },
 ];
 
-function TrustBadge({ tier }: { tier: string }) {
-  const colors: Record<string, string> = {
-    official: "bg-blue-500/20 text-blue-400 border-blue-500/30",
-    verified: "bg-green-500/20 text-green-400 border-green-500/30",
-    community: "bg-gray-500/20 text-gray-400 border-gray-500/30",
-  };
-  return (
-    <span
-      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${colors[tier] ?? colors.community}`}
-    >
-      {tier}
-    </span>
-  );
-}
+const SEED_TOTAL_INSTALLS = 8950;
 
-function PluginRow({ component }: { component: Component }) {
-  const updatedDate = component.updated_at
-    ? new Date(component.updated_at).toLocaleDateString("en-US", {
-        month: "short",
-        day: "numeric",
-        year: "numeric",
-      })
-    : null;
-
+function PluginCardFeatured({ component }: { component: Component }) {
   return (
     <Link
       href={`/plugins/${component.slug}`}
-      className="group flex items-center gap-4 border-b border-[#2a2a2a] px-4 py-3 transition-colors hover:bg-[#1a1a1a]"
+      className="group relative rounded-xl border border-[#2a2a2e] bg-[#141416] p-6 transition-all duration-300 hover:border-violet-500/30 hover:shadow-lg hover:shadow-violet-500/10 cursor-pointer"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <div className="mb-2 flex flex-wrap items-center gap-2">
+            <span className="font-display font-semibold text-gray-100 transition-colors duration-200 group-hover:text-violet-400">
+              {component.name}
+            </span>
+            <TrustBadge tier={component.trust_tier} />
+            <span className="rounded-full border border-[#2a2a2e] bg-[#1a1a1e] px-2 py-0.5 text-xs text-gray-500">
+              {component.type}
+            </span>
+          </div>
+          <p className="text-sm leading-relaxed text-gray-400 line-clamp-2">
+            {component.description}
+          </p>
+        </div>
+        <div className="shrink-0 text-right">
+          <div className="font-display text-sm font-semibold text-gray-200">
+            {component.install_count.toLocaleString()}
+          </div>
+          <div className="text-xs text-gray-500">installs</div>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+function PluginCard({ component }: { component: Component }) {
+  return (
+    <Link
+      href={`/plugins/${component.slug}`}
+      className="group flex items-start justify-between gap-3 rounded-xl border border-[#2a2a2e] bg-[#141416] p-4 transition-all duration-300 hover:border-violet-500/30 hover:shadow-lg hover:shadow-violet-500/5 cursor-pointer"
     >
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
-          <span className="font-semibold text-gray-100 group-hover:text-blue-400">
+          <span className="text-sm font-semibold text-gray-100 transition-colors duration-200 group-hover:text-violet-400">
             {component.name}
           </span>
           <TrustBadge tier={component.trust_tier} />
-          <span className="text-xs text-gray-500">
-            {component.install_count.toLocaleString()} installs
-          </span>
         </div>
-        <p className="mt-0.5 truncate text-sm text-gray-400">
+        <p className="mt-1 truncate text-xs text-gray-500">
           {component.description}
         </p>
       </div>
-      <div className="hidden shrink-0 text-right text-xs text-gray-500 sm:block">
-        <div>v{component.version}</div>
-        {updatedDate && <div className="mt-0.5">{updatedDate}</div>}
+      <div className="shrink-0 text-right text-xs text-gray-500">
+        {component.install_count.toLocaleString()}
       </div>
     </Link>
   );
@@ -93,92 +104,283 @@ function PluginRow({ component }: { component: Component }) {
 
 export default async function HomePage() {
   let trending: Component[] = [];
+  let pluginCount = 16;
+  let totalInstalls = SEED_TOTAL_INSTALLS;
+
   try {
-    const { data } = await supabase
-      .from("components")
-      .select("*")
-      .order("install_count", { ascending: false })
-      .limit(6);
-    trending = (data as Component[]) ?? [];
+    const [trendingResult, countResult] = await Promise.all([
+      supabase
+        .from("components")
+        .select("*")
+        .order("install_count", { ascending: false })
+        .limit(8),
+      supabase
+        .from("components")
+        .select("*", { count: "exact", head: true }),
+    ]);
+
+    trending = (trendingResult.data as Component[]) ?? [];
+
+    if (countResult.count != null) {
+      pluginCount = countResult.count;
+    }
+
+    if (trending.length > 0) {
+      const trendingTotal = trending.reduce(
+        (sum, c) => sum + c.install_count,
+        0
+      );
+      // Use trending total as a floor; if we have more plugins, estimate conservatively
+      totalInstalls =
+        pluginCount > trending.length
+          ? Math.round((trendingTotal / trending.length) * pluginCount * 0.6)
+          : trendingTotal;
+    }
   } catch {
-    // Supabase not configured yet — render with empty data
+    // Supabase not configured — render with fallback data
   }
 
   return (
-    <div className="space-y-20">
-      {/* Hero */}
-      <section className="pt-8 text-center">
-        <h1 className="text-5xl font-bold tracking-tight">
-          Harness Kit Marketplace
-        </h1>
-        <p className="mt-4 text-lg text-gray-400">
-          Skills, agents, and configuration for Claude Code
-        </p>
+    <div className="animate-fade-in -mx-6 -my-12">
+      {/* ── Hero ──────────────────────────────────────────────────── */}
+      <section className="relative overflow-hidden">
+        {/* Ambient glow */}
+        <div className="pointer-events-none absolute left-1/2 top-0 -translate-x-1/2 -translate-y-1/4">
+          <div className="h-[500px] w-[700px] rounded-full bg-purple-500/15 blur-[120px]" />
+        </div>
+        <div className="absolute inset-0 bg-gradient-to-b from-violet-500/5 via-transparent to-transparent" />
 
-        <div className="mx-auto mt-10 grid max-w-2xl gap-4 sm:grid-cols-2">
-          <Link
-            href="/plugins"
-            className="group rounded-xl border border-[#2a2a2a] bg-[#1a1a1a] p-6 text-left transition-colors hover:border-blue-500/40"
-          >
-            <h2 className="text-lg font-semibold group-hover:text-blue-400">
-              Browse Plugins
-            </h2>
-            <p className="mt-1 text-sm text-gray-400">
-              Discover skills, agents, hooks, and more
-            </p>
-          </Link>
-          <Link
-            href="/profiles"
-            className="group rounded-xl border border-[#2a2a2a] bg-[#1a1a1a] p-6 text-left transition-colors hover:border-blue-500/40"
-          >
-            <h2 className="text-lg font-semibold group-hover:text-blue-400">
+        <div className="relative mx-auto max-w-4xl px-6 pb-16 pt-24 text-center">
+          <h1 className="font-display mb-5 text-5xl font-bold sm:text-6xl">
+            Extend Claude Code with{" "}
+            <span className="bg-gradient-to-r from-violet-400 to-purple-500 bg-clip-text text-transparent">
+              proven workflows
+            </span>
+          </h1>
+          <p className="mx-auto mb-10 max-w-2xl text-lg leading-relaxed text-gray-400">
+            Browse, search, and install skills, agents, and configuration —
+            the parts worth sharing.
+          </p>
+
+          <HeroSearch />
+
+          <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+            <Link
+              href="/plugins"
+              className="cursor-pointer rounded-lg bg-violet-600 px-5 py-2.5 text-sm font-medium text-white shadow-lg shadow-violet-500/20 transition-all duration-200 hover:bg-violet-500 hover:shadow-violet-500/30"
+            >
+              Browse All Plugins
+            </Link>
+            <Link
+              href="/profiles"
+              className="cursor-pointer rounded-lg border border-[#2a2a2e] bg-[#141416] px-5 py-2.5 text-sm font-medium text-gray-200 transition-all duration-200 hover:border-violet-500/40 hover:bg-[#1a1a1e]"
+            >
               Explore Profiles
-            </h2>
-            <p className="mt-1 text-sm text-gray-400">
-              Pre-configured setups for your role
-            </p>
-          </Link>
+            </Link>
+          </div>
         </div>
       </section>
 
-      {/* Trending Plugins */}
-      {trending.length > 0 && (
-        <section>
-          <div className="mb-4 flex items-center justify-between">
-            <h2 className="text-2xl font-bold">Trending Plugins</h2>
-            <Link
-              href="/plugins"
-              className="text-sm text-blue-400 hover:text-blue-300"
-            >
-              View all
-            </Link>
+      {/* ── Stats Bar ─────────────────────────────────────────────── */}
+      <section className="border-y border-[#1e1e22] bg-[#0e0e10]">
+        <div className="mx-auto max-w-5xl px-6 py-5">
+          <StatsBar
+            pluginCount={pluginCount}
+            totalInstalls={totalInstalls}
+            categoryCount={CATEGORIES.length}
+          />
+        </div>
+      </section>
+
+      <div className="mx-auto max-w-5xl px-6">
+        {/* ── Trending ──────────────────────────────────────────────── */}
+        {trending.length > 0 && (
+          <section className="py-20">
+            <div className="mb-8 flex items-center justify-between">
+              <h2 className="font-display text-2xl font-bold">Trending</h2>
+              <Link
+                href="/plugins?sort=installs"
+                className="cursor-pointer text-sm text-violet-400 transition-colors duration-200 hover:text-violet-300"
+              >
+                View all →
+              </Link>
+            </div>
+
+            {/* Top 2 featured */}
+            <div className="grid gap-3 sm:grid-cols-2">
+              {trending.slice(0, 2).map((c) => (
+                <PluginCardFeatured key={c.id} component={c} />
+              ))}
+            </div>
+
+            {/* Remaining */}
+            {trending.length > 2 && (
+              <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                {trending.slice(2).map((c) => (
+                  <PluginCard key={c.id} component={c} />
+                ))}
+              </div>
+            )}
+          </section>
+        )}
+
+        {/* ── Categories ────────────────────────────────────────────── */}
+        <section className={trending.length > 0 ? "border-t border-[#1e1e22] py-20" : "py-20"}>
+          <div className="mb-10 text-center">
+            <h2 className="font-display mb-2 text-2xl font-bold">
+              Browse by category
+            </h2>
+            <p className="text-sm text-gray-400">
+              Find the right plugin for your workflow
+            </p>
           </div>
-          <div className="rounded-xl border border-[#2a2a2a]">
-            {trending.map((c) => (
-              <PluginRow key={c.id} component={c} />
+
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {CATEGORIES.map((cat) => (
+              <Link
+                key={cat.slug}
+                href={`/plugins?category=${cat.slug}`}
+                className="group flex cursor-pointer items-start gap-4 rounded-xl border border-[#2a2a2e] bg-[#141416] p-5 transition-all duration-300 hover:border-violet-500/30 hover:shadow-lg hover:shadow-violet-500/5"
+              >
+                <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-violet-500/10 text-violet-400 transition-colors duration-200 group-hover:bg-violet-500/20">
+                  <CategoryIcon slug={cat.slug} />
+                </div>
+                <div>
+                  <h3 className="font-display font-semibold text-gray-100 transition-colors duration-200 group-hover:text-violet-400">
+                    {cat.name}
+                  </h3>
+                  <p className="mt-1 text-sm text-gray-400">
+                    {cat.description}
+                  </p>
+                </div>
+              </Link>
             ))}
           </div>
         </section>
-      )}
 
-      {/* Featured Categories */}
-      <section>
-        <h2 className="mb-6 text-2xl font-bold">Featured Categories</h2>
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {CATEGORIES.map((cat) => (
-            <Link
-              key={cat.slug}
-              href={`/plugins?category=${cat.slug}`}
-              className="group rounded-xl border border-[#2a2a2a] bg-[#1a1a1a] p-5 transition-colors hover:border-blue-500/40"
-            >
-              <h3 className="font-semibold group-hover:text-blue-400">
-                {cat.name}
+        {/* ── How it works ──────────────────────────────────────────── */}
+        <section className="border-t border-[#1e1e22] py-20">
+          <div className="mb-12 text-center">
+            <h2 className="font-display mb-2 text-2xl font-bold">
+              How it works
+            </h2>
+            <p className="text-sm text-gray-400">
+              Three steps to extend your Claude Code setup
+            </p>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-3">
+            {/* Step 1 */}
+            <div className="rounded-xl border border-[#2a2a2e] bg-[#141416] p-6 transition-all duration-300 hover:border-violet-500/20 hover:shadow-lg hover:shadow-violet-500/5">
+              <div className="mb-4 flex size-10 items-center justify-center rounded-lg bg-violet-500/10 text-violet-400">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  width={20}
+                  height={20}
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={1.5}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <polyline points="4 17 10 11 4 5" />
+                  <line x1="12" y1="19" x2="20" y2="19" />
+                </svg>
+              </div>
+              <div className="mb-1 text-xs font-medium text-violet-400">
+                Step 1
+              </div>
+              <h3 className="font-display mb-2 font-semibold text-gray-100">
+                Browse the marketplace
               </h3>
-              <p className="mt-1 text-sm text-gray-400">{cat.description}</p>
-            </Link>
-          ))}
-        </div>
-      </section>
+              <p className="text-sm leading-relaxed text-gray-400">
+                Search by name, category, or use case. Every plugin is open
+                source and ready to install.
+              </p>
+            </div>
+
+            {/* Step 2 */}
+            <div className="rounded-xl border border-[#2a2a2e] bg-[#141416] p-6 transition-all duration-300 hover:border-violet-500/20 hover:shadow-lg hover:shadow-violet-500/5">
+              <div className="mb-4 flex size-10 items-center justify-center rounded-lg bg-violet-500/10 text-violet-400">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  width={20}
+                  height={20}
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={1.5}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                  <polyline points="7 10 12 15 17 10" />
+                  <line x1="12" y1="15" x2="12" y2="3" />
+                </svg>
+              </div>
+              <div className="mb-1 text-xs font-medium text-violet-400">
+                Step 2
+              </div>
+              <h3 className="font-display mb-2 font-semibold text-gray-100">
+                Install by name
+              </h3>
+              <p className="text-sm leading-relaxed text-gray-400">
+                Run{" "}
+                <code className="rounded bg-[#1a1a1e] px-1.5 py-0.5 font-mono text-xs text-gray-300">
+                  /plugin install research@harness-kit
+                </code>{" "}
+                — one command, no config files to edit.
+              </p>
+            </div>
+
+            {/* Step 3 */}
+            <div className="rounded-xl border border-[#2a2a2e] bg-[#141416] p-6 transition-all duration-300 hover:border-violet-500/20 hover:shadow-lg hover:shadow-violet-500/5">
+              <div className="mb-4 flex size-10 items-center justify-center rounded-lg bg-violet-500/10 text-violet-400">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  width={20}
+                  height={20}
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={1.5}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="m13 2-3 6.5H4l6 4.5-2.5 7L13 16l5.5 4-2.5-7 6-4.5h-6z" />
+                </svg>
+              </div>
+              <div className="mb-1 text-xs font-medium text-violet-400">
+                Step 3
+              </div>
+              <h3 className="font-display mb-2 font-semibold text-gray-100">
+                Start using it
+              </h3>
+              <p className="text-sm leading-relaxed text-gray-400">
+                Invoke your new skill with a slash command. It&apos;s ready
+                immediately — no restart required.
+              </p>
+            </div>
+          </div>
+
+          <p className="mt-10 text-center text-sm text-gray-500">
+            Part of the{" "}
+            <a
+              href="https://harnessprotocol.ai"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="cursor-pointer text-gray-400 transition-colors duration-200 hover:text-gray-300"
+            >
+              Harness Protocol
+            </a>{" "}
+            — a harness-agnostic framework for AI coding tools.
+          </p>
+        </section>
+      </div>
     </div>
   );
 }

--- a/apps/marketplace/app/plugins/[slug]/page.tsx
+++ b/apps/marketplace/app/plugins/[slug]/page.tsx
@@ -3,21 +3,7 @@ import { notFound } from "next/navigation";
 import sanitizeHtml from "sanitize-html";
 import { supabase } from "@/lib/supabase";
 import type { Component, Profile, TrustTier } from "@/lib/types";
-
-function TrustBadge({ tier }: { tier: TrustTier }) {
-  const colors: Record<TrustTier, string> = {
-    official: "bg-blue-500/20 text-blue-400 border-blue-500/30",
-    verified: "bg-green-500/20 text-green-400 border-green-500/30",
-    community: "bg-gray-500/20 text-gray-400 border-gray-500/30",
-  };
-  return (
-    <span
-      className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${colors[tier]}`}
-    >
-      {tier}
-    </span>
-  );
-}
+import { TrustBadge } from "@/app/components/TrustBadge";
 
 /**
  * Allowed tags and attributes for sanitizeHtml.
@@ -67,12 +53,12 @@ function renderMarkdown(md: string): string {
     // Inline code
     .replace(
       /`([^`]+)`/g,
-      '<code class="rounded bg-[#1a1a1a] px-1.5 py-0.5 text-sm text-blue-300">$1</code>',
+      '<code class="rounded bg-[#1a1a1e] px-1.5 py-0.5 text-sm text-violet-300">$1</code>',
     )
     // Links
     .replace(
       /\[([^\]]+)\]\(([^)]+)\)/g,
-      '<a href="$2" class="text-blue-400 underline hover:text-blue-300" target="_blank" rel="noopener noreferrer">$1</a>',
+      '<a href="$2" class="text-violet-400 underline hover:text-violet-300" target="_blank" rel="noopener noreferrer">$1</a>',
     )
     // Unordered lists
     .replace(/^- (.+)$/gm, '<li class="ml-4 list-disc text-gray-300">$1</li>')
@@ -188,7 +174,7 @@ export default async function PluginDetailPage({
             <div className="flex flex-wrap items-center gap-3">
               <h1 className="text-3xl font-bold">{component.name}</h1>
               <TrustBadge tier={component.trust_tier} />
-              <span className="rounded-full border border-[#2a2a2a] px-2.5 py-0.5 text-xs capitalize text-gray-400">
+              <span className="rounded-full border border-[#2a2a2e] px-2.5 py-0.5 text-xs capitalize text-gray-400">
                 {component.type}
               </span>
             </div>
@@ -227,7 +213,7 @@ export default async function PluginDetailPage({
                 <Link
                   key={tag}
                   href={`/plugins?tag=${tag}`}
-                  className="rounded-full border border-[#2a2a2a] px-3 py-1 text-xs text-gray-400 transition-colors hover:border-blue-500/30 hover:text-blue-400"
+                  className="rounded-full border border-[#2a2a2e] px-3 py-1 text-xs text-gray-400 transition-colors hover:border-violet-500/30 hover:text-violet-400"
                 >
                   {tag}
                 </Link>
@@ -240,7 +226,7 @@ export default async function PluginDetailPage({
             <section className="mb-10">
               <h2 className="mb-4 text-xl font-bold">Skill Definition</h2>
               <div
-                className="prose-invert max-w-none rounded-xl border border-[#2a2a2a] bg-[#1a1a1a] p-6"
+                className="prose-invert max-w-none rounded-xl border border-[#2a2a2e] bg-[#1a1a1e] p-6"
                 dangerouslySetInnerHTML={{ __html: skillHtml }}
               />
             </section>
@@ -251,7 +237,7 @@ export default async function PluginDetailPage({
             <section className="mb-10">
               <h2 className="mb-4 text-xl font-bold">Documentation</h2>
               <div
-                className="prose-invert max-w-none rounded-xl border border-[#2a2a2a] bg-[#1a1a1a] p-6"
+                className="prose-invert max-w-none rounded-xl border border-[#2a2a2e] bg-[#1a1a1e] p-6"
                 dangerouslySetInnerHTML={{ __html: readmeHtml }}
               />
             </section>
@@ -263,18 +249,18 @@ export default async function PluginDetailPage({
           <div className="space-y-5">
             {/* Author card */}
             {component.author && (
-              <div className="rounded-xl border border-[#2a2a2a] bg-[#1a1a1a] p-4">
+              <div className="rounded-xl border border-[#2a2a2e] bg-[#1a1a1e] p-4">
                 <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-gray-400">
                   Author
                 </h3>
                 <div className="flex items-center gap-3">
-                  <div className="flex h-8 w-8 items-center justify-center rounded-full bg-[#2a2a2a] text-sm font-semibold text-gray-300">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-full bg-[#2a2a2e] text-sm font-semibold text-gray-300">
                     {component.author.name.charAt(0).toUpperCase()}
                   </div>
                   {component.author.url ? (
                     <a
                       href={component.author.url}
-                      className="text-sm font-medium text-blue-400 hover:text-blue-300"
+                      className="text-sm font-medium text-violet-400 hover:text-violet-300"
                       target="_blank"
                       rel="noopener noreferrer"
                     >
@@ -295,7 +281,7 @@ export default async function PluginDetailPage({
                 href={component.repo_url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex items-center justify-center gap-2 rounded-xl border border-[#2a2a2a] bg-[#1a1a1a] px-4 py-3 text-sm font-medium text-gray-200 transition-colors hover:border-blue-500/40 hover:text-blue-400"
+                className="flex items-center justify-center gap-2 rounded-xl border border-[#2a2a2e] bg-[#1a1a1e] px-4 py-3 text-sm font-medium text-gray-200 transition-colors hover:border-violet-500/40 hover:text-violet-400"
               >
                 <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
                   <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
@@ -305,18 +291,18 @@ export default async function PluginDetailPage({
             )}
 
             {/* Install command */}
-            <div className="rounded-xl border border-[#2a2a2a] bg-[#1a1a1a] p-4">
+            <div className="rounded-xl border border-[#2a2a2e] bg-[#1a1a1e] p-4">
               <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-gray-400">
                 Install
               </h3>
-              <code className="block rounded-lg bg-[#111] px-3 py-2.5 text-sm text-blue-300">
+              <code className="block rounded-lg bg-[#111] px-3 py-2.5 text-sm text-violet-300">
                 /plugin install {component.slug}@harness-kit
               </code>
             </div>
 
             {/* Included in Profiles */}
             {includedInProfiles.length > 0 && (
-              <div className="rounded-xl border border-[#2a2a2a] bg-[#1a1a1a] p-4">
+              <div className="rounded-xl border border-[#2a2a2e] bg-[#1a1a1e] p-4">
                 <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-400">
                   Included in Profiles
                 </h3>
@@ -325,7 +311,7 @@ export default async function PluginDetailPage({
                     <li key={profile.id}>
                       <Link
                         href={`/profiles/${profile.slug}`}
-                        className="text-sm text-blue-400 hover:text-blue-300"
+                        className="text-sm text-violet-400 hover:text-violet-300"
                       >
                         {profile.name}
                       </Link>
@@ -337,7 +323,7 @@ export default async function PluginDetailPage({
 
             {/* Related Plugins */}
             {relatedComponents.length > 0 && (
-              <div className="rounded-xl border border-[#2a2a2a] bg-[#1a1a1a] p-4">
+              <div className="rounded-xl border border-[#2a2a2e] bg-[#1a1a1e] p-4">
                 <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-400">
                   Related Plugins
                 </h3>
@@ -349,7 +335,7 @@ export default async function PluginDetailPage({
                         className="group block"
                       >
                         <div className="flex items-center justify-between">
-                          <span className="text-sm font-medium text-gray-200 group-hover:text-blue-400">
+                          <span className="text-sm font-medium text-gray-200 group-hover:text-violet-400">
                             {related.name}
                           </span>
                           <span className="text-xs text-gray-500">

--- a/apps/marketplace/app/plugins/page.tsx
+++ b/apps/marketplace/app/plugins/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { supabase } from "@/lib/supabase";
 import type { Component, ComponentType, TrustTier } from "@/lib/types";
+import { TrustBadge } from "@/app/components/TrustBadge";
 
 const CATEGORIES = [
   { slug: "research-knowledge", name: "Research & Knowledge" },
@@ -19,21 +20,6 @@ const COMPONENT_TYPES: ComponentType[] = [
   "knowledge",
   "rules",
 ];
-
-function TrustBadge({ tier }: { tier: TrustTier }) {
-  const colors: Record<TrustTier, string> = {
-    official: "bg-blue-500/20 text-blue-400 border-blue-500/30",
-    verified: "bg-green-500/20 text-green-400 border-green-500/30",
-    community: "bg-gray-500/20 text-gray-400 border-gray-500/30",
-  };
-  return (
-    <span
-      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${colors[tier]}`}
-    >
-      {tier}
-    </span>
-  );
-}
 
 interface SearchParams {
   q?: string;
@@ -144,7 +130,7 @@ export default async function PluginsPage({
             name="q"
             defaultValue={query}
             placeholder="Search plugins..."
-            className="flex-1 rounded-lg border border-[#2a2a2a] bg-[#1a1a1a] px-4 py-2.5 text-sm text-gray-100 placeholder-gray-500 outline-none focus:border-blue-500/50"
+            className="flex-1 rounded-lg border border-[#2a2a2e] bg-[#1a1a1e] px-4 py-2.5 text-sm text-gray-100 placeholder-gray-500 outline-none focus:border-violet-500/50"
           />
           {selectedCategory && (
             <input type="hidden" name="category" value={selectedCategory} />
@@ -160,7 +146,7 @@ export default async function PluginsPage({
           )}
           <button
             type="submit"
-            className="rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-blue-500"
+            className="rounded-lg bg-violet-600 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-violet-500"
           >
             Search
           </button>
@@ -185,7 +171,7 @@ export default async function PluginsPage({
                     })}
                     className={`block rounded-md px-3 py-1.5 text-sm transition-colors ${
                       selectedCategory === cat.slug
-                        ? "bg-blue-500/20 text-blue-400"
+                        ? "bg-violet-500/20 text-violet-400"
                         : "text-gray-400 hover:text-gray-200"
                     }`}
                   >
@@ -210,7 +196,7 @@ export default async function PluginsPage({
                     })}
                     className={`block rounded-md px-3 py-1.5 text-sm capitalize transition-colors ${
                       selectedType === t
-                        ? "bg-blue-500/20 text-blue-400"
+                        ? "bg-violet-500/20 text-violet-400"
                         : "text-gray-400 hover:text-gray-200"
                     }`}
                   >
@@ -236,7 +222,7 @@ export default async function PluginsPage({
                       })}
                       className={`block rounded-md px-3 py-1.5 text-sm capitalize transition-colors ${
                         selectedTrust === tier
-                          ? "bg-blue-500/20 text-blue-400"
+                          ? "bg-violet-500/20 text-violet-400"
                           : "text-gray-400 hover:text-gray-200"
                       }`}
                     >
@@ -258,7 +244,7 @@ export default async function PluginsPage({
               href={buildUrl({ sort: "installs" })}
               className={`rounded-md px-3 py-1 transition-colors ${
                 sortBy === "installs"
-                  ? "bg-blue-500/20 text-blue-400"
+                  ? "bg-violet-500/20 text-violet-400"
                   : "text-gray-400 hover:text-gray-200"
               }`}
             >
@@ -268,7 +254,7 @@ export default async function PluginsPage({
               href={buildUrl({ sort: "recent" })}
               className={`rounded-md px-3 py-1 transition-colors ${
                 sortBy === "recent"
-                  ? "bg-blue-500/20 text-blue-400"
+                  ? "bg-violet-500/20 text-violet-400"
                   : "text-gray-400 hover:text-gray-200"
               }`}
             >
@@ -277,13 +263,13 @@ export default async function PluginsPage({
           </div>
 
           {components.length === 0 ? (
-            <div className="rounded-xl border border-[#2a2a2a] bg-[#1a1a1a] py-16 text-center">
+            <div className="rounded-xl border border-[#2a2a2e] bg-[#1a1a1e] py-16 text-center">
               <p className="text-gray-400">
                 No plugins found. Connect Supabase to load data.
               </p>
             </div>
           ) : (
-            <div className="rounded-xl border border-[#2a2a2a]">
+            <div className="rounded-xl border border-[#2a2a2e]">
               {components.map((component) => {
                 const updatedDate = component.updated_at
                   ? new Date(component.updated_at).toLocaleDateString(
@@ -296,11 +282,11 @@ export default async function PluginsPage({
                   <Link
                     key={component.id}
                     href={`/plugins/${component.slug}`}
-                    className="group flex items-start gap-4 border-b border-[#2a2a2a] px-5 py-3.5 transition-colors last:border-b-0 hover:bg-[#1a1a1a]"
+                    className="group flex items-start gap-4 border-b border-[#2a2a2e] px-5 py-3.5 transition-colors last:border-b-0 hover:bg-[#1a1a1e]"
                   >
                     <div className="min-w-0 flex-1">
                       <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-                        <span className="font-semibold text-gray-100 group-hover:text-blue-400">
+                        <span className="font-semibold text-gray-100 group-hover:text-violet-400">
                           {component.name}
                         </span>
                         <span className="inline-flex items-center gap-1 text-xs text-gray-500">
@@ -325,7 +311,7 @@ export default async function PluginsPage({
                           </span>
                         )}
                         <TrustBadge tier={component.trust_tier} />
-                        <span className="rounded-full border border-[#2a2a2a] px-2 py-0.5 text-xs capitalize text-gray-500">
+                        <span className="rounded-full border border-[#2a2a2e] px-2 py-0.5 text-xs capitalize text-gray-500">
                           {component.type}
                         </span>
                       </div>

--- a/apps/marketplace/app/profiles/[slug]/page.tsx
+++ b/apps/marketplace/app/profiles/[slug]/page.tsx
@@ -1,22 +1,8 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { supabase } from "@/lib/supabase";
-import type { Component, Profile, TrustTier } from "@/lib/types";
-
-function TrustBadge({ tier }: { tier: TrustTier }) {
-  const colors: Record<TrustTier, string> = {
-    official: "bg-blue-500/20 text-blue-400 border-blue-500/30",
-    verified: "bg-green-500/20 text-green-400 border-green-500/30",
-    community: "bg-gray-500/20 text-gray-400 border-gray-500/30",
-  };
-  return (
-    <span
-      className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${colors[tier]}`}
-    >
-      {tier}
-    </span>
-  );
-}
+import type { Component, Profile } from "@/lib/types";
+import { TrustBadge } from "@/app/components/TrustBadge";
 
 export default async function ProfileDetailPage({
   params,
@@ -112,7 +98,7 @@ export default async function ProfileDetailPage({
             {profile.author.url ? (
               <a
                 href={profile.author.url}
-                className="text-blue-400 hover:text-blue-300"
+                className="text-violet-400 hover:text-violet-300"
                 target="_blank"
                 rel="noopener noreferrer"
               >
@@ -131,7 +117,7 @@ export default async function ProfileDetailPage({
           {tags.map((tag) => (
             <span
               key={tag}
-              className="rounded-full border border-[#2a2a2a] px-3 py-1 text-xs text-gray-400"
+              className="rounded-full border border-[#2a2a2e] px-3 py-1 text-xs text-gray-400"
             >
               {tag}
             </span>
@@ -154,15 +140,15 @@ export default async function ProfileDetailPage({
               <Link
                 key={component.id}
                 href={`/plugins/${component.slug}`}
-                className="group flex items-center justify-between rounded-xl border border-[#2a2a2a] bg-[#1a1a1a] p-4 transition-colors hover:border-blue-500/40"
+                className="group flex items-center justify-between rounded-xl border border-[#2a2a2e] bg-[#1a1a1e] p-4 transition-colors hover:border-violet-500/40"
               >
                 <div>
                   <div className="flex items-center gap-2">
-                    <h3 className="font-semibold group-hover:text-blue-400">
+                    <h3 className="font-semibold group-hover:text-violet-400">
                       {component.name}
                     </h3>
                     <TrustBadge tier={component.trust_tier} />
-                    <span className="rounded-full border border-[#2a2a2a] px-2 py-0.5 text-xs capitalize text-gray-500">
+                    <span className="rounded-full border border-[#2a2a2e] px-2 py-0.5 text-xs capitalize text-gray-500">
                       {component.type}
                     </span>
                   </div>
@@ -183,14 +169,14 @@ export default async function ProfileDetailPage({
       {profile.harness_yaml_template && (
         <section className="mb-10">
           <h2 className="mb-4 text-xl font-bold">harness.yaml</h2>
-          <pre className="overflow-x-auto rounded-xl border border-[#2a2a2a] bg-[#111] p-5 text-sm text-gray-300">
+          <pre className="overflow-x-auto rounded-xl border border-[#2a2a2e] bg-[#111] p-5 text-sm text-gray-300">
             <code>{profile.harness_yaml_template}</code>
           </pre>
         </section>
       )}
 
       {/* Install Profile */}
-      <section className="mb-10 rounded-xl border border-[#2a2a2a] bg-[#1a1a1a] p-5">
+      <section className="mb-10 rounded-xl border border-[#2a2a2e] bg-[#1a1a1e] p-5">
         <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-gray-400">
           Install Profile
         </h2>
@@ -202,7 +188,7 @@ export default async function ProfileDetailPage({
           {components.map((component) => (
             <code
               key={component.id}
-              className="block rounded-lg bg-[#111] px-4 py-2 text-sm text-blue-300"
+              className="block rounded-lg bg-[#111] px-4 py-2 text-sm text-violet-300"
             >
               /plugin install {component.slug}@harness-kit
             </code>
@@ -219,9 +205,9 @@ export default async function ProfileDetailPage({
               <Link
                 key={related.id}
                 href={`/profiles/${related.slug}`}
-                className="group rounded-xl border border-[#2a2a2a] bg-[#1a1a1a] p-4 transition-colors hover:border-blue-500/40"
+                className="group rounded-xl border border-[#2a2a2e] bg-[#1a1a1e] p-4 transition-colors hover:border-violet-500/40"
               >
-                <h3 className="font-semibold group-hover:text-blue-400">
+                <h3 className="font-semibold group-hover:text-violet-400">
                   {related.name}
                 </h3>
                 <p className="mt-1 text-sm text-gray-400">

--- a/apps/marketplace/app/profiles/page.tsx
+++ b/apps/marketplace/app/profiles/page.tsx
@@ -1,21 +1,7 @@
 import Link from "next/link";
 import { supabase } from "@/lib/supabase";
-import type { Profile, TrustTier } from "@/lib/types";
-
-function TrustBadge({ tier }: { tier: TrustTier }) {
-  const colors: Record<TrustTier, string> = {
-    official: "bg-blue-500/20 text-blue-400 border-blue-500/30",
-    verified: "bg-green-500/20 text-green-400 border-green-500/30",
-    community: "bg-gray-500/20 text-gray-400 border-gray-500/30",
-  };
-  return (
-    <span
-      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${colors[tier]}`}
-    >
-      {tier}
-    </span>
-  );
-}
+import type { Profile } from "@/lib/types";
+import { TrustBadge } from "@/app/components/TrustBadge";
 
 interface ProfileWithCounts extends Profile {
   component_count?: number;
@@ -61,11 +47,11 @@ export default async function ProfilesPage({
             name="q"
             defaultValue={query}
             placeholder="Search profiles..."
-            className="flex-1 rounded-lg border border-[#2a2a2a] bg-[#1a1a1a] px-4 py-2.5 text-sm text-gray-100 placeholder-gray-500 outline-none focus:border-blue-500/50"
+            className="flex-1 rounded-lg border border-[#2a2a2e] bg-[#1a1a1e] px-4 py-2.5 text-sm text-gray-100 placeholder-gray-500 outline-none focus:border-violet-500/50"
           />
           <button
             type="submit"
-            className="rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-blue-500"
+            className="rounded-lg bg-violet-600 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-violet-500"
           >
             Search
           </button>
@@ -74,22 +60,22 @@ export default async function ProfilesPage({
 
       {/* Profile list */}
       {profiles.length === 0 ? (
-        <div className="rounded-xl border border-[#2a2a2a] bg-[#1a1a1a] py-16 text-center">
+        <div className="rounded-xl border border-[#2a2a2e] bg-[#1a1a1e] py-16 text-center">
           <p className="text-gray-400">
             No profiles found. Connect Supabase to load data.
           </p>
         </div>
       ) : (
-        <div className="rounded-xl border border-[#2a2a2a]">
+        <div className="rounded-xl border border-[#2a2a2e]">
           {profiles.map((profile) => (
             <Link
               key={profile.id}
               href={`/profiles/${profile.slug}`}
-              className="group flex items-start gap-4 border-b border-[#2a2a2a] px-5 py-3.5 transition-colors last:border-b-0 hover:bg-[#1a1a1a]"
+              className="group flex items-start gap-4 border-b border-[#2a2a2e] px-5 py-3.5 transition-colors last:border-b-0 hover:bg-[#1a1a1e]"
             >
               <div className="min-w-0 flex-1">
                 <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-                  <span className="font-semibold text-gray-100 group-hover:text-blue-400">
+                  <span className="font-semibold text-gray-100 group-hover:text-violet-400">
                     {profile.name}
                   </span>
                   <TrustBadge tier={profile.trust_tier} />


### PR DESCRIPTION
## Summary

The marketplace landing page looked generic — plain text hero, blue accents that didn't match the main website's violet identity, no display font, no visual effects, no footer. This PR brings it in line with the established harness-kit brand and adopts a search-first marketplace pattern.

## Changes

**New components**
- `HeroSearch` — client component, search bar with progressive enhancement (works without JS, `router.push` with JS), violet focus ring
- `TrustBadge` — extracted from 4 copy-pasted inline definitions across plugin/profile pages; violet for official tier
- `CategoryIcon` — inline Lucide SVGs for all 7 categories
- `StatsBar` — social proof metrics row (plugins / installs / categories / open source)

**Landing page rewrite (`app/page.tsx`)**
- Hero: ambient violet glow orb + gradient text headline ("proven workflows") + search bar as primary CTA + dual CTA buttons
- Stats band: full-width dark section with key metrics, Supabase-backed with hardcoded fallbacks
- Trending plugins: top 2 as featured large cards, remaining 6 in a tighter grid (asymmetric layout)
- Categories: icon + name + description cards with violet hover effects
- How it works: 3-step cards with step labels and icons
- Harness Protocol attribution footer link

**Layout shell (`app/layout.tsx`)**
- Added Space Grotesk as `--font-display` CSS variable alongside Inter
- HK logo SVG monogram in nav (matching website)
- Replaced `<a>` with Next.js `<Link>` for internal nav routes
- "Marketplace" violet accent badge next to brand name
- Warm-tinted background (`#0c0c0e`) instead of pure black
- Footer with brand / resources / legal columns and gradient top border line

**Global styles (`app/globals.css`)**
- `.font-display` utility for Space Grotesk headings
- `-0.03em` letter-spacing on `h1/h2/h3`
- `fadeInUp` animation + `.animate-fade-in`
- `.glass` and `.glow-purple` utilities
- `prefers-reduced-motion` disables all animations

**Color migration (all pages)**
- Blue accent → violet throughout (`plugins/page.tsx`, `plugins/[slug]/page.tsx`, `profiles/page.tsx`, `profiles/[slug]/page.tsx`)
- Warm-tinted card/border backgrounds (`#1a1a1e`, `#2a2a2e`) replacing pure neutrals

## Test Plan
- [x] `pnpm typecheck` passes with zero errors
- [ ] CI checks pass
- [ ] Visual: violet accents throughout, no blue remnants, Space Grotesk on headings
- [ ] Search bar navigates to `/plugins?q=...` on submit
- [ ] Responsive at 375px, 768px, 1024px, 1440px
- [ ] Supabase not configured: trending section hidden, stats show hardcoded fallbacks
- [ ] `prefers-reduced-motion`: all animations disabled

## Notes

No new npm dependencies — Space Grotesk comes from `next/font/google` (already available), icons are inline SVGs following the pattern established in `website/app/page.tsx`. The Tauri schema files in `apps/desktop/src-tauri/gen/schemas/` were pre-existing uncommitted changes and are intentionally excluded from this PR.