### PR TITLE
feat(desktop): standardize Harness section editors with formatted views

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -9,8 +9,9 @@ import PluginsPage from "./pages/harness/PluginsPage";
 import HooksPage from "./pages/harness/HooksPage";
 import McpServersPage from "./pages/harness/McpServersPage";
 import SettingsPage from "./pages/harness/SettingsPage";
-import FileViewerPage from "./pages/harness/FileViewerPage";
+import PluginExplorerPage from "./pages/harness/PluginExplorerPage";
 import ClaudeMdPage from "./pages/harness/ClaudeMdPage";
+import ConfigFilePage from "./pages/harness/ConfigFilePage";
 import SyncPage from "./pages/harness/SyncPage";
 import MarketplacePage from "./pages/marketplace/MarketplacePage";
 import DashboardPage from "./pages/observatory/DashboardPage";
@@ -65,12 +66,13 @@ export default function App() {
           <Route index element={<DefaultRedirect />} />
           <Route path="harness/file" element={<HarnessFilePage />} />
           <Route path="harness/plugins" element={<PluginsPage />} />
+          <Route path="harness/plugins/:pluginName" element={<PluginExplorerPage />} />
           <Route path="harness/mcp" element={<McpServersPage />} />
           <Route path="harness/hooks" element={<HooksPage />} />
           <Route path="harness/claude-md" element={<ClaudeMdPage />} />
           <Route path="harness/sync" element={<SyncPage />} />
           <Route path="harness/settings" element={<SettingsPage />} />
-          <Route path="harness/settings/:filename" element={<FileViewerPage />} />
+          <Route path="harness/config/:filename" element={<ConfigFilePage />} />
 
           {/* Marketplace */}
           <Route path="marketplace/:slug?" element={<MarketplacePage />} />

--- a/apps/desktop/src/components/file-explorer/ClaudeFileListPanel.tsx
+++ b/apps/desktop/src/components/file-explorer/ClaudeFileListPanel.tsx
@@ -1,0 +1,146 @@
+import { useCallback, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+interface ClaudeFileListPanelProps {
+  files: string[];
+  loading: boolean;
+  error: string | null;
+  selectedFile: string | null;
+  onSelectFile: (name: string) => void;
+  isDirty: boolean;
+}
+
+export default function ClaudeFileListPanel({
+  files,
+  loading,
+  error,
+  selectedFile,
+  onSelectFile,
+  isDirty,
+}: ClaudeFileListPanelProps) {
+  const navigate = useNavigate();
+  const [pendingFile, setPendingFile] = useState<string | null>(null);
+
+  const handleSelect = useCallback((name: string) => {
+    if (name === selectedFile) return;
+    if (isDirty) {
+      setPendingFile(name);
+    } else {
+      onSelectFile(name);
+    }
+  }, [selectedFile, isDirty, onSelectFile]);
+
+  const handleConfirmDiscard = useCallback(() => {
+    if (!pendingFile) return;
+    onSelectFile(pendingFile);
+    setPendingFile(null);
+  }, [pendingFile, onSelectFile]);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0, overflow: "hidden" }}>
+      <div style={{
+        padding: "10px 12px 6px",
+        fontSize: "10px",
+        fontWeight: 600,
+        textTransform: "uppercase",
+        letterSpacing: "0.05em",
+        color: "var(--fg-subtle)",
+        flexShrink: 0,
+      }}>
+        Config Files
+      </div>
+
+      {pendingFile && (
+        <div style={{
+          margin: "0 8px 6px",
+          padding: "8px 10px",
+          background: "var(--bg-surface)",
+          border: "1px solid var(--border-base)",
+          borderRadius: "6px",
+          fontSize: "11px",
+          color: "var(--fg-base)",
+          flexShrink: 0,
+        }}>
+          <div style={{ marginBottom: "6px" }}>
+            Unsaved changes in{" "}
+            <code style={{ fontFamily: "ui-monospace, monospace" }}>{selectedFile}</code>.
+            Discard and switch?
+          </div>
+          <div style={{ display: "flex", gap: "6px" }}>
+            <button
+              onClick={handleConfirmDiscard}
+              style={{
+                fontSize: "11px", padding: "2px 8px", borderRadius: "4px",
+                border: "1px solid var(--border-base)",
+                background: "var(--danger-light)", color: "var(--danger)", cursor: "pointer",
+              }}
+            >
+              Discard
+            </button>
+            <button
+              onClick={() => setPendingFile(null)}
+              style={{
+                fontSize: "11px", padding: "2px 8px", borderRadius: "4px",
+                border: "1px solid var(--border-base)",
+                background: "transparent", color: "var(--fg-muted)", cursor: "pointer",
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div style={{ flex: 1, overflow: "auto" }}>
+        {loading && (
+          <p style={{ fontSize: "12px", color: "var(--fg-subtle)", padding: "8px 12px", margin: 0 }}>
+            Loading...
+          </p>
+        )}
+        {error && (
+          <p style={{ fontSize: "12px", color: "var(--danger)", padding: "8px 12px", margin: 0 }}>
+            {error}
+          </p>
+        )}
+        {!loading && !error && files.length === 0 && (
+          <div style={{ padding: "8px 12px", fontSize: "12px", color: "var(--fg-subtle)" }}>
+            No files found.{" "}
+            <button
+              onClick={() => navigate("/preferences")}
+              style={{
+                background: "none", border: "none", padding: 0, cursor: "pointer",
+                color: "var(--accent-text)", fontSize: "12px", textDecoration: "underline",
+              }}
+            >
+              Change detail level in Preferences
+            </button>
+          </div>
+        )}
+        {files.map((name) => (
+          <button
+            key={name}
+            onClick={() => handleSelect(name)}
+            style={{
+              display: "block",
+              width: "100%",
+              textAlign: "left",
+              padding: "6px 12px",
+              background: selectedFile === name ? "var(--bg-elevated)" : "transparent",
+              border: "none",
+              borderLeft: selectedFile === name ? "2px solid var(--accent)" : "2px solid transparent",
+              cursor: "pointer",
+              fontSize: "12px",
+              fontFamily: "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace",
+              color: selectedFile === name ? "var(--fg-base)" : "var(--fg-muted)",
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+          >
+            {name}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/file-explorer/EditorPane.tsx
+++ b/apps/desktop/src/components/file-explorer/EditorPane.tsx
@@ -1,0 +1,183 @@
+import { Suspense, lazy } from "react";
+import type { FileEditorState } from "../../hooks/useFileEditor";
+import EditorToolbar from "./EditorToolbar";
+
+const MonacoEditor = lazy(() => import("../plugin-explorer/MonacoEditor"));
+const MarkdownPanel = lazy(() => import("../MarkdownPanel"));
+
+// ── Shimmer skeleton (loading state) ─────────────────────────
+
+function ShimmerSkeleton() {
+  return (
+    <div style={{
+      display: "flex", flexDirection: "column", gap: "8px",
+      padding: "16px", flex: 1,
+    }}>
+      {Array.from({ length: 12 }).map((_, i) => (
+        <div
+          key={i}
+          style={{
+            height: "14px",
+            borderRadius: "4px",
+            background: "var(--bg-elevated)",
+            width: `${60 + ((i * 17) % 35)}%`,
+            animation: "shimmer 1.5s ease-in-out infinite",
+            animationDelay: `${i * 0.05}s`,
+            opacity: 0.5,
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+// ── Props ─────────────────────────────────────────────────────
+
+export interface EditorPaneProps {
+  filePath: string | null;
+  editor: FileEditorState;
+  viewMode: string;
+  availableModes: Array<{ key: string; label: string }>;
+  onViewModeChange: (mode: string) => void;
+  /** Rendered when viewMode === "formatted" (harness.yaml structured view) */
+  formattedContent?: React.ReactNode;
+  /** Extra toolbar buttons (export menu, version history, etc.) */
+  toolbarActions?: React.ReactNode;
+  /** Smaller text below filename in toolbar */
+  toolbarSubtitle?: string;
+}
+
+// ── Component ─────────────────────────────────────────────────
+
+export default function EditorPane({
+  filePath,
+  editor,
+  viewMode,
+  availableModes,
+  onViewModeChange,
+  formattedContent,
+  toolbarActions,
+  toolbarSubtitle,
+}: EditorPaneProps) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0 }}>
+      <EditorToolbar
+        filePath={filePath}
+        isDirty={editor.isDirty}
+        saving={editor.saving}
+        viewMode={viewMode}
+        availableModes={availableModes}
+        onViewModeChange={onViewModeChange}
+        onSave={filePath ? editor.saveFile : undefined}
+        actions={toolbarActions}
+        subtitle={toolbarSubtitle}
+      />
+
+      <div style={{ flex: 1, minHeight: 0, position: "relative" }}>
+        {/* Empty state */}
+        {!filePath && (
+          <div style={{
+            display: "flex", alignItems: "center", justifyContent: "center",
+            flex: 1, height: "100%", color: "var(--fg-subtle)", fontSize: "12px",
+          }}>
+            Select a file to view
+          </div>
+        )}
+
+        {/* Loading */}
+        {filePath && editor.loading && <ShimmerSkeleton />}
+
+        {/* Error */}
+        {filePath && editor.error && (
+          <div style={{ padding: "20px 24px" }}>
+            <div style={{ fontSize: "13px", color: "var(--danger)", marginBottom: "8px" }}>
+              {editor.error}
+            </div>
+            <button
+              onClick={editor.reload}
+              style={{
+                fontSize: "12px", color: "var(--accent-text)", background: "none",
+                border: "none", padding: 0, cursor: "pointer", textDecoration: "underline",
+              }}
+            >
+              Reload
+            </button>
+          </div>
+        )}
+
+        {/* Content views */}
+        {filePath && !editor.loading && !editor.error && editor.content !== null && (
+          <>
+            {viewMode === "editor" && (
+              <Suspense fallback={<ShimmerSkeleton />}>
+                <MonacoEditor
+                  filePath={filePath}
+                  content={editor.content}
+                  onChange={editor.updateContent}
+                  onSave={editor.saveFile}
+                />
+              </Suspense>
+            )}
+
+            {(viewMode === "preview" || (viewMode === "formatted" && !formattedContent)) && (
+              <Suspense fallback={<ShimmerSkeleton />}>
+                <div style={{ flex: 1, overflow: "auto", padding: "0 4px", height: "100%" }}>
+                  <MarkdownPanel content={editor.content} defaultView="preview" fill />
+                </div>
+              </Suspense>
+            )}
+
+            {viewMode === "split" && (
+              <div style={{ display: "flex", height: "100%", minHeight: 0 }}>
+                {/* Left: editor */}
+                <div style={{ flex: 1, minWidth: 0, minHeight: 0 }}>
+                  <Suspense fallback={<ShimmerSkeleton />}>
+                    <MonacoEditor
+                      filePath={filePath}
+                      content={editor.content}
+                      onChange={editor.updateContent}
+                      onSave={editor.saveFile}
+                    />
+                  </Suspense>
+                </div>
+                {/* Divider */}
+                <div style={{
+                  width: "1px",
+                  flexShrink: 0,
+                  background: "var(--border-base)",
+                }} />
+                {/* Right: live preview */}
+                <div style={{ flex: 1, minWidth: 0, overflow: "auto", padding: "0 4px" }}>
+                  <Suspense fallback={<ShimmerSkeleton />}>
+                    <MarkdownPanel content={editor.content} defaultView="preview" fill />
+                  </Suspense>
+                </div>
+              </div>
+            )}
+
+            {viewMode === "raw" && (
+              <div style={{
+                height: "100%", overflow: "auto",
+                padding: "14px 16px",
+              }}>
+                <pre style={{
+                  margin: 0,
+                  fontFamily: "ui-monospace, monospace",
+                  fontSize: "11px",
+                  lineHeight: "1.6",
+                  color: "var(--fg-muted)",
+                  whiteSpace: "pre-wrap",
+                  wordBreak: "break-word",
+                }}>
+                  {editor.content}
+                </pre>
+              </div>
+            )}
+
+            {viewMode === "formatted" && formattedContent}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/file-explorer/EditorToolbar.tsx
+++ b/apps/desktop/src/components/file-explorer/EditorToolbar.tsx
@@ -6,6 +6,10 @@ interface EditorToolbarProps {
   availableModes: Array<{ key: string; label: string }>;
   onViewModeChange: (mode: string) => void;
   onSave?: () => void;
+  /** Extra controls rendered after the save button (e.g. export menu, version history) */
+  actions?: React.ReactNode;
+  /** Smaller muted text below the filename (e.g. full file path) */
+  subtitle?: string;
 }
 
 function basename(path: string): string {
@@ -20,6 +24,8 @@ export default function EditorToolbar({
   availableModes,
   onViewModeChange,
   onSave,
+  actions,
+  subtitle,
 }: EditorToolbarProps) {
   return (
     <div
@@ -34,22 +40,37 @@ export default function EditorToolbar({
         minHeight: "36px",
       }}
     >
-      {/* Filename + dirty indicator */}
+      {/* Filename + dirty indicator + subtitle */}
       {filePath && (
-        <span style={{
-          fontSize: "12px",
-          color: "var(--fg-base)",
-          fontFamily: "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace",
-          fontWeight: 500,
-          overflow: "hidden",
-          textOverflow: "ellipsis",
-          whiteSpace: "nowrap",
-        }}>
-          {basename(filePath)}
-          {isDirty && (
-            <span style={{ color: "var(--warning)", marginLeft: "4px" }} title="Unsaved changes">●</span>
+        <div style={{ overflow: "hidden", minWidth: 0 }}>
+          <span style={{
+            fontSize: "12px",
+            color: "var(--fg-base)",
+            fontFamily: "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace",
+            fontWeight: 500,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            display: "block",
+          }}>
+            {basename(filePath)}
+            {isDirty && (
+              <span style={{ color: "var(--warning)", marginLeft: "4px" }} title="Unsaved changes">●</span>
+            )}
+          </span>
+          {subtitle && (
+            <span style={{
+              fontSize: "10px",
+              color: "var(--fg-subtle)",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              display: "block",
+            }}>
+              {subtitle}
+            </span>
           )}
-        </span>
+        </div>
       )}
 
       {/* Spacer */}
@@ -108,6 +129,9 @@ export default function EditorToolbar({
           {saving ? "Saving\u2026" : "Save"}
         </button>
       )}
+
+      {/* Extra actions slot */}
+      {actions}
     </div>
   );
 }

--- a/apps/desktop/src/hooks/useClaudeFileList.ts
+++ b/apps/desktop/src/hooks/useClaudeFileList.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+import { listClaudeDir } from "../lib/tauri";
+import {
+  getConfigFilesDetailLevel,
+  type ConfigFilesDetailLevel,
+} from "../lib/preferences";
+
+// ── File filtering ────────────────────────────────────────────
+
+const TEXT_EXTENSIONS = new Set([".md", ".json", ".yaml", ".yml", ".sh", ".txt", ".toml", ".mjs"]);
+const HIDDEN_PATTERNS: RegExp[] = [
+  /^security_warnings_state_/,
+  /^statsig-/,
+  /^stats-cache\.json$/,
+];
+const ESSENTIALS = new Set(["CLAUDE.md", "AGENT.md", "SOUL.md", "settings.json", "keybindings.json"]);
+
+export function extOf(name: string): string {
+  const idx = name.lastIndexOf(".");
+  return idx === -1 ? "" : name.slice(idx);
+}
+
+export function filterFiles(files: string[], level: ConfigFilesDetailLevel): string[] {
+  if (level === "essentials") return files.filter((f) => ESSENTIALS.has(f));
+  if (level === "text-files") return files.filter(
+    (f) => TEXT_EXTENSIONS.has(extOf(f)) && !HIDDEN_PATTERNS.some((p) => p.test(f))
+  );
+  return files;
+}
+
+// ── Hook ──────────────────────────────────────────────────────
+
+export interface UseClaudeFileListReturn {
+  files: string[];
+  allFiles: string[];
+  loading: boolean;
+  error: string | null;
+  detailLevel: ConfigFilesDetailLevel;
+}
+
+export function useClaudeFileList(): UseClaudeFileListReturn {
+  const detailLevel = getConfigFilesDetailLevel();
+  const [allFiles, setAllFiles] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    listClaudeDir()
+      .then(setAllFiles)
+      .catch((e) => setError(String(e)))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const files = filterFiles(allFiles, detailLevel);
+
+  return { files, allFiles, loading, error, detailLevel };
+}

--- a/apps/desktop/src/layouts/AppLayout.tsx
+++ b/apps/desktop/src/layouts/AppLayout.tsx
@@ -1,5 +1,5 @@
 import { Outlet, NavLink, useLocation, useNavigate } from "react-router-dom";
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { open } from "@tauri-apps/plugin-shell";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useGlobalShortcuts } from "../hooks/useGlobalShortcuts";
@@ -9,6 +9,7 @@ import { initTheme } from "../lib/theme";
 import { initPreferences, getHiddenSections } from "../lib/preferences";
 import { useChat } from "../context/ChatContext";
 import ChatPanel from "../components/chat/ChatPanel";
+import { useClaudeFileList } from "../hooks/useClaudeFileList";
 
 type NavSection = {
   id: string;
@@ -23,13 +24,11 @@ export const NAV_SECTIONS: NavSection[] = [
     label: "Harness",
     path: "/harness/file",
     children: [
-      { label: "Harness File", path: "/harness/file" },
+      { label: "harness.yaml", path: "/harness/file" },
+      { label: "CLAUDE.md", path: "/harness/claude-md" },
       { label: "Plugins", path: "/harness/plugins" },
       { label: "MCP Servers", path: "/harness/mcp" },
       { label: "Hooks", path: "/harness/hooks" },
-      { label: "CLAUDE.md", path: "/harness/claude-md" },
-      { label: "Sync", path: "/harness/sync" },
-      { label: "Config Files", path: "/harness/settings" },
     ],
   },
   {
@@ -95,6 +94,118 @@ export const NAV_SECTIONS: NavSection[] = [
   },
 ];
 
+// Files with dedicated nav items — excluded from the Config Files tree
+const DEDICATED_NAV_FILES = new Set(["harness.yaml", "CLAUDE.md"]);
+
+function HarnessSubnav({ configFiles }: { configFiles: string[] }) {
+  const navigate = useNavigate();
+  const [configExpanded, setConfigExpanded] = useState(true);
+  const staticItems = [
+    { label: "harness.yaml", path: "/harness/file" },
+    { label: "CLAUDE.md", path: "/harness/claude-md" },
+    { label: "Plugins", path: "/harness/plugins" },
+    { label: "MCP Servers", path: "/harness/mcp" },
+    { label: "Hooks", path: "/harness/hooks" },
+  ];
+  const visibleConfigFiles = configFiles.filter((f) => !DEDICATED_NAV_FILES.has(f));
+  const syncItem = { label: "Sync", path: "/harness/sync" };
+  const allItems = [
+    syncItem,
+    ...staticItems,
+    ...(configExpanded ? visibleConfigFiles.map((f) => ({ label: f, path: `/harness/config/${encodeURIComponent(f)}` })) : []),
+  ];
+  const { focusedIndex, onKeyDown } = useArrowNavigation({
+    count: allItems.length,
+    onActivate: (i) => navigate(allItems[i].path),
+  });
+
+  return (
+    <div className="mt-0.5 mb-1" tabIndex={0} onKeyDown={onKeyDown} style={{ outline: "none" }}>
+      {/* Sync — action at top, separated from files below */}
+      <NavLink
+        to="/harness/sync"
+        className={({ isActive }) => `sidebar-subitem${isActive ? " active" : ""}`}
+        style={{
+          display: "flex", alignItems: "center", gap: "5px",
+          ...(focusedIndex === 0 ? { outline: "2px solid var(--accent)", outlineOffset: "-2px", borderRadius: "5px" } : {}),
+        }}
+      >
+        <svg width="11" height="11" viewBox="0 0 20 20" fill="currentColor" style={{ opacity: 0.6, flexShrink: 0 }}>
+          <path fillRule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clipRule="evenodd" />
+        </svg>
+        Sync
+      </NavLink>
+
+      <div style={{ margin: "4px 8px 4px", borderTop: "1px solid var(--separator)" }} />
+
+      {/* Static file items */}
+      {staticItems.map((item, idx) => (
+        <NavLink
+          key={item.path}
+          to={item.path}
+          end={item.path === "/harness/plugins" ? false : undefined}
+          className={({ isActive }) => `sidebar-subitem${isActive ? " active" : ""}`}
+          style={focusedIndex === idx + 1 ? { outline: "2px solid var(--accent)", outlineOffset: "-2px", borderRadius: "5px" } : undefined}
+        >
+          {item.label}
+        </NavLink>
+      ))}
+
+      {/* Config Files section header — collapsible */}
+      {visibleConfigFiles.length > 0 && (
+        <button
+          onClick={() => setConfigExpanded((v) => !v)}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            width: "100%",
+            padding: "8px 8px 2px",
+            background: "none",
+            border: "none",
+            cursor: "pointer",
+            fontSize: "10px",
+            fontWeight: 600,
+            textTransform: "uppercase",
+            letterSpacing: "0.05em",
+            color: "var(--fg-subtle)",
+          }}
+        >
+          Config Files
+          <svg
+            width="10"
+            height="10"
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            style={{ transform: configExpanded ? "rotate(0deg)" : "rotate(-90deg)", transition: "transform 0.15s ease", flexShrink: 0 }}
+          >
+            <path d="M8 10.5L2.5 5h11L8 10.5z" />
+          </svg>
+        </button>
+      )}
+
+      {/* Dynamic file items */}
+      {configExpanded && visibleConfigFiles.map((file, idx) => {
+        const path = `/harness/config/${encodeURIComponent(file)}`;
+        const itemIdx = 1 + staticItems.length + idx;
+        return (
+          <NavLink
+            key={file}
+            to={path}
+            className={({ isActive }) => `sidebar-subitem${isActive ? " active" : ""}`}
+            style={{
+              paddingLeft: "20px",
+              ...(focusedIndex === itemIdx ? { outline: "2px solid var(--accent)", outlineOffset: "-2px", borderRadius: "5px" } : {}),
+            }}
+          >
+            {file}
+          </NavLink>
+        );
+      })}
+    </div>
+  );
+}
+
 function SidebarSubnav({ children }: { children: { label: string; path: string }[] }) {
   const navigate = useNavigate();
   const { focusedIndex, onKeyDown } = useArrowNavigation({
@@ -108,6 +219,7 @@ function SidebarSubnav({ children }: { children: { label: string; path: string }
         <NavLink
           key={child.path}
           to={child.path}
+          end={child.path === "/harness/plugins" ? false : undefined}
           className={({ isActive: childActive }) =>
             `sidebar-subitem${childActive ? " active" : ""}`
           }
@@ -137,8 +249,21 @@ export default function AppLayout() {
     });
   }, []);
 
+  const [harnessExpanded, setHarnessExpanded] = useState(
+    () => location.pathname.startsWith("/harness")
+  );
+  // Auto-expand when navigating into harness from another section
+  const prevPathRef = useRef(location.pathname);
+  useEffect(() => {
+    const wasHarness = prevPathRef.current.startsWith("/harness");
+    const isHarness = location.pathname.startsWith("/harness");
+    if (!wasHarness && isHarness) setHarnessExpanded(true);
+    prevPathRef.current = location.pathname;
+  }, [location.pathname]);
+
   useGlobalShortcuts({ navigate, toggleSidebar });
   const { onMouseDown: onResizeMouseDown } = useSidebarResize();
+  const { files: configFiles } = useClaudeFileList();
 
   const [hiddenSections, setHiddenSectionsState] = useState(getHiddenSections);
 
@@ -290,23 +415,45 @@ export default function AppLayout() {
                 const shortcutNum = sectionIndex >= 0 && sectionIndex < 8 ? sectionIndex + 1 : null;
                 return (
                   <div key={section.id} className="mb-0.5">
-                    <NavLink to={section.path} className={`sidebar-item${active ? " active" : ""}`}>
-                      <span style={{ flex: 1 }}>{section.label}</span>
-                      {shortcutNum && !sidebarCollapsed && (
-                        <span
-                          style={{
-                            fontSize: 10,
-                            fontFamily: 'ui-monospace, monospace',
-                            color: 'var(--fg-subtle)',
-                            flexShrink: 0,
-                          }}
+                    {section.id === "harness" ? (
+                      <button
+                        onClick={() => setHarnessExpanded((v) => !v)}
+                        className={`sidebar-item${active ? " active" : ""}`}
+                        style={{ display: "flex", alignItems: "center", justifyContent: "space-between", width: "100%", cursor: "pointer", border: "none", background: "transparent", textAlign: "left" }}
+                      >
+                        <span style={{ flex: 1 }}>{section.label}</span>
+                        <svg
+                          width="10"
+                          height="10"
+                          viewBox="0 0 16 16"
+                          fill="currentColor"
+                          style={{ transform: harnessExpanded ? "rotate(0deg)" : "rotate(-90deg)", transition: "transform 0.15s ease", flexShrink: 0, opacity: 0.6 }}
                         >
-                          {'\u2318'}{shortcutNum}
-                        </span>
-                      )}
-                    </NavLink>
+                          <path d="M8 10.5L2.5 5h11L8 10.5z" />
+                        </svg>
+                      </button>
+                    ) : (
+                      <NavLink to={section.path} className={`sidebar-item${active ? " active" : ""}`}>
+                        <span style={{ flex: 1 }}>{section.label}</span>
+                        {shortcutNum && !sidebarCollapsed && (
+                          <span
+                            style={{
+                              fontSize: 10,
+                              fontFamily: 'ui-monospace, monospace',
+                              color: 'var(--fg-subtle)',
+                              flexShrink: 0,
+                            }}
+                          >
+                            {'\u2318'}{shortcutNum}
+                          </span>
+                        )}
+                      </NavLink>
+                    )}
 
-                    {active && section.children && (
+                    {active && section.id === "harness" && harnessExpanded && (
+                      <HarnessSubnav configFiles={configFiles} />
+                    )}
+                    {active && section.children && section.id !== "harness" && (
                       <SidebarSubnav children={section.children} />
                     )}
                   </div>

--- a/apps/desktop/src/lib/mcp-registry.ts
+++ b/apps/desktop/src/lib/mcp-registry.ts
@@ -1,0 +1,255 @@
+import type { ClaudeMcpServer } from "./mcp-types";
+
+export interface McpServerMeta {
+  displayName: string;
+  description: string;
+  /** simple-icons slug → used with cdn.simpleicons.org/{slug}/ffffff */
+  iconSlug?: string;
+  /** Background color for the icon container */
+  iconBg?: string;
+  docsUrl?: string;
+  sourceUrl?: string;
+  homepageUrl?: string;
+}
+
+// Keyed by exact npm package name (matched against args array)
+const PACKAGE_META: Record<string, McpServerMeta> = {
+  "@modelcontextprotocol/server-github": {
+    displayName: "GitHub",
+    description: "Search repos, manage issues and PRs, read files, and interact with GitHub resources.",
+    iconSlug: "github",
+    iconBg: "#24292e",
+    docsUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/github",
+    sourceUrl: "https://github.com/modelcontextprotocol/servers",
+    homepageUrl: "https://github.com",
+  },
+  "@modelcontextprotocol/server-gitlab": {
+    displayName: "GitLab",
+    description: "Interact with GitLab projects, merge requests, and CI/CD pipelines.",
+    iconSlug: "gitlab",
+    iconBg: "#FC6D26",
+    docsUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/gitlab",
+    sourceUrl: "https://github.com/modelcontextprotocol/servers",
+    homepageUrl: "https://gitlab.com",
+  },
+  "@modelcontextprotocol/server-slack": {
+    displayName: "Slack",
+    description: "Read channels, post messages, and search Slack workspaces.",
+    iconSlug: "slack",
+    iconBg: "#4A154B",
+    docsUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/slack",
+    sourceUrl: "https://github.com/modelcontextprotocol/servers",
+    homepageUrl: "https://slack.com",
+  },
+  "@modelcontextprotocol/server-postgres": {
+    displayName: "PostgreSQL",
+    description: "Run SQL queries and explore schemas in PostgreSQL databases.",
+    iconSlug: "postgresql",
+    iconBg: "#336791",
+    docsUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/postgres",
+    sourceUrl: "https://github.com/modelcontextprotocol/servers",
+    homepageUrl: "https://www.postgresql.org",
+  },
+  "@modelcontextprotocol/server-sqlite": {
+    displayName: "SQLite",
+    description: "Query and manipulate SQLite databases with full SQL support.",
+    iconSlug: "sqlite",
+    iconBg: "#003B57",
+    docsUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/sqlite",
+    sourceUrl: "https://github.com/modelcontextprotocol/servers",
+    homepageUrl: "https://www.sqlite.org",
+  },
+  "@modelcontextprotocol/server-filesystem": {
+    displayName: "Filesystem",
+    description: "Read and write files within configured allowed directories.",
+    iconBg: "#374151",
+    docsUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem",
+    sourceUrl: "https://github.com/modelcontextprotocol/servers",
+  },
+  "@modelcontextprotocol/server-puppeteer": {
+    displayName: "Puppeteer",
+    description: "Automate Chrome via Puppeteer — screenshot, click, fill forms, scrape pages.",
+    iconBg: "#00D8A2",
+    docsUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/puppeteer",
+    sourceUrl: "https://github.com/modelcontextprotocol/servers",
+    homepageUrl: "https://pptr.dev",
+  },
+  "@modelcontextprotocol/server-brave-search": {
+    displayName: "Brave Search",
+    description: "Web and local search powered by the Brave Search API.",
+    iconSlug: "brave",
+    iconBg: "#BF3930",
+    docsUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/brave-search",
+    sourceUrl: "https://github.com/modelcontextprotocol/servers",
+    homepageUrl: "https://search.brave.com",
+  },
+  "@modelcontextprotocol/server-fetch": {
+    displayName: "Fetch",
+    description: "Fetch web content — HTML, JSON, and raw text from any URL.",
+    iconBg: "#2563EB",
+    docsUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/fetch",
+    sourceUrl: "https://github.com/modelcontextprotocol/servers",
+  },
+  "@modelcontextprotocol/server-memory": {
+    displayName: "Memory",
+    description: "Persistent knowledge graph memory — entities, relations, and observations.",
+    iconBg: "#7C3AED",
+    docsUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/memory",
+    sourceUrl: "https://github.com/modelcontextprotocol/servers",
+  },
+  "@modelcontextprotocol/server-everything": {
+    displayName: "Everything (test)",
+    description: "Test server that exercises the full MCP spec — prompts, resources, tools, sampling.",
+    iconBg: "#6B7280",
+    sourceUrl: "https://github.com/modelcontextprotocol/servers",
+  },
+  "mcp-grafana": {
+    displayName: "Grafana",
+    description: "Query dashboards, metrics, logs, and alerts from your Grafana instance.",
+    iconSlug: "grafana",
+    iconBg: "#F05A28",
+    docsUrl: "https://github.com/grafana/mcp-grafana",
+    sourceUrl: "https://github.com/grafana/mcp-grafana",
+    homepageUrl: "https://grafana.com",
+  },
+  "@supabase/mcp-server-supabase": {
+    displayName: "Supabase",
+    description: "Manage Supabase projects, run SQL queries, and explore your data.",
+    iconSlug: "supabase",
+    iconBg: "#1C1C1C",
+    docsUrl: "https://github.com/supabase-community/supabase-mcp",
+    sourceUrl: "https://github.com/supabase-community/supabase-mcp",
+    homepageUrl: "https://supabase.com",
+  },
+  "@hypothesi/tauri-mcp-server": {
+    displayName: "Tauri",
+    description: "Interact with Tauri desktop application internals and APIs.",
+    iconSlug: "tauri",
+    iconBg: "#FFC131",
+    docsUrl: "https://www.npmjs.com/package/@hypothesi/tauri-mcp-server",
+    homepageUrl: "https://tauri.app",
+  },
+  "@notionhq/notion-mcp-server": {
+    displayName: "Notion",
+    description: "Read and write Notion pages, databases, and blocks.",
+    iconSlug: "notion",
+    iconBg: "#000000",
+    docsUrl: "https://github.com/makenotion/notion-mcp-server",
+    sourceUrl: "https://github.com/makenotion/notion-mcp-server",
+    homepageUrl: "https://notion.so",
+  },
+  "@linear/mcp-server": {
+    displayName: "Linear",
+    description: "Create and manage Linear issues, projects, and cycles.",
+    iconSlug: "linear",
+    iconBg: "#5E6AD2",
+    docsUrl: "https://github.com/linear/linear-mcp",
+    sourceUrl: "https://github.com/linear/linear-mcp",
+    homepageUrl: "https://linear.app",
+  },
+  "mcp-server-linear": {
+    displayName: "Linear",
+    description: "Create and manage Linear issues, projects, and cycles.",
+    iconSlug: "linear",
+    iconBg: "#5E6AD2",
+    homepageUrl: "https://linear.app",
+  },
+  "@anthropic-ai/mcp-server-everything": {
+    displayName: "Anthropic Everything",
+    description: "Full-featured MCP reference server from Anthropic.",
+    iconSlug: "anthropic",
+    iconBg: "#D97706",
+    homepageUrl: "https://anthropic.com",
+  },
+  "mcp-server-kubernetes": {
+    displayName: "Kubernetes",
+    description: "Manage Kubernetes clusters, pods, and workloads.",
+    iconSlug: "kubernetes",
+    iconBg: "#326CE5",
+    homepageUrl: "https://kubernetes.io",
+  },
+  "@playwright/mcp": {
+    displayName: "Playwright",
+    description: "Browser automation via Playwright — navigate, click, screenshot, and scrape.",
+    iconSlug: "playwright",
+    iconBg: "#2EAD33",
+    docsUrl: "https://github.com/microsoft/playwright-mcp",
+    sourceUrl: "https://github.com/microsoft/playwright-mcp",
+    homepageUrl: "https://playwright.dev",
+  },
+  "mcp-server-redis": {
+    displayName: "Redis",
+    description: "Get, set, and query Redis keys and data structures.",
+    iconSlug: "redis",
+    iconBg: "#DC382D",
+    homepageUrl: "https://redis.io",
+  },
+  "mongodb-mcp-server": {
+    displayName: "MongoDB",
+    description: "Query and manage MongoDB Atlas databases.",
+    iconSlug: "mongodb",
+    iconBg: "#47A248",
+    homepageUrl: "https://mongodb.com",
+  },
+  "@context7/mcp": {
+    displayName: "Context7",
+    description: "Fetch up-to-date documentation for any library directly into your context.",
+    iconBg: "#0A0A0A",
+    docsUrl: "https://context7.com",
+    homepageUrl: "https://context7.com",
+  },
+};
+
+// Fuzzy fallback: keyed by lowercase server name
+const NAME_META: Record<string, McpServerMeta> = {
+  grafana:    PACKAGE_META["mcp-grafana"],
+  github:     PACKAGE_META["@modelcontextprotocol/server-github"],
+  gitlab:     PACKAGE_META["@modelcontextprotocol/server-gitlab"],
+  slack:      PACKAGE_META["@modelcontextprotocol/server-slack"],
+  postgres:   PACKAGE_META["@modelcontextprotocol/server-postgres"],
+  postgresql: PACKAGE_META["@modelcontextprotocol/server-postgres"],
+  sqlite:     PACKAGE_META["@modelcontextprotocol/server-sqlite"],
+  filesystem: PACKAGE_META["@modelcontextprotocol/server-filesystem"],
+  supabase:   PACKAGE_META["@supabase/mcp-server-supabase"],
+  tauri:      PACKAGE_META["@hypothesi/tauri-mcp-server"],
+  notion:     PACKAGE_META["@notionhq/notion-mcp-server"],
+  linear:     PACKAGE_META["@linear/mcp-server"],
+  brave:      PACKAGE_META["@modelcontextprotocol/server-brave-search"],
+  puppeteer:  PACKAGE_META["@modelcontextprotocol/server-puppeteer"],
+  playwright: PACKAGE_META["@playwright/mcp"],
+  redis:      PACKAGE_META["mcp-server-redis"],
+  mongodb:    PACKAGE_META["mongodb-mcp-server"],
+  kubernetes: PACKAGE_META["mcp-server-kubernetes"],
+  fetch:      PACKAGE_META["@modelcontextprotocol/server-fetch"],
+  memory:     PACKAGE_META["@modelcontextprotocol/server-memory"],
+  context7:   PACKAGE_META["@context7/mcp"],
+};
+
+export function lookupMcpServer(name: string, config: ClaudeMcpServer): McpServerMeta | null {
+  // 1. Exact match on args entries
+  if ("args" in config && config.args) {
+    for (const arg of config.args) {
+      if (PACKAGE_META[arg]) return PACKAGE_META[arg];
+    }
+    // Partial match — package name is a substring of an arg (handles `npx -y @pkg@latest`)
+    for (const arg of config.args) {
+      for (const [pkg, meta] of Object.entries(PACKAGE_META)) {
+        if (arg.includes(pkg)) return meta;
+      }
+    }
+  }
+
+  // 2. Match by server name
+  return NAME_META[name.toLowerCase()] ?? null;
+}
+
+// Deterministic avatar color derived from the server name
+const AVATAR_COLORS = [
+  "#7C3AED", "#2563EB", "#059669", "#D97706",
+  "#DC2626", "#0891B2", "#DB2777", "#374151",
+];
+
+export function getAvatarColor(name: string): string {
+  const sum = [...name].reduce((acc, c) => acc + c.charCodeAt(0), 0);
+  return AVATAR_COLORS[sum % AVATAR_COLORS.length];
+}

--- a/apps/desktop/src/lib/viewModes.ts
+++ b/apps/desktop/src/lib/viewModes.ts
@@ -1,0 +1,40 @@
+export interface ViewModeOption {
+  key: string;
+  label: string;
+}
+
+export function getAvailableViewModes(
+  filePath: string | null,
+  isHarnessYaml?: boolean,
+): ViewModeOption[] {
+  if (isHarnessYaml) {
+    return [
+      { key: "formatted", label: "Formatted" },
+      { key: "raw", label: "Raw" },
+      { key: "editor", label: "Editor" },
+    ];
+  }
+
+  if (filePath && isMarkdownFile(filePath)) {
+    return [
+      { key: "formatted", label: "Formatted" },
+      { key: "editor", label: "Editor" },
+      { key: "split", label: "Split" },
+    ];
+  }
+
+  return [{ key: "editor", label: "Editor" }];
+}
+
+export function getDefaultViewMode(
+  filePath: string | null,
+  isHarnessYaml?: boolean,
+): string {
+  if (isHarnessYaml) return "formatted";
+  if (filePath && isMarkdownFile(filePath)) return "formatted";
+  return "editor";
+}
+
+function isMarkdownFile(path: string): boolean {
+  return path.endsWith(".md") || path.endsWith(".mdx");
+}

--- a/apps/desktop/src/pages/harness/ClaudeMdPage.tsx
+++ b/apps/desktop/src/pages/harness/ClaudeMdPage.tsx
@@ -1,58 +1,22 @@
-import { Suspense, lazy, useState } from "react";
+import { useState } from "react";
 import { useFileEditor } from "../../hooks/useFileEditor";
-import EditorToolbar from "../../components/file-explorer/EditorToolbar";
-
-const MonacoEditor = lazy(() => import("../../components/plugin-explorer/MonacoEditor"));
-const MarkdownPanel = lazy(() => import("../../components/MarkdownPanel"));
+import { getAvailableViewModes, getDefaultViewMode } from "../../lib/viewModes";
+import EditorPane from "../../components/file-explorer/EditorPane";
 
 const FILE_PATH = "~/.claude/CLAUDE.md";
-const VIEW_MODES = [
-  { key: "preview", label: "Preview" },
-  { key: "editor", label: "Editor" },
-];
 
 export default function ClaudeMdPage() {
-  const [viewMode, setViewMode] = useState("preview");
   const editor = useFileEditor(FILE_PATH);
-
+  const [viewMode, setViewMode] = useState(getDefaultViewMode(FILE_PATH));
   return (
-    <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
-      <EditorToolbar
+    <div style={{ display: "flex", flexDirection: "column", height: "100%", overflow: "hidden" }}>
+      <EditorPane
         filePath={FILE_PATH}
-        isDirty={editor.isDirty}
-        saving={editor.saving}
+        editor={editor}
         viewMode={viewMode}
-        availableModes={VIEW_MODES}
+        availableModes={getAvailableViewModes(FILE_PATH)}
         onViewModeChange={setViewMode}
-        onSave={editor.saveFile}
       />
-      <div style={{ flex: 1, minHeight: 0, position: "relative" }}>
-        {editor.loading && (
-          <p style={{ padding: "20px 24px", fontSize: "13px", color: "var(--fg-subtle)" }}>
-            Loading…
-          </p>
-        )}
-        {editor.error && (
-          <p style={{ padding: "20px 24px", fontSize: "13px", color: "var(--danger)" }}>
-            {editor.error}
-          </p>
-        )}
-        {!editor.loading && !editor.error && editor.content !== null && viewMode === "preview" && (
-          <Suspense fallback={null}>
-            <MarkdownPanel content={editor.content} defaultView="preview" fill />
-          </Suspense>
-        )}
-        {!editor.loading && !editor.error && editor.content !== null && viewMode === "editor" && (
-          <Suspense fallback={null}>
-            <MonacoEditor
-              filePath={FILE_PATH}
-              content={editor.content}
-              onChange={editor.updateContent}
-              onSave={editor.saveFile}
-            />
-          </Suspense>
-        )}
-      </div>
     </div>
   );
 }

--- a/apps/desktop/src/pages/harness/ConfigFilePage.tsx
+++ b/apps/desktop/src/pages/harness/ConfigFilePage.tsx
@@ -6,7 +6,10 @@ import EditorPane from "../../components/file-explorer/EditorPane";
 
 export default function ConfigFilePage() {
   const { filename } = useParams<{ filename: string }>();
-  const filePath = filename ? `~/.claude/${decodeURIComponent(filename)}` : null;
+  // Decode and validate: reject any name containing path separators or traversal sequences
+  const decoded = filename ? decodeURIComponent(filename) : null;
+  const safeName = decoded && !decoded.includes("/") && !decoded.includes("\\") && !decoded.includes("..") ? decoded : null;
+  const filePath = safeName ? `~/.claude/${safeName}` : null;
   const editor = useFileEditor(filePath);
   const [viewMode, setViewMode] = useState(() => getDefaultViewMode(filePath));
 

--- a/apps/desktop/src/pages/harness/ConfigFilePage.tsx
+++ b/apps/desktop/src/pages/harness/ConfigFilePage.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { useFileEditor } from "../../hooks/useFileEditor";
+import { getAvailableViewModes, getDefaultViewMode } from "../../lib/viewModes";
+import EditorPane from "../../components/file-explorer/EditorPane";
+
+export default function ConfigFilePage() {
+  const { filename } = useParams<{ filename: string }>();
+  const filePath = filename ? `~/.claude/${decodeURIComponent(filename)}` : null;
+  const editor = useFileEditor(filePath);
+  const [viewMode, setViewMode] = useState(() => getDefaultViewMode(filePath));
+
+  useEffect(() => {
+    setViewMode(getDefaultViewMode(filePath));
+  }, [filePath]);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", height: "100%", overflow: "hidden" }}>
+      <EditorPane
+        filePath={filePath}
+        editor={editor}
+        viewMode={viewMode}
+        availableModes={getAvailableViewModes(filePath)}
+        onViewModeChange={setViewMode}
+      />
+    </div>
+  );
+}

--- a/apps/desktop/src/pages/harness/HarnessFilePage.tsx
+++ b/apps/desktop/src/pages/harness/HarnessFilePage.tsx
@@ -1,9 +1,12 @@
 import { Suspense, lazy, useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { readHarnessFile, scanClaudeConfig, writeHarnessFile, saveCustomProfile } from "../../lib/tauri";
 import { parseHarness, validateHarnessYaml } from "@harness-kit/core";
 import type { HarnessConfig, ValidationResult } from "@harness-kit/core";
 import { generateHarnessYaml, HARNESS_TEMPLATE } from "../../lib/harness-generator";
 import type { HarnessProfile } from "../../lib/profiles";
+import { getAvailableViewModes } from "../../lib/viewModes";
+import EditorToolbar from "../../components/file-explorer/EditorToolbar";
 import ValidationBanner from "./harness-file/ValidationBanner";
 import MetadataSection from "./harness-file/MetadataSection";
 import PluginsSection from "./harness-file/PluginsSection";
@@ -19,6 +22,7 @@ const MonacoEditor = lazy(() => import("../../components/plugin-explorer/MonacoE
 type View = "formatted" | "raw" | "editor";
 
 export default function HarnessFilePage() {
+  const navigate = useNavigate();
   const [loading, setLoading] = useState(true);
   const [fetchError, setFetchError] = useState<string | null>(null);
   const [found, setFound] = useState(false);
@@ -78,7 +82,7 @@ export default function HarnessFilePage() {
     }
   }, [diskContent, parsed.parseError]);
 
-  // ── Save ──────────────────────────────────────────────────────────────────
+  // ── Save ──────────────────────────────────────────────────────
 
   const handleSave = useCallback(async () => {
     if (saving || !saveable) return;
@@ -109,7 +113,7 @@ export default function HarnessFilePage() {
     return () => window.removeEventListener("keydown", onKey);
   }, [view, handleSave]);
 
-  // ── Empty state actions ───────────────────────────────────────────────────
+  // ── Empty state actions ───────────────────────────────────────
 
   function openEditor(content: string) {
     setEditorContent(content);
@@ -138,13 +142,17 @@ export default function HarnessFilePage() {
     openEditor(profile.yaml);
   }
 
-  function handleEditCurrent() {
-    setEditorContent(diskContent ?? HARNESS_TEMPLATE);
-    setView("editor");
-    setSaveError(null);
+  // ── View mode change (populate editor content when switching to editor) ──
+
+  function handleViewModeChange(mode: string) {
+    if (mode === "editor") {
+      setEditorContent(diskContent ?? HARNESS_TEMPLATE);
+      setSaveError(null);
+    }
+    setView(mode as View);
   }
 
-  // ── Save as profile ───────────────────────────────────────────────────────
+  // ── Save as profile ───────────────────────────────────────────
 
   async function handleSaveAsProfile() {
     if (!profileNameInput.trim()) return;
@@ -165,163 +173,115 @@ export default function HarnessFilePage() {
     }
   }
 
-  // ── Style helpers ─────────────────────────────────────────────────────────
+  // ── Toolbar actions ──────────────────────────────────────────
 
-  const tabBtn = (active: boolean): React.CSSProperties => ({
-    fontSize: "10px",
-    fontWeight: active ? 600 : 400,
-    padding: "3px 8px",
-    borderRadius: "4px",
-    border: "none",
-    background: active ? "var(--bg-elevated)" : "transparent",
-    color: active ? "var(--fg-base)" : "var(--fg-subtle)",
-    cursor: "pointer",
-    boxShadow: active ? "var(--shadow-sm)" : "none",
-    transition: "all 0.1s",
-  });
-
-  // ── Render ────────────────────────────────────────────────────────────────
-
-  const isFullHeight = view === "editor" && found;
-
-  return (
-    <div style={{ display: "flex", flexDirection: "column", height: "100%", overflow: "hidden" }}>
-      {/* Header */}
-      <div style={{
-        padding: "20px 24px 16px",
-        display: "flex",
-        alignItems: "flex-start",
-        justifyContent: "space-between",
-        flexShrink: 0,
-        borderBottom: isFullHeight ? "1px solid var(--border-base)" : "none",
-      }}>
-        <div>
-          <h1 style={{ fontSize: "17px", fontWeight: 600, letterSpacing: "-0.3px", color: "var(--fg-base)", margin: 0 }}>
-            Harness File
-          </h1>
-          <p style={{ fontSize: "12px", color: "var(--fg-muted)", margin: "3px 0 0" }}>
-            The single source of truth for your AI assistant configuration.
-          </p>
-        </div>
-
-        {found && !loading && (
-          <div style={{ display: "flex", alignItems: "center", gap: "8px", flexShrink: 0, marginLeft: "16px" }}>
-            {/* File path */}
-            {filePath && (
-              <code style={{ fontSize: "11px", color: "var(--fg-subtle)", fontFamily: "ui-monospace, monospace" }}>
-                {filePath}
-              </code>
-            )}
-
-            {/* Save as Profile button */}
-            <div style={{ position: "relative" }}>
-              <button
-                onClick={() => { setProfileNameOpen((v) => !v); setProfileSaveError(null); }}
-                style={{
-                  display: "flex", alignItems: "center", gap: "4px",
-                  padding: "4px 10px", borderRadius: "6px",
-                  border: "1px solid var(--border-base)",
-                  background: "var(--bg-elevated)",
-                  color: "var(--fg-subtle)", fontSize: "11px",
-                  cursor: "pointer", whiteSpace: "nowrap",
-                }}
-                title="Save current harness as a reusable profile"
-              >
-                Save as profile
+  const toolbarActions = found && !loading ? (
+    <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+      {/* Sync */}
+      <button
+        onClick={() => navigate("/harness/sync")}
+        style={{
+          display: "flex", alignItems: "center", gap: "4px",
+          padding: "3px 8px", borderRadius: "5px",
+          border: "1px solid var(--border-base)",
+          background: "var(--bg-elevated)",
+          color: "var(--fg-subtle)", fontSize: "11px",
+          cursor: "pointer", whiteSpace: "nowrap",
+          fontFamily: "inherit",
+        }}
+        title="Sync harness.yaml to platform config files"
+      >
+        <svg width="11" height="11" viewBox="0 0 20 20" fill="currentColor">
+          <path fillRule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clipRule="evenodd" />
+        </svg>
+        Sync
+      </button>
+      {/* Save as Profile */}
+      <div style={{ position: "relative" }}>
+        <button
+          onClick={() => { setProfileNameOpen((v) => !v); setProfileSaveError(null); }}
+          style={{
+            display: "flex", alignItems: "center", gap: "4px",
+            padding: "3px 8px", borderRadius: "5px",
+            border: "1px solid var(--border-base)",
+            background: "var(--bg-elevated)",
+            color: "var(--fg-subtle)", fontSize: "11px",
+            cursor: "pointer", whiteSpace: "nowrap",
+            fontFamily: "inherit",
+          }}
+          title="Save current harness as a reusable profile"
+        >
+          Save as profile
+        </button>
+        {profileSavedMsg && (
+          <span style={{ position: "absolute", top: "calc(100% + 6px)", right: 0, fontSize: "11px", color: "var(--accent)", whiteSpace: "nowrap", zIndex: 50 }}>
+            Profile saved!
+          </span>
+        )}
+        {profileNameOpen && (
+          <div style={{
+            position: "absolute", top: "calc(100% + 6px)", right: 0,
+            background: "var(--bg-surface)", border: "1px solid var(--border-base)",
+            borderRadius: "8px", padding: "10px 12px",
+            boxShadow: "0 4px 16px rgba(0,0,0,0.2)",
+            zIndex: 50, minWidth: "220px",
+            display: "flex", flexDirection: "column", gap: "8px",
+          }}>
+            <span style={{ fontSize: "11px", fontWeight: 600, color: "var(--fg-base)" }}>Profile name</span>
+            <input
+              autoFocus
+              type="text"
+              value={profileNameInput}
+              onChange={(e) => setProfileNameInput(e.target.value)}
+              onKeyDown={(e) => { if (e.key === "Enter") handleSaveAsProfile(); if (e.key === "Escape") setProfileNameOpen(false); }}
+              placeholder="e.g. my-setup"
+              style={{
+                padding: "5px 8px", borderRadius: "5px",
+                border: "1px solid var(--border-base)",
+                background: "var(--bg-elevated)",
+                color: "var(--fg-base)", fontSize: "12px", outline: "none",
+              }}
+            />
+            {profileSaveError && <span style={{ fontSize: "10px", color: "var(--danger)" }}>{profileSaveError}</span>}
+            <div style={{ display: "flex", gap: "6px", justifyContent: "flex-end" }}>
+              <button onClick={() => setProfileNameOpen(false)} style={{ padding: "4px 10px", borderRadius: "5px", border: "1px solid var(--border-base)", background: "transparent", color: "var(--fg-subtle)", fontSize: "11px", cursor: "pointer" }}>
+                Cancel
               </button>
-              {profileSavedMsg && (
-                <span style={{ position: "absolute", top: "calc(100% + 6px)", right: 0, fontSize: "11px", color: "var(--accent)", whiteSpace: "nowrap" }}>
-                  Profile saved!
-                </span>
-              )}
-              {profileNameOpen && (
-                <div style={{
-                  position: "absolute", top: "calc(100% + 6px)", right: 0,
-                  background: "var(--bg-surface)", border: "1px solid var(--border-base)",
-                  borderRadius: "8px", padding: "10px 12px",
-                  boxShadow: "0 4px 16px rgba(0,0,0,0.2)",
-                  zIndex: 50, minWidth: "220px",
-                  display: "flex", flexDirection: "column", gap: "8px",
-                }}>
-                  <span style={{ fontSize: "11px", fontWeight: 600, color: "var(--fg-base)" }}>Profile name</span>
-                  <input
-                    autoFocus
-                    type="text"
-                    value={profileNameInput}
-                    onChange={(e) => setProfileNameInput(e.target.value)}
-                    onKeyDown={(e) => { if (e.key === "Enter") handleSaveAsProfile(); if (e.key === "Escape") setProfileNameOpen(false); }}
-                    placeholder="e.g. my-setup"
-                    style={{
-                      padding: "5px 8px", borderRadius: "5px",
-                      border: "1px solid var(--border-base)",
-                      background: "var(--bg-elevated)",
-                      color: "var(--fg-base)", fontSize: "12px", outline: "none",
-                    }}
-                  />
-                  {profileSaveError && <span style={{ fontSize: "10px", color: "var(--danger)" }}>{profileSaveError}</span>}
-                  <div style={{ display: "flex", gap: "6px", justifyContent: "flex-end" }}>
-                    <button onClick={() => setProfileNameOpen(false)} style={{ padding: "4px 10px", borderRadius: "5px", border: "1px solid var(--border-base)", background: "transparent", color: "var(--fg-subtle)", fontSize: "11px", cursor: "pointer" }}>
-                      Cancel
-                    </button>
-                    <button
-                      onClick={handleSaveAsProfile}
-                      disabled={!profileNameInput.trim() || profileSaving}
-                      style={{ padding: "4px 10px", borderRadius: "5px", border: "none", background: profileNameInput.trim() ? "var(--accent)" : "var(--bg-elevated)", color: profileNameInput.trim() ? "var(--accent-text, #fff)" : "var(--fg-subtle)", fontSize: "11px", fontWeight: 600, cursor: profileNameInput.trim() ? "pointer" : "not-allowed" }}
-                    >
-                      {profileSaving ? "Saving…" : "Save"}
-                    </button>
-                  </div>
-                </div>
-              )}
-            </div>
-
-            {/* Edit / Save buttons */}
-            {view !== "editor" ? (
               <button
-                onClick={handleEditCurrent}
-                style={{
-                  display: "flex", alignItems: "center", gap: "5px",
-                  padding: "4px 10px", borderRadius: "6px",
-                  border: "1px solid var(--border-base)",
-                  background: "var(--bg-elevated)",
-                  color: "var(--fg-base)", fontSize: "11px", fontWeight: 500,
-                  cursor: "pointer",
-                }}
+                onClick={handleSaveAsProfile}
+                disabled={!profileNameInput.trim() || profileSaving}
+                style={{ padding: "4px 10px", borderRadius: "5px", border: "none", background: profileNameInput.trim() ? "var(--accent)" : "var(--bg-elevated)", color: profileNameInput.trim() ? "var(--accent-text, #fff)" : "var(--fg-subtle)", fontSize: "11px", fontWeight: 600, cursor: profileNameInput.trim() ? "pointer" : "not-allowed" }}
               >
-                <svg width="11" height="11" viewBox="0 0 20 20" fill="currentColor">
-                  <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
-                </svg>
-                Edit
+                {profileSaving ? "Saving..." : "Save"}
               </button>
-            ) : (
-              <button
-                onClick={handleSave}
-                disabled={!saveable || saving}
-                style={{
-                  padding: "4px 12px", borderRadius: "6px", border: "none",
-                  background: saveable && !saving ? "var(--accent)" : "var(--bg-elevated)",
-                  color: saveable && !saving ? "var(--accent-text, #fff)" : "var(--fg-subtle)",
-                  fontSize: "11px", fontWeight: 600,
-                  cursor: saveable && !saving ? "pointer" : "not-allowed",
-                }}
-              >
-                {saving ? "Saving…" : "Save"}
-              </button>
-            )}
-
-            {/* View toggle */}
-            <div style={{
-              display: "flex", gap: "2px",
-              background: "var(--bg-base)", border: "1px solid var(--border-base)",
-              borderRadius: "6px", padding: "2px",
-            }}>
-              <button onClick={() => setView("formatted")} style={tabBtn(view === "formatted")}>Formatted</button>
-              <button onClick={() => setView("raw")} style={tabBtn(view === "raw")}>Raw</button>
-              <button onClick={() => { setEditorContent(diskContent ?? ""); setView("editor"); }} style={tabBtn(view === "editor")}>Editor</button>
             </div>
           </div>
         )}
       </div>
+    </div>
+  ) : undefined;
+
+  // ── Render ────────────────────────────────────────────────────
+
+  const isFullHeight = view === "editor" && found;
+  const viewModes = getAvailableViewModes("harness.yaml", true);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", height: "100%", overflow: "hidden" }}>
+      {/* Standardized toolbar */}
+      {found && !loading && (
+        <EditorToolbar
+          filePath="harness.yaml"
+          subtitle={filePath ?? undefined}
+          isDirty={saveable}
+          saving={saving}
+          viewMode={view}
+          availableModes={viewModes}
+          onViewModeChange={handleViewModeChange}
+          onSave={handleSave}
+          actions={toolbarActions}
+        />
+      )}
 
       {/* Save error (editor view) */}
       {saveError && view === "editor" && (
@@ -335,7 +295,7 @@ export default function HarnessFilePage() {
 
         {/* Loading */}
         {loading && (
-          <p style={{ fontSize: "13px", color: "var(--fg-subtle)", paddingTop: "4px" }}>Loading…</p>
+          <p style={{ fontSize: "13px", color: "var(--fg-subtle)", paddingTop: "4px" }}>Loading...</p>
         )}
 
         {/* Fetch error */}
@@ -356,7 +316,6 @@ export default function HarnessFilePage() {
             borderRadius: "8px", padding: "32px 24px",
             textAlign: "center", maxWidth: "540px", marginTop: "4px",
           }}>
-            <div style={{ fontSize: "28px", marginBottom: "12px" }}>🧰</div>
             <h2 style={{ fontSize: "15px", fontWeight: 600, color: "var(--fg-base)", margin: "0 0 6px" }}>
               No harness.yaml found
             </h2>
@@ -381,7 +340,7 @@ export default function HarnessFilePage() {
                   cursor: generating ? "not-allowed" : "pointer",
                 }}
               >
-                {generating ? "Scanning…" : "Generate from Claude Code setup"}
+                {generating ? "Scanning..." : "Generate from Claude Code setup"}
               </button>
               <button
                 onClick={() => setProfilePickerOpen(true)}
@@ -430,7 +389,7 @@ export default function HarnessFilePage() {
                       cursor: saveable && !saving ? "pointer" : "not-allowed",
                     }}
                   >
-                    {saving ? "Saving…" : "Save harness.yaml"}
+                    {saving ? "Saving..." : "Save harness.yaml"}
                   </button>
                 </div>
               </div>
@@ -438,7 +397,7 @@ export default function HarnessFilePage() {
             <div style={{ flex: 1, overflow: "hidden", border: "1px solid var(--border-base)", borderRadius: found ? 0 : "8px" }}>
               <Suspense fallback={
                 <div style={{ display: "flex", alignItems: "center", justifyContent: "center", height: "100%", fontSize: "12px", color: "var(--fg-subtle)" }}>
-                  Loading editor…
+                  Loading editor...
                 </div>
               }>
                 <MonacoEditor

--- a/apps/desktop/src/pages/harness/HooksPage.tsx
+++ b/apps/desktop/src/pages/harness/HooksPage.tsx
@@ -1,38 +1,416 @@
-import { Suspense, lazy } from "react";
+import { Suspense, lazy, useState, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
 import { useFileEditor } from "../../hooks/useFileEditor";
 import EditorToolbar from "../../components/file-explorer/EditorToolbar";
 
 const MonacoEditor = lazy(() => import("../../components/plugin-explorer/MonacoEditor"));
 
 const FILE_PATH = "~/.claude/settings.json";
-const VIEW_MODES = [{ key: "editor", label: "Editor" }];
 
-export default function HooksPage() {
-  const editor = useFileEditor(FILE_PATH);
+// ── Hook event metadata ───────────────────────────────────────
+
+interface HookEventMeta {
+  label: string;
+  description: string;
+  icon: React.ReactNode;
+  order: number;
+}
+
+const HOOK_ICON_STYLE: React.CSSProperties = {
+  color: "var(--fg-subtle)", flexShrink: 0,
+};
+
+const EVENT_META: Record<string, HookEventMeta> = {
+  SessionStart: {
+    label: "Session Start",
+    description: "Runs once when a new Claude Code session is created.",
+    order: 0,
+    icon: (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" style={HOOK_ICON_STYLE}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M5.636 5.636a9 9 0 1012.728 0M12 3v9" />
+      </svg>
+    ),
+  },
+  UserPromptSubmit: {
+    label: "User Prompt Submit",
+    description: "Fires each time the user submits a message. Can inject context or block requests.",
+    order: 1,
+    icon: (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" style={HOOK_ICON_STYLE}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M6 12L3.269 3.126A59.768 59.768 0 0121.485 12 59.77 59.77 0 013.27 20.876L5.999 12zm0 0h7.5" />
+      </svg>
+    ),
+  },
+  PreToolUse: {
+    label: "Pre Tool Use",
+    description: "Runs before every tool call. Can inspect, modify, or block the operation.",
+    order: 2,
+    icon: (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" style={HOOK_ICON_STYLE}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.971l-11.54 6.347a1.125 1.125 0 01-1.667-.985V5.653z" />
+      </svg>
+    ),
+  },
+  PostToolUse: {
+    label: "Post Tool Use",
+    description: "Runs after every tool call completes. Can observe results or trigger side effects.",
+    order: 3,
+    icon: (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" style={HOOK_ICON_STYLE}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.971l-11.54 6.347a1.125 1.125 0 01-1.667-.985V5.653z" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 5.25v13.5" />
+      </svg>
+    ),
+  },
+  Notification: {
+    label: "Notification",
+    description: "Fires when Claude sends a notification — permission prompts, idle alerts, dialogs.",
+    order: 4,
+    icon: (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" style={HOOK_ICON_STYLE}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0" />
+      </svg>
+    ),
+  },
+  Stop: {
+    label: "Stop",
+    description: "Runs when Claude finishes a response successfully.",
+    order: 5,
+    icon: (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" style={HOOK_ICON_STYLE}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M5.25 7.5A2.25 2.25 0 017.5 5.25h9a2.25 2.25 0 012.25 2.25v9a2.25 2.25 0 01-2.25 2.25h-9a2.25 2.25 0 01-2.25-2.25v-9z" />
+      </svg>
+    ),
+  },
+  StopFailure: {
+    label: "Stop Failure",
+    description: "Fires on rate limits, auth failures, billing errors, or server errors.",
+    order: 6,
+    icon: (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" style={HOOK_ICON_STYLE}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+      </svg>
+    ),
+  },
+  PreCompact: {
+    label: "Pre Compact",
+    description: "Runs before context compaction. Use to capture state before the window shrinks.",
+    order: 7,
+    icon: (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" style={HOOK_ICON_STYLE}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 9V4.5M9 9H4.5M9 9L3.75 3.75M9 15v4.5M9 15H4.5M9 15l-5.25 5.25M15 9h4.5M15 9V4.5M15 9l5.25-5.25M15 15h4.5M15 15v4.5m0-4.5l5.25 5.25" />
+      </svg>
+    ),
+  },
+  SessionEnd: {
+    label: "Session End",
+    description: "Fires when a Claude Code session terminates. Good for cleanup or capture.",
+    order: 8,
+    icon: (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" style={HOOK_ICON_STYLE}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M5.636 5.636a9 9 0 1012.728 0M12 3v9" transform="rotate(180 12 12)" />
+      </svg>
+    ),
+  },
+};
+
+// ── Hook entry ────────────────────────────────────────────────
+
+interface HookEntry {
+  type: string;
+  command?: string;
+  timeout?: number;
+}
+
+interface HookMatcher {
+  matcher?: string;
+  hooks: HookEntry[];
+}
+
+function MatcherBadge({ matcher }: { matcher?: string }) {
+  if (!matcher || matcher === "*") {
+    return (
+      <span style={{
+        padding: "1px 6px", borderRadius: "4px", fontSize: "10px", fontWeight: 600,
+        background: "var(--bg-elevated)", color: "var(--fg-subtle)",
+        fontFamily: "ui-monospace, monospace",
+      }}>
+        all tools
+      </span>
+    );
+  }
+  return (
+    <span style={{
+      padding: "1px 6px", borderRadius: "4px", fontSize: "10px", fontWeight: 600,
+      background: "var(--accent-light, #1a1a2e)", color: "var(--accent)",
+      fontFamily: "ui-monospace, monospace", wordBreak: "break-all",
+    }}>
+      {matcher}
+    </span>
+  );
+}
+
+function HookRow({ entry }: { entry: HookEntry }) {
+  const cmd = entry.command ?? "";
+  // Show basename for long absolute paths, keep the full path accessible via title
+  const display = cmd.startsWith("/") ? cmd.split("/").pop() ?? cmd : cmd;
+  const isScript = cmd.endsWith(".sh") || cmd.endsWith(".py") || cmd.endsWith(".js");
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+    <div style={{
+      display: "flex", alignItems: "center", gap: "8px",
+      padding: "5px 10px",
+      background: "var(--bg-elevated)",
+      borderRadius: "6px",
+    }}>
+      {/* Type indicator */}
+      {entry.type === "command" && (
+        <svg width="11" height="11" viewBox="0 0 20 20" fill="currentColor" style={{ color: "var(--fg-subtle)", flexShrink: 0 }}>
+          <path fillRule="evenodd" d="M2 5a2 2 0 012-2h12a2 2 0 012 2v10a2 2 0 01-2 2H4a2 2 0 01-2-2V5zm3.293 1.293a1 1 0 011.414 0l3 3a1 1 0 010 1.414l-3 3a1 1 0 01-1.414-1.414L7.586 10 5.293 7.707a1 1 0 010-1.414zM11 12a1 1 0 100 2h3a1 1 0 100-2h-3z" clipRule="evenodd" />
+        </svg>
+      )}
+      <code
+        title={cmd}
+        style={{
+          fontSize: "11px", fontFamily: "ui-monospace, monospace",
+          color: isScript ? "var(--accent)" : "var(--fg-muted)",
+          flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
+        }}
+      >
+        {display}
+      </code>
+      {cmd !== display && (
+        <span style={{
+          fontSize: "10px", color: "var(--fg-subtle)", fontFamily: "ui-monospace, monospace",
+          overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
+          maxWidth: "160px", flexShrink: 1,
+        }}>
+          {cmd.replace(display, "").replace(/\/$/, "")}
+        </span>
+      )}
+      {entry.timeout != null && (
+        <span style={{
+          fontSize: "10px", color: "var(--fg-subtle)", whiteSpace: "nowrap", flexShrink: 0,
+        }}>
+          {entry.timeout}s
+        </span>
+      )}
+    </div>
+  );
+}
+
+function HookMatcherBlock({ matcher }: { matcher: HookMatcher }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+      <div style={{ marginBottom: "2px" }}>
+        <MatcherBadge matcher={matcher.matcher} />
+      </div>
+      {matcher.hooks.map((entry, i) => <HookRow key={i} entry={entry} />)}
+    </div>
+  );
+}
+
+function HookEventSection({ event, matchers }: { event: string; matchers: HookMatcher[] }) {
+  const meta = EVENT_META[event];
+  const totalHooks = matchers.reduce((n, m) => n + m.hooks.length, 0);
+
+  return (
+    <div style={{
+      background: "var(--bg-surface)",
+      border: "1px solid var(--border-base)",
+      borderRadius: "10px",
+      padding: "14px 16px",
+      display: "flex",
+      flexDirection: "column",
+      gap: "10px",
+    }}>
+      {/* Section header */}
+      <div style={{ display: "flex", alignItems: "flex-start", gap: "10px" }}>
+        <div style={{
+          width: "28px", height: "28px", borderRadius: "7px",
+          background: "var(--bg-elevated)", border: "1px solid var(--border-base)",
+          display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0,
+        }}>
+          {meta?.icon ?? (
+            <svg width="14" height="14" viewBox="0 0 20 20" fill="currentColor" style={{ color: "var(--fg-subtle)" }}>
+              <path fillRule="evenodd" d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 5a1 1 0 011-1h6a1 1 0 110 2H4a1 1 0 01-1-1z" clipRule="evenodd" />
+            </svg>
+          )}
+        </div>
+        <div style={{ flex: 1 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+            <span style={{ fontSize: "13px", fontWeight: 600, color: "var(--fg-base)" }}>
+              {meta?.label ?? event}
+            </span>
+            <span style={{
+              padding: "1px 6px", borderRadius: "4px", fontSize: "10px", fontWeight: 600,
+              background: "var(--bg-elevated)", color: "var(--fg-subtle)",
+            }}>
+              {totalHooks} {totalHooks === 1 ? "hook" : "hooks"}
+            </span>
+          </div>
+          {meta?.description && (
+            <p style={{ margin: "2px 0 0", fontSize: "12px", color: "var(--fg-muted)", lineHeight: "1.4" }}>
+              {meta.description}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Matchers */}
+      <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+        {matchers.map((m, i) => <HookMatcherBlock key={i} matcher={m} />)}
+      </div>
+    </div>
+  );
+}
+
+// ── Formatted view ────────────────────────────────────────────
+
+function HooksFormattedView({ content }: { content: string }) {
+  const { hooks, parseError } = useMemo(() => {
+    try {
+      const parsed = JSON.parse(content);
+      const raw = parsed?.hooks ?? {};
+      return { hooks: raw as Record<string, HookMatcher[]>, parseError: null };
+    } catch (e) {
+      return { hooks: {}, parseError: String(e) };
+    }
+  }, [content]);
+
+  if (parseError) {
+    return (
+      <div style={{ padding: "20px 24px" }}>
+        <div style={{
+          background: "var(--bg-surface)", border: "1px solid var(--border-base)",
+          borderRadius: "8px", padding: "12px 16px", color: "var(--danger)", fontSize: "12px",
+        }}>
+          {parseError}
+        </div>
+      </div>
+    );
+  }
+
+  // Sort events by lifecycle order
+  const entries = Object.entries(hooks).sort(([a], [b]) => {
+    const ao = EVENT_META[a]?.order ?? 99;
+    const bo = EVENT_META[b]?.order ?? 99;
+    return ao - bo;
+  });
+
+  if (entries.length === 0) {
+    return (
+      <div style={{ padding: "32px 24px", textAlign: "center" }}>
+        <div style={{
+          background: "var(--bg-surface)", border: "1px solid var(--border-base)",
+          borderRadius: "10px", padding: "32px 24px", maxWidth: "480px", margin: "0 auto",
+        }}>
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"
+            style={{ color: "var(--fg-subtle)", margin: "0 auto 12px", display: "block" }}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M14.25 9.75L16.5 12l-2.25 2.25m-4.5 0L7.5 12l2.25-2.25M6 20.25h12A2.25 2.25 0 0020.25 18V6A2.25 2.25 0 0018 3.75H6A2.25 2.25 0 003.75 6v12A2.25 2.25 0 006 20.25z" />
+          </svg>
+          <p style={{ fontSize: "14px", fontWeight: 600, color: "var(--fg-base)", margin: "0 0 6px" }}>
+            No hooks configured
+          </p>
+          <p style={{ fontSize: "12px", color: "var(--fg-muted)", margin: 0, lineHeight: "1.5" }}>
+            Add a <code style={{ fontFamily: "ui-monospace, monospace" }}>hooks</code> key to <code style={{ fontFamily: "ui-monospace, monospace" }}>~/.claude/settings.json</code> to run scripts at key points in Claude's lifecycle.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const totalHooks = entries.reduce((n, [, matchers]) =>
+    n + matchers.reduce((m, matcher) => m + matcher.hooks.length, 0), 0);
+
+  return (
+    <div style={{ padding: "16px 24px", display: "flex", flexDirection: "column", gap: "10px" }}>
+      <div style={{ fontSize: "11px", color: "var(--fg-subtle)", marginBottom: "2px" }}>
+        {totalHooks} {totalHooks === 1 ? "hook" : "hooks"} across {entries.length} {entries.length === 1 ? "event" : "events"}
+      </div>
+      {entries.map(([event, matchers]) => (
+        <HookEventSection key={event} event={event} matchers={matchers} />
+      ))}
+    </div>
+  );
+}
+
+// ── Page ──────────────────────────────────────────────────────
+
+export default function HooksPage() {
+  const navigate = useNavigate();
+  const editor = useFileEditor(FILE_PATH);
+  const [viewMode, setViewMode] = useState<"formatted" | "editor">("formatted");
+
+  const toolbarActions = (
+    <button
+      onClick={() => navigate(`/harness/config/${encodeURIComponent("settings.json")}`)}
+      style={{
+        display: "flex", alignItems: "center", gap: "4px",
+        padding: "3px 8px", borderRadius: "5px",
+        border: "1px solid var(--border-base)",
+        background: "var(--bg-elevated)",
+        color: "var(--fg-subtle)", fontSize: "11px",
+        cursor: "pointer", whiteSpace: "nowrap", fontFamily: "inherit",
+      }}
+      title="Open settings.json in the editor"
+    >
+      <svg width="11" height="11" viewBox="0 0 20 20" fill="currentColor">
+        <path fillRule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4zm2 6a1 1 0 011-1h6a1 1 0 110 2H7a1 1 0 01-1-1zm1 3a1 1 0 100 2h6a1 1 0 100-2H7z" clipRule="evenodd" />
+      </svg>
+      settings.json
+    </button>
+  );
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", height: "100%", overflow: "hidden" }}>
       <EditorToolbar
-        filePath={FILE_PATH}
+        filePath="Hooks"
+        subtitle="~/.claude/settings.json"
         isDirty={editor.isDirty}
         saving={editor.saving}
-        viewMode="editor"
-        availableModes={VIEW_MODES}
-        onViewModeChange={() => {}}
-        onSave={editor.saveFile}
+        viewMode={viewMode}
+        availableModes={[
+          { key: "formatted", label: "Formatted" },
+          { key: "editor", label: "Editor" },
+        ]}
+        onViewModeChange={(m) => setViewMode(m as "formatted" | "editor")}
+        onSave={viewMode === "editor" ? editor.saveFile : undefined}
+        actions={toolbarActions}
       />
-      <div style={{ flex: 1, minHeight: 0, position: "relative" }}>
-        {editor.loading && (
-          <p style={{ padding: "20px 24px", fontSize: "13px", color: "var(--fg-subtle)" }}>
-            Loading…
-          </p>
-        )}
-        {editor.error && (
-          <p style={{ padding: "20px 24px", fontSize: "13px", color: "var(--danger)" }}>
-            {editor.error}
-          </p>
-        )}
-        {!editor.loading && !editor.error && editor.content !== null && (
+
+      {viewMode === "formatted" && (
+        <div style={{ flex: 1, overflow: "auto" }}>
+          {editor.loading && (
+            <div style={{ padding: "20px 24px", display: "flex", flexDirection: "column", gap: "10px" }}>
+              {[1, 2, 3].map((i) => (
+                <div key={i} style={{
+                  height: "90px", borderRadius: "10px",
+                  background: "var(--bg-elevated)",
+                  animation: "shimmer 1.5s ease-in-out infinite",
+                  animationDelay: `${i * 0.1}s`, opacity: 0.5,
+                }} />
+              ))}
+            </div>
+          )}
+          {editor.error && (
+            <div style={{ padding: "20px 24px" }}>
+              <div style={{
+                background: "var(--bg-surface)", border: "1px solid var(--border-base)",
+                borderRadius: "8px", padding: "12px 16px", color: "var(--danger)", fontSize: "12px",
+              }}>
+                {editor.error}
+              </div>
+            </div>
+          )}
+          {!editor.loading && !editor.error && editor.content !== null && (
+            <HooksFormattedView content={editor.content} />
+          )}
+        </div>
+      )}
+
+      {viewMode === "editor" && !editor.loading && editor.content !== null && (
+        <div style={{ flex: 1, minHeight: 0 }}>
           <Suspense fallback={null}>
             <MonacoEditor
               filePath={FILE_PATH}
@@ -41,8 +419,8 @@ export default function HooksPage() {
               onSave={editor.saveFile}
             />
           </Suspense>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/pages/harness/McpServersPage.tsx
+++ b/apps/desktop/src/pages/harness/McpServersPage.tsx
@@ -1,38 +1,372 @@
-import { Suspense, lazy } from "react";
+import { Suspense, lazy, useState, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
 import { useFileEditor } from "../../hooks/useFileEditor";
 import EditorToolbar from "../../components/file-explorer/EditorToolbar";
+import { type ClaudeMcpConfig, type ClaudeMcpServer, isNetworkServer, inferTransport } from "../../lib/mcp-types";
+import { lookupMcpServer, getAvatarColor, type McpServerMeta } from "../../lib/mcp-registry";
 
 const MonacoEditor = lazy(() => import("../../components/plugin-explorer/MonacoEditor"));
 
 const FILE_PATH = "~/.claude/mcp.json";
-const VIEW_MODES = [{ key: "editor", label: "Editor" }];
 
-export default function McpServersPage() {
-  const editor = useFileEditor(FILE_PATH);
+// ── Server icon ───────────────────────────────────────────────
+
+function ServerIcon({ meta, name }: { meta: McpServerMeta | null; name: string }) {
+  const [imgFailed, setImgFailed] = useState(false);
+  const bg = meta?.iconBg ?? getAvatarColor(name);
+  const letter = (meta?.displayName ?? name).charAt(0).toUpperCase();
+
+  if (meta?.iconSlug && !imgFailed) {
+    return (
+      <div style={{
+        width: "36px", height: "36px", borderRadius: "8px",
+        background: bg, flexShrink: 0,
+        display: "flex", alignItems: "center", justifyContent: "center",
+        overflow: "hidden",
+      }}>
+        <img
+          src={`https://cdn.simpleicons.org/${meta.iconSlug}/ffffff`}
+          alt={meta.displayName}
+          width={22}
+          height={22}
+          onError={() => setImgFailed(true)}
+          style={{ display: "block" }}
+        />
+      </div>
+    );
+  }
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+    <div style={{
+      width: "36px", height: "36px", borderRadius: "8px",
+      background: bg, flexShrink: 0,
+      display: "flex", alignItems: "center", justifyContent: "center",
+      fontSize: "15px", fontWeight: 700, color: "#fff",
+      letterSpacing: "-0.5px",
+    }}>
+      {letter}
+    </div>
+  );
+}
+
+// ── Transport badge ───────────────────────────────────────────
+
+function TransportBadge({ transport }: { transport: "stdio" | "sse" | "http" }) {
+  const colors: Record<string, { bg: string; text: string }> = {
+    stdio: { bg: "var(--bg-elevated)", text: "var(--fg-subtle)" },
+    sse:   { bg: "#7C3AED22", text: "#A78BFA" },
+    http:  { bg: "#2563EB22", text: "#60A5FA" },
+  };
+  const c = colors[transport] ?? colors.stdio;
+  return (
+    <span style={{
+      padding: "1px 6px", borderRadius: "4px", fontSize: "10px", fontWeight: 600,
+      textTransform: "uppercase", letterSpacing: "0.04em",
+      background: c.bg, color: c.text,
+    }}>
+      {transport}
+    </span>
+  );
+}
+
+// ── Link button ───────────────────────────────────────────────
+
+function ExternalLink({ href, children }: { href: string; children: React.ReactNode }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      style={{
+        display: "inline-flex", alignItems: "center", gap: "3px",
+        fontSize: "11px", color: "var(--accent)", textDecoration: "none",
+        padding: "2px 6px", borderRadius: "4px",
+        border: "1px solid var(--border-base)",
+        background: "var(--bg-elevated)",
+        transition: "opacity 0.1s",
+      }}
+      onMouseEnter={(e) => (e.currentTarget.style.opacity = "0.8")}
+      onMouseLeave={(e) => (e.currentTarget.style.opacity = "1")}
+    >
+      {children}
+      <svg width="9" height="9" viewBox="0 0 20 20" fill="currentColor" style={{ opacity: 0.6 }}>
+        <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z" />
+        <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z" />
+      </svg>
+    </a>
+  );
+}
+
+// ── Env var row ───────────────────────────────────────────────
+
+function EnvRow({ name, value }: { name: string; value: string }) {
+  const isTemplate = /^\$\{.+\}$/.test(value.trim());
+  const isLikelySecret = !isTemplate && value.length > 20 && /^[A-Za-z0-9_\-+/=]{20,}$/.test(value);
+  const display = isLikelySecret ? `${value.slice(0, 4)}${"•".repeat(8)}${value.slice(-4)}` : value;
+
+  return (
+    <div style={{ display: "flex", gap: "8px", alignItems: "baseline", minWidth: 0 }}>
+      <code style={{
+        fontSize: "11px", fontFamily: "ui-monospace, monospace",
+        color: "var(--fg-subtle)", flexShrink: 0, whiteSpace: "nowrap",
+      }}>
+        {name}
+      </code>
+      <span style={{ color: "var(--separator)", fontSize: "11px", flexShrink: 0 }}>=</span>
+      <code style={{
+        fontSize: "11px", fontFamily: "ui-monospace, monospace",
+        color: isTemplate ? "var(--accent)" : "var(--fg-muted)",
+        wordBreak: "break-all",
+      }}>
+        {display}
+      </code>
+    </div>
+  );
+}
+
+// ── Server card ───────────────────────────────────────────────
+
+function ServerCard({ name, config }: { name: string; config: ClaudeMcpServer }) {
+  const meta = lookupMcpServer(name, config);
+  const transport = inferTransport(config);
+  const isNetwork = isNetworkServer(config);
+  const displayName = meta?.displayName ?? name;
+
+  const commandStr = !isNetwork
+    ? [config.command, ...(config.args ?? [])].join(" ")
+    : null;
+
+  const env = !isNetwork && config.env ? Object.entries(config.env) : [];
+
+  return (
+    <div style={{
+      background: "var(--bg-surface)",
+      border: "1px solid var(--border-base)",
+      borderRadius: "10px",
+      padding: "14px 16px",
+      display: "flex",
+      flexDirection: "column",
+      gap: "10px",
+    }}>
+      {/* Header row */}
+      <div style={{ display: "flex", alignItems: "flex-start", gap: "12px" }}>
+        <ServerIcon meta={meta} name={name} />
+
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: "8px", flexWrap: "wrap" }}>
+            <span style={{ fontSize: "13px", fontWeight: 600, color: "var(--fg-base)" }}>
+              {displayName}
+            </span>
+            {meta?.displayName && meta.displayName !== name && (
+              <span style={{ fontSize: "11px", color: "var(--fg-subtle)", fontFamily: "ui-monospace, monospace" }}>
+                {name}
+              </span>
+            )}
+            <TransportBadge transport={transport} />
+          </div>
+
+          {meta?.description && (
+            <p style={{ margin: "3px 0 0", fontSize: "12px", color: "var(--fg-muted)", lineHeight: "1.4" }}>
+              {meta.description}
+            </p>
+          )}
+        </div>
+
+        {/* External links */}
+        <div style={{ display: "flex", gap: "4px", flexShrink: 0, flexWrap: "wrap", justifyContent: "flex-end" }}>
+          {meta?.homepageUrl && <ExternalLink href={meta.homepageUrl}>Homepage</ExternalLink>}
+          {meta?.docsUrl && <ExternalLink href={meta.docsUrl}>Docs</ExternalLink>}
+          {meta?.sourceUrl && meta.sourceUrl !== meta.docsUrl && (
+            <ExternalLink href={meta.sourceUrl}>Source</ExternalLink>
+          )}
+        </div>
+      </div>
+
+      {/* Command / URL */}
+      {commandStr && (
+        <div style={{
+          background: "var(--bg-elevated)",
+          borderRadius: "6px",
+          padding: "7px 10px",
+          fontFamily: "ui-monospace, monospace",
+          fontSize: "11px",
+          color: "var(--fg-muted)",
+          wordBreak: "break-all",
+          lineHeight: "1.6",
+        }}>
+          <span style={{ color: "var(--fg-subtle)", marginRight: "6px", userSelect: "none" }}>$</span>
+          {commandStr}
+        </div>
+      )}
+      {isNetwork && (
+        <div style={{
+          background: "var(--bg-elevated)",
+          borderRadius: "6px",
+          padding: "7px 10px",
+          display: "flex", alignItems: "center", gap: "8px",
+        }}>
+          <span style={{ fontSize: "10px", fontWeight: 600, color: "var(--fg-subtle)", textTransform: "uppercase", letterSpacing: "0.05em" }}>URL</span>
+          <code style={{ fontSize: "11px", color: "var(--accent)", wordBreak: "break-all" }}>
+            {(config as { url: string }).url}
+          </code>
+        </div>
+      )}
+
+      {/* Environment variables */}
+      {env.length > 0 && (
+        <div style={{
+          background: "var(--bg-elevated)",
+          borderRadius: "6px",
+          padding: "8px 10px",
+          display: "flex", flexDirection: "column", gap: "4px",
+        }}>
+          <span style={{ fontSize: "10px", fontWeight: 600, color: "var(--fg-subtle)", textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: "2px" }}>
+            Environment
+          </span>
+          {env.map(([k, v]) => <EnvRow key={k} name={k} value={v} />)}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Formatted view ────────────────────────────────────────────
+
+function McpFormattedView({ content }: { content: string }) {
+  const { servers, parseError } = useMemo(() => {
+    try {
+      const parsed: ClaudeMcpConfig = JSON.parse(content);
+      return { servers: parsed.mcpServers ?? {}, parseError: null };
+    } catch (e) {
+      return { servers: {}, parseError: String(e) };
+    }
+  }, [content]);
+
+  if (parseError) {
+    return (
+      <div style={{ padding: "20px 24px" }}>
+        <div style={{
+          background: "var(--bg-surface)", border: "1px solid var(--border-base)",
+          borderRadius: "8px", padding: "12px 16px", color: "var(--danger)", fontSize: "12px",
+        }}>
+          {parseError}
+        </div>
+      </div>
+    );
+  }
+
+  const entries = Object.entries(servers);
+
+  if (entries.length === 0) {
+    return (
+      <div style={{ padding: "32px 24px", textAlign: "center" }}>
+        <div style={{
+          background: "var(--bg-surface)", border: "1px solid var(--border-base)",
+          borderRadius: "10px", padding: "32px 24px", maxWidth: "480px", margin: "0 auto",
+        }}>
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"
+            style={{ color: "var(--fg-subtle)", margin: "0 auto 12px", display: "block" }}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M5.25 14.25h13.5m-13.5 0a3 3 0 01-3-3m3 3a3 3 0 100 6h13.5a3 3 0 100-6m-16.5-3a3 3 0 013-3h13.5a3 3 0 013 3m-19.5 0a4.5 4.5 0 01.9-2.7L5.737 5.1a3.375 3.375 0 012.7-1.35h7.126c1.062 0 2.062.5 2.7 1.35l2.587 3.45a4.5 4.5 0 01.9 2.7m0 0a3 3 0 01-3 3m0 3h.008v.008h-.008v-.008zm0-6h.008v.008h-.008v-.008zm-3 6h.008v.008h-.008v-.008zm0-6h.008v.008h-.008v-.008z" />
+          </svg>
+          <p style={{ fontSize: "14px", fontWeight: 600, color: "var(--fg-base)", margin: "0 0 6px" }}>
+            No MCP servers configured
+          </p>
+          <p style={{ fontSize: "12px", color: "var(--fg-muted)", margin: 0, lineHeight: "1.5" }}>
+            Add servers to <code style={{ fontFamily: "ui-monospace, monospace" }}>~/.claude/mcp.json</code> under the <code style={{ fontFamily: "ui-monospace, monospace" }}>mcpServers</code> key.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: "16px 24px", display: "flex", flexDirection: "column", gap: "10px" }}>
+      <div style={{ fontSize: "11px", color: "var(--fg-subtle)", marginBottom: "2px" }}>
+        {entries.length} server{entries.length !== 1 ? "s" : ""} configured
+      </div>
+      {entries.map(([name, config]) => (
+        <ServerCard key={name} name={name} config={config} />
+      ))}
+    </div>
+  );
+}
+
+// ── Page ──────────────────────────────────────────────────────
+
+export default function McpServersPage() {
+  const navigate = useNavigate();
+  const editor = useFileEditor(FILE_PATH);
+  const [viewMode, setViewMode] = useState<"formatted" | "editor">("formatted");
+
+  const toolbarActions = (
+    <button
+      onClick={() => navigate(`/harness/config/${encodeURIComponent("mcp.json")}`)}
+      style={{
+        display: "flex", alignItems: "center", gap: "4px",
+        padding: "3px 8px", borderRadius: "5px",
+        border: "1px solid var(--border-base)",
+        background: "var(--bg-elevated)",
+        color: "var(--fg-subtle)", fontSize: "11px",
+        cursor: "pointer", whiteSpace: "nowrap", fontFamily: "inherit",
+      }}
+      title="Open mcp.json in the editor"
+    >
+      <svg width="11" height="11" viewBox="0 0 20 20" fill="currentColor">
+        <path fillRule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4zm2 6a1 1 0 011-1h6a1 1 0 110 2H7a1 1 0 01-1-1zm1 3a1 1 0 100 2h6a1 1 0 100-2H7z" clipRule="evenodd" />
+      </svg>
+      mcp.json
+    </button>
+  );
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", height: "100%", overflow: "hidden" }}>
       <EditorToolbar
-        filePath={FILE_PATH}
+        filePath="MCP Servers"
+        subtitle="~/.claude/mcp.json"
         isDirty={editor.isDirty}
         saving={editor.saving}
-        viewMode="editor"
-        availableModes={VIEW_MODES}
-        onViewModeChange={() => {}}
-        onSave={editor.saveFile}
+        viewMode={viewMode}
+        availableModes={[
+          { key: "formatted", label: "Formatted" },
+          { key: "editor", label: "Editor" },
+        ]}
+        onViewModeChange={(m) => setViewMode(m as "formatted" | "editor")}
+        onSave={viewMode === "editor" ? editor.saveFile : undefined}
+        actions={toolbarActions}
       />
-      <div style={{ flex: 1, minHeight: 0, position: "relative" }}>
-        {editor.loading && (
-          <p style={{ padding: "20px 24px", fontSize: "13px", color: "var(--fg-subtle)" }}>
-            Loading…
-          </p>
-        )}
-        {editor.error && (
-          <p style={{ padding: "20px 24px", fontSize: "13px", color: "var(--danger)" }}>
-            {editor.error}
-          </p>
-        )}
-        {!editor.loading && !editor.error && editor.content !== null && (
+
+      {viewMode === "formatted" && (
+        <div style={{ flex: 1, overflow: "auto" }}>
+          {editor.loading && (
+            <div style={{ padding: "20px 24px", display: "flex", flexDirection: "column", gap: "10px" }}>
+              {[1, 2, 3].map((i) => (
+                <div key={i} style={{
+                  height: "100px", borderRadius: "10px",
+                  background: "var(--bg-elevated)",
+                  animation: "shimmer 1.5s ease-in-out infinite",
+                  animationDelay: `${i * 0.1}s`, opacity: 0.5,
+                }} />
+              ))}
+            </div>
+          )}
+          {editor.error && (
+            <div style={{ padding: "20px 24px" }}>
+              <div style={{
+                background: "var(--bg-surface)", border: "1px solid var(--border-base)",
+                borderRadius: "8px", padding: "12px 16px", color: "var(--danger)", fontSize: "12px",
+              }}>
+                {editor.error}
+              </div>
+            </div>
+          )}
+          {!editor.loading && !editor.error && editor.content !== null && (
+            <McpFormattedView content={editor.content} />
+          )}
+        </div>
+      )}
+
+      {viewMode === "editor" && !editor.loading && editor.content !== null && (
+        <div style={{ flex: 1, minHeight: 0 }}>
           <Suspense fallback={null}>
             <MonacoEditor
               filePath={FILE_PATH}
@@ -41,8 +375,8 @@ export default function McpServersPage() {
               onSave={editor.saveFile}
             />
           </Suspense>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/pages/harness/McpServersPage.tsx
+++ b/apps/desktop/src/pages/harness/McpServersPage.tsx
@@ -99,9 +99,14 @@ function ExternalLink({ href, children }: { href: string; children: React.ReactN
 
 // ── Env var row ───────────────────────────────────────────────
 
+const SECRET_KEY_RE = /key|token|secret|password|auth|credential/i;
+
 function EnvRow({ name, value }: { name: string; value: string }) {
   const isTemplate = /^\$\{.+\}$/.test(value.trim());
-  const isLikelySecret = !isTemplate && value.length > 20 && /^[A-Za-z0-9_\-+/=]{20,}$/.test(value);
+  const isLikelySecret = !isTemplate && (
+    SECRET_KEY_RE.test(name) ||
+    (value.length > 20 && /^[A-Za-z0-9_\-+/=]{20,}$/.test(value))
+  );
   const display = isLikelySecret ? `${value.slice(0, 4)}${"•".repeat(8)}${value.slice(-4)}` : value;
 
   return (

--- a/apps/desktop/src/pages/harness/PluginExplorerPage.tsx
+++ b/apps/desktop/src/pages/harness/PluginExplorerPage.tsx
@@ -1,0 +1,236 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { AnimatePresence, motion } from "framer-motion";
+import { listInstalledPlugins } from "../../lib/tauri";
+import type { InstalledPlugin } from "@harness-kit/shared";
+import { usePluginExplorer } from "../../hooks/usePluginExplorer";
+import { getAvailableViewModes, getDefaultViewMode } from "../../lib/viewModes";
+import type { FileEditorState } from "../../hooks/useFileEditor";
+import SplitPane from "../../components/file-explorer/SplitPane";
+import EditorPane from "../../components/file-explorer/EditorPane";
+import FileTree from "../../components/plugin-explorer/FileTree";
+import ExportMenu from "../../components/plugin-explorer/ExportMenu";
+import SaveConfirmPopover from "../../components/plugin-explorer/SaveConfirmPopover";
+import VersionHistoryPopover from "../../components/plugin-explorer/VersionHistoryPopover";
+
+export default function PluginExplorerPage() {
+  const { pluginName } = useParams<{ pluginName: string }>();
+  const navigate = useNavigate();
+  const [plugin, setPlugin] = useState<InstalledPlugin | null>(null);
+  const [loadingPlugin, setLoadingPlugin] = useState(true);
+  const [collapsed, setCollapsed] = useState(false);
+  const [viewMode, setViewMode] = useState("editor");
+
+  // Load the plugin by name
+  useEffect(() => {
+    if (!pluginName) return;
+    setLoadingPlugin(true);
+    listInstalledPlugins()
+      .then((plugins) => {
+        const found = plugins.find((p) => p.name === decodeURIComponent(pluginName));
+        setPlugin(found ?? null);
+      })
+      .catch(() => setPlugin(null))
+      .finally(() => setLoadingPlugin(false));
+  }, [pluginName]);
+
+  const explorer = usePluginExplorer(plugin, plugin !== null);
+
+  // Update view mode when file selection changes
+  useEffect(() => {
+    if (explorer.selectedPath) {
+      setViewMode(getDefaultViewMode(explorer.selectedPath));
+    }
+  }, [explorer.selectedPath]);
+
+  // Keyboard shortcuts
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key === "s") {
+        e.preventDefault();
+        explorer.requestSave();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [explorer]);
+
+  // Adapt usePluginExplorer to FileEditorState interface
+  const editorState: FileEditorState = useMemo(() => ({
+    content: explorer.fileContent,
+    originalContent: null,
+    loading: explorer.fileLoading,
+    saving: explorer.saving,
+    savedRecently: explorer.savedRecently,
+    error: explorer.error,
+    isDirty: explorer.dirty,
+    updateContent: explorer.updateContent,
+    saveFile: explorer.saveFile,
+    revertFile: explorer.revertFile,
+    reload: () => {},
+  }), [explorer]);
+
+  const availableModes = getAvailableViewModes(explorer.selectedPath);
+
+  // Toolbar actions: save/revert, version history, export
+  const toolbarActions = (
+    <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+      {/* Save confirm popover */}
+      <AnimatePresence mode="wait">
+        {explorer.confirmState !== "idle" ? (
+          <motion.div
+            key="confirm"
+            initial={{ opacity: 0, x: 8 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: 8 }}
+            transition={{ duration: 0.15 }}
+          >
+            <SaveConfirmPopover
+              variant={explorer.confirmState === "critical" ? "critical" : "inline"}
+              onConfirm={explorer.confirmSave}
+              onCancel={explorer.cancelSave}
+            />
+          </motion.div>
+        ) : explorer.savedRecently ? (
+          <motion.span
+            key="saved-indicator"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            style={{ fontSize: "11px", color: "var(--success, #22c55e)", fontWeight: 500 }}
+          >
+            Saved
+          </motion.span>
+        ) : null}
+      </AnimatePresence>
+
+      <VersionHistoryPopover
+        entries={explorer.historyEntries}
+        loading={explorer.historyLoading}
+        onRestore={explorer.restoreVersion}
+      />
+
+      <ExportMenu
+        onExportZip={explorer.exportAsZip}
+        onExportFolder={explorer.exportToFolder}
+      />
+    </div>
+  );
+
+  // ── Left panel ──────────────────────────────────────────────
+
+  const leftPanel = (
+    <div style={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0, overflow: "hidden" }}>
+      {/* Back link */}
+      <button
+        onClick={() => navigate("/harness/plugins")}
+        style={{
+          display: "flex", alignItems: "center", gap: "4px",
+          padding: "8px 12px 4px",
+          background: "none", border: "none", cursor: "pointer",
+          fontSize: "11px", color: "var(--fg-subtle)",
+          textAlign: "left",
+        }}
+      >
+        <svg width="10" height="10" viewBox="0 0 20 20" fill="currentColor">
+          <path fillRule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clipRule="evenodd" />
+        </svg>
+        Installed Plugins
+      </button>
+
+      {/* Plugin metadata */}
+      {plugin && (
+        <div style={{ padding: "6px 12px 10px", borderBottom: "1px solid var(--border-subtle)" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: "6px", flexWrap: "wrap" }}>
+            <span style={{ fontSize: "13px", fontWeight: 600, color: "var(--fg-base)" }}>
+              {plugin.name}
+            </span>
+            <span style={{
+              fontSize: "10px", fontFamily: "ui-monospace, monospace",
+              padding: "1px 5px", borderRadius: "4px",
+              background: "var(--bg-elevated)", color: "var(--fg-subtle)",
+              border: "1px solid var(--border-subtle)",
+            }}>
+              {plugin.version}
+            </span>
+          </div>
+          {plugin.category && (
+            <span style={{
+              fontSize: "10px", fontWeight: 500, color: "var(--fg-muted)",
+              display: "inline-block", marginTop: "2px",
+            }}>
+              {plugin.category}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* File tree */}
+      {explorer.tree && (
+        <FileTree
+          tree={explorer.tree}
+          selectedPath={explorer.selectedPath}
+          onSelectFile={explorer.selectFile}
+        />
+      )}
+    </div>
+  );
+
+  // ── Loading / not found states ──────────────────────────────
+
+  if (loadingPlugin) {
+    return (
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "center", height: "100%", color: "var(--fg-subtle)", fontSize: "13px" }}>
+        Loading plugin...
+      </div>
+    );
+  }
+
+  if (!plugin) {
+    return (
+      <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", height: "100%", gap: "8px" }}>
+        <p style={{ fontSize: "13px", color: "var(--fg-muted)" }}>
+          Plugin "{pluginName}" not found.
+        </p>
+        <button
+          onClick={() => navigate("/harness/plugins")}
+          style={{
+            fontSize: "12px", color: "var(--accent-text)", background: "none",
+            border: "none", cursor: "pointer", textDecoration: "underline",
+          }}
+        >
+          Back to Installed Plugins
+        </button>
+      </div>
+    );
+  }
+
+  if (explorer.loading) {
+    return (
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "center", height: "100%", color: "var(--fg-subtle)", fontSize: "13px" }}>
+        Loading plugin files...
+      </div>
+    );
+  }
+
+  // ── Main layout ─────────────────────────────────────────────
+
+  return (
+    <SplitPane
+      left={leftPanel}
+      right={
+        <EditorPane
+          filePath={explorer.selectedPath}
+          editor={editorState}
+          viewMode={viewMode}
+          availableModes={availableModes}
+          onViewModeChange={setViewMode}
+          toolbarActions={toolbarActions}
+        />
+      }
+      collapsed={collapsed}
+      onToggleCollapsed={() => setCollapsed((c) => !c)}
+    />
+  );
+}

--- a/apps/desktop/src/pages/harness/PluginsPage.tsx
+++ b/apps/desktop/src/pages/harness/PluginsPage.tsx
@@ -13,7 +13,6 @@ import PluginRow from "./plugins/PluginRow";
 import ImportOverlay from "./plugins/ImportOverlay";
 import ImportBanner, { type ImportStatus } from "./plugins/ImportBanner";
 import UninstallDialog from "./plugins/UninstallDialog";
-import PluginExplorerModal from "../../components/plugin-explorer/PluginExplorerModal";
 import { useChat } from "../../context/ChatContext";
 import { emitChatShare } from "../../lib/chat-events";
 
@@ -36,9 +35,6 @@ export default function PluginsPage() {
 
   // Uninstall state
   const [uninstallTarget, setUninstallTarget] = useState<InstalledPlugin | null>(null);
-
-  // Explorer modal
-  const [explorerPlugin, setExplorerPlugin] = useState<InstalledPlugin | null>(null);
 
   const loadPlugins = useCallback(() => {
     listInstalledPlugins()
@@ -342,7 +338,7 @@ export default function PluginsPage() {
                   update={updates[plugin.name]}
                   index={i}
                   isLast={i === filtered.length - 1}
-                  onClick={() => setExplorerPlugin(plugin)}
+                  onClick={() => navigate(`/harness/plugins/${encodeURIComponent(plugin.name)}`)}
                   onContextMenu={(e) => {
                     setContextMenu({ x: e.clientX, y: e.clientY, plugin });
                   }}
@@ -383,11 +379,6 @@ export default function PluginsPage() {
         onClose={() => setUninstallTarget(null)}
       />
 
-      {/* Plugin Explorer Modal */}
-      <PluginExplorerModal
-        plugin={explorerPlugin}
-        onClose={() => setExplorerPlugin(null)}
-      />
     </div>
   );
 }

--- a/apps/desktop/src/pages/harness/SettingsPage.tsx
+++ b/apps/desktop/src/pages/harness/SettingsPage.tsx
@@ -1,265 +1,57 @@
-import { Suspense, lazy, useCallback, useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
-import { listClaudeDir } from "../../lib/tauri";
+import { useCallback, useEffect, useState } from "react";
+import { useClaudeFileList } from "../../hooks/useClaudeFileList";
 import { useFileEditor } from "../../hooks/useFileEditor";
+import { getAvailableViewModes, getDefaultViewMode } from "../../lib/viewModes";
 import SplitPane from "../../components/file-explorer/SplitPane";
-import EditorToolbar from "../../components/file-explorer/EditorToolbar";
-import {
-  getConfigFilesDetailLevel,
-  type ConfigFilesDetailLevel,
-} from "../../lib/preferences";
-
-const MonacoEditor = lazy(() => import("../../components/plugin-explorer/MonacoEditor"));
-const MarkdownPanel = lazy(() => import("../../components/MarkdownPanel"));
-
-// ── File filtering ────────────────────────────────────────────
-
-const TEXT_EXTENSIONS = new Set([".md", ".json", ".yaml", ".yml", ".sh", ".txt", ".toml", ".mjs"]);
-const HIDDEN_PATTERNS: RegExp[] = [
-  /^security_warnings_state_/,
-  /^statsig-/,
-  /^stats-cache\.json$/,
-];
-const ESSENTIALS = new Set(["CLAUDE.md", "AGENT.md", "SOUL.md", "settings.json", "keybindings.json"]);
-
-function extOf(name: string): string {
-  const idx = name.lastIndexOf(".");
-  return idx === -1 ? "" : name.slice(idx);
-}
-
-function filterFiles(files: string[], level: ConfigFilesDetailLevel): string[] {
-  if (level === "essentials") return files.filter((f) => ESSENTIALS.has(f));
-  if (level === "text-files") return files.filter(
-    (f) => TEXT_EXTENSIONS.has(extOf(f)) && !HIDDEN_PATTERNS.some((p) => p.test(f))
-  );
-  return files;
-}
-
-// ── Component ─────────────────────────────────────────────────
+import ClaudeFileListPanel from "../../components/file-explorer/ClaudeFileListPanel";
+import EditorPane from "../../components/file-explorer/EditorPane";
 
 export default function SettingsPage() {
-  const navigate = useNavigate();
-  const detailLevel = getConfigFilesDetailLevel();
-
-  const [allFiles, setAllFiles] = useState<string[]>([]);
-  const [loadingList, setLoadingList] = useState(true);
-  const [listError, setListError] = useState<string | null>(null);
+  const fileList = useClaudeFileList();
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
   const [collapsed, setCollapsed] = useState(false);
-  const [pendingFile, setPendingFile] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState("editor");
 
-  const files = filterFiles(allFiles, detailLevel);
   const filePath = selectedFile ? `~/.claude/${selectedFile}` : null;
   const editor = useFileEditor(filePath);
 
-  // Auto-select first file and set view mode on initial load
+  // Auto-select first file on initial load
   useEffect(() => {
-    listClaudeDir()
-      .then((entries) => {
-        setAllFiles(entries);
-        const filtered = filterFiles(entries, detailLevel);
-        if (filtered.length > 0) {
-          setSelectedFile(filtered[0]);
-          setViewMode(extOf(filtered[0]) === ".md" ? "preview" : "editor");
-        }
-      })
-      .catch((e) => setListError(String(e)))
-      .finally(() => setLoadingList(false));
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    if (!fileList.loading && fileList.files.length > 0 && selectedFile === null) {
+      const first = fileList.files[0];
+      setSelectedFile(first);
+      setViewMode(getDefaultViewMode(`~/.claude/${first}`));
+    }
+  }, [fileList.loading, fileList.files, selectedFile]);
 
   const handleSelectFile = useCallback((name: string) => {
-    if (name === selectedFile) return;
-    if (editor.isDirty) {
-      setPendingFile(name);
-    } else {
-      setSelectedFile(name);
-      setViewMode(extOf(name) === ".md" ? "preview" : "editor");
-    }
-  }, [selectedFile, editor.isDirty]);
+    setSelectedFile(name);
+    setViewMode(getDefaultViewMode(`~/.claude/${name}`));
+  }, []);
 
-  const handleConfirmDiscard = useCallback(() => {
-    if (!pendingFile) return;
-    setSelectedFile(pendingFile);
-    setViewMode(extOf(pendingFile) === ".md" ? "preview" : "editor");
-    setPendingFile(null);
-  }, [pendingFile]);
-
-  const viewModes = extOf(selectedFile ?? "") === ".md"
-    ? [{ key: "editor", label: "Editor" }, { key: "preview", label: "Preview" }]
-    : [{ key: "editor", label: "Editor" }];
-
-  // ── Left panel ───────────────────────────────────────────────
-  const leftPanel = (
-    <div style={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0, overflow: "hidden" }}>
-      <div style={{
-        padding: "10px 12px 6px",
-        fontSize: "10px",
-        fontWeight: 600,
-        textTransform: "uppercase",
-        letterSpacing: "0.05em",
-        color: "var(--fg-subtle)",
-        flexShrink: 0,
-      }}>
-        Config Files
-      </div>
-
-      {pendingFile && (
-        <div style={{
-          margin: "0 8px 6px",
-          padding: "8px 10px",
-          background: "var(--bg-surface)",
-          border: "1px solid var(--border-base)",
-          borderRadius: "6px",
-          fontSize: "11px",
-          color: "var(--fg-base)",
-          flexShrink: 0,
-        }}>
-          <div style={{ marginBottom: "6px" }}>
-            Unsaved changes in{" "}
-            <code style={{ fontFamily: "ui-monospace, monospace" }}>{selectedFile}</code>.
-            Discard and switch?
-          </div>
-          <div style={{ display: "flex", gap: "6px" }}>
-            <button
-              onClick={handleConfirmDiscard}
-              style={{
-                fontSize: "11px", padding: "2px 8px", borderRadius: "4px",
-                border: "1px solid var(--border-base)",
-                background: "var(--danger-light)", color: "var(--danger)", cursor: "pointer",
-              }}
-            >
-              Discard
-            </button>
-            <button
-              onClick={() => setPendingFile(null)}
-              style={{
-                fontSize: "11px", padding: "2px 8px", borderRadius: "4px",
-                border: "1px solid var(--border-base)",
-                background: "transparent", color: "var(--fg-muted)", cursor: "pointer",
-              }}
-            >
-              Cancel
-            </button>
-          </div>
-        </div>
-      )}
-
-      <div style={{ flex: 1, overflow: "auto" }}>
-        {loadingList && (
-          <p style={{ fontSize: "12px", color: "var(--fg-subtle)", padding: "8px 12px", margin: 0 }}>
-            Loading…
-          </p>
-        )}
-        {listError && (
-          <p style={{ fontSize: "12px", color: "var(--danger)", padding: "8px 12px", margin: 0 }}>
-            {listError}
-          </p>
-        )}
-        {!loadingList && !listError && files.length === 0 && (
-          <div style={{ padding: "8px 12px", fontSize: "12px", color: "var(--fg-subtle)" }}>
-            No files found.{" "}
-            <button
-              onClick={() => navigate("/preferences")}
-              style={{
-                background: "none", border: "none", padding: 0, cursor: "pointer",
-                color: "var(--accent-text)", fontSize: "12px", textDecoration: "underline",
-              }}
-            >
-              Change detail level in Preferences
-            </button>
-          </div>
-        )}
-        {files.map((name) => (
-          <button
-            key={name}
-            onClick={() => handleSelectFile(name)}
-            style={{
-              display: "block",
-              width: "100%",
-              textAlign: "left",
-              padding: "6px 12px",
-              background: selectedFile === name ? "var(--bg-elevated)" : "transparent",
-              border: "none",
-              borderLeft: selectedFile === name ? "2px solid var(--accent)" : "2px solid transparent",
-              cursor: "pointer",
-              fontSize: "12px",
-              fontFamily: "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace",
-              color: selectedFile === name ? "var(--fg-base)" : "var(--fg-muted)",
-              whiteSpace: "nowrap",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-            }}
-          >
-            {name}
-          </button>
-        ))}
-      </div>
-    </div>
-  );
-
-  // ── Right panel ──────────────────────────────────────────────
-  const rightPanel = (
-    <div style={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0 }}>
-      <EditorToolbar
-        filePath={filePath}
-        isDirty={editor.isDirty}
-        saving={editor.saving}
-        viewMode={viewMode}
-        availableModes={viewModes}
-        onViewModeChange={setViewMode}
-        onSave={filePath ? editor.saveFile : undefined}
-      />
-      <div style={{ flex: 1, minHeight: 0, position: "relative" }}>
-        {!selectedFile && (
-          <div style={{ padding: "20px 24px", fontSize: "13px", color: "var(--fg-subtle)" }}>
-            Select a file to edit
-          </div>
-        )}
-        {selectedFile && editor.loading && (
-          <div style={{ padding: "20px 24px", fontSize: "13px", color: "var(--fg-subtle)" }}>
-            Loading…
-          </div>
-        )}
-        {selectedFile && editor.error && (
-          <div style={{ padding: "20px 24px" }}>
-            <div style={{ fontSize: "13px", color: "var(--danger)", marginBottom: "8px" }}>
-              {editor.error}
-            </div>
-            <button
-              onClick={editor.reload}
-              style={{
-                fontSize: "12px", color: "var(--accent-text)", background: "none",
-                border: "none", padding: 0, cursor: "pointer", textDecoration: "underline",
-              }}
-            >
-              Reload
-            </button>
-          </div>
-        )}
-        {selectedFile && !editor.loading && !editor.error && editor.content !== null && viewMode === "preview" && (
-          <Suspense fallback={null}>
-            <MarkdownPanel content={editor.content} defaultView="preview" fill />
-          </Suspense>
-        )}
-        {selectedFile && !editor.loading && !editor.error && editor.content !== null && viewMode !== "preview" && (
-          <Suspense fallback={null}>
-            <MonacoEditor
-              filePath={`~/.claude/${selectedFile}`}
-              content={editor.content}
-              onChange={editor.updateContent}
-              onSave={editor.saveFile}
-            />
-          </Suspense>
-        )}
-      </div>
-    </div>
-  );
+  const availableModes = getAvailableViewModes(filePath);
 
   return (
     <SplitPane
-      left={leftPanel}
-      right={rightPanel}
+      left={
+        <ClaudeFileListPanel
+          files={fileList.files}
+          loading={fileList.loading}
+          error={fileList.error}
+          selectedFile={selectedFile}
+          onSelectFile={handleSelectFile}
+          isDirty={editor.isDirty}
+        />
+      }
+      right={
+        <EditorPane
+          filePath={filePath}
+          editor={editor}
+          viewMode={viewMode}
+          availableModes={availableModes}
+          onViewModeChange={setViewMode}
+        />
+      }
       collapsed={collapsed}
       onToggleCollapsed={() => setCollapsed((c) => !c)}
     />

--- a/apps/desktop/src/pages/harness/__tests__/ClaudeMdPage.test.tsx
+++ b/apps/desktop/src/pages/harness/__tests__/ClaudeMdPage.test.tsx
@@ -10,6 +10,10 @@ vi.mock("../../../lib/tauri", () => ({
   writeConfigFile: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("../../../lib/preferences", () => ({
+  getMarkdownFont: vi.fn(() => "sans"),
+}));
+
 vi.mock("../../../components/plugin-explorer/MonacoEditor", () => ({
   default: ({ content }: { content: string }) => (
     <div data-testid="monaco-editor">{content}</div>
@@ -29,17 +33,10 @@ function renderPage() {
 describe("ClaudeMdPage", () => {
   beforeEach(() => { vi.clearAllMocks(); });
 
-  it("shows loading state initially", () => {
-    mockReadClaudeMd.mockReturnValue(new Promise(() => {}));
-    renderPage();
-    expect(screen.getByText(/Loading/i)).toBeInTheDocument();
-  });
-
   it("shows file content after loading", async () => {
     mockReadClaudeMd.mockResolvedValue("# Hello");
     renderPage();
     await waitFor(() => {
-      // Monaco or MarkdownPanel should render with the content
       const editor = screen.queryByTestId("monaco-editor") ?? screen.queryByTestId("markdown-panel");
       expect(editor).not.toBeNull();
     });

--- a/apps/desktop/src/pages/harness/__tests__/HarnessFilePage.test.tsx
+++ b/apps/desktop/src/pages/harness/__tests__/HarnessFilePage.test.tsx
@@ -38,7 +38,6 @@ describe("HarnessFilePage", () => {
   });
 
   it("shows loading state initially", () => {
-    // Promise that never resolves — keeps loading state indefinitely
     mockReadHarnessFile.mockReturnValue(new Promise(() => {}));
     renderPage();
     expect(screen.getByText(/Loading/)).toBeInTheDocument();
@@ -50,7 +49,6 @@ describe("HarnessFilePage", () => {
     await waitFor(() => {
       expect(screen.getByText(/No harness\.yaml found/i)).toBeInTheDocument();
     });
-    // Loading indicator should be gone
     expect(screen.queryByText(/Loading/)).toBeNull();
   });
 
@@ -62,7 +60,7 @@ describe("HarnessFilePage", () => {
     });
     renderPage();
     await waitFor(() => {
-      // The file path is rendered in a <code> element in the header
+      // The file path now appears in the EditorToolbar subtitle
       expect(screen.getByText("~/.claude/harness.yaml")).toBeInTheDocument();
     });
   });

--- a/apps/desktop/src/pages/harness/__tests__/HooksPage.test.tsx
+++ b/apps/desktop/src/pages/harness/__tests__/HooksPage.test.tsx
@@ -10,6 +10,10 @@ vi.mock("../../../lib/tauri", () => ({
   writeConfigFile: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("../../../lib/preferences", () => ({
+  getMarkdownFont: vi.fn(() => "sans"),
+}));
+
 vi.mock("../../../components/plugin-explorer/MonacoEditor", () => ({
   default: ({ content }: { content: string }) => (
     <div data-testid="monaco-editor">{content}</div>
@@ -23,17 +27,11 @@ function renderPage() {
 describe("HooksPage", () => {
   beforeEach(() => { vi.clearAllMocks(); });
 
-  it("shows loading state initially", () => {
-    mockReadClaudeMd.mockReturnValue(new Promise(() => {}));
-    renderPage();
-    expect(screen.getByText(/Loading/i)).toBeInTheDocument();
-  });
-
-  it("shows editor with settings.json content after loading", async () => {
+  it("shows formatted view with settings.json content after loading", async () => {
     mockReadClaudeMd.mockResolvedValue('{"hooks": {}}');
     renderPage();
     await waitFor(() => {
-      expect(screen.getByTestId("monaco-editor")).toBeInTheDocument();
+      expect(screen.getByText(/no hooks configured/i)).toBeInTheDocument();
     });
   });
 

--- a/apps/desktop/src/pages/harness/__tests__/McpServersPage.test.tsx
+++ b/apps/desktop/src/pages/harness/__tests__/McpServersPage.test.tsx
@@ -10,6 +10,10 @@ vi.mock("../../../lib/tauri", () => ({
   writeConfigFile: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("../../../lib/preferences", () => ({
+  getMarkdownFont: vi.fn(() => "sans"),
+}));
+
 vi.mock("../../../components/plugin-explorer/MonacoEditor", () => ({
   default: ({ content }: { content: string }) => (
     <div data-testid="monaco-editor">{content}</div>
@@ -26,14 +30,15 @@ describe("McpServersPage", () => {
   it("shows loading state initially", () => {
     mockReadClaudeMd.mockReturnValue(new Promise(() => {}));
     renderPage();
-    expect(screen.getByText(/Loading/i)).toBeInTheDocument();
+    // Toolbar renders the filename immediately; editor content is still loading
+    expect(screen.getByText("mcp.json")).toBeInTheDocument();
   });
 
-  it("shows editor with mcp.json content after loading", async () => {
+  it("shows formatted view with mcp.json content after loading", async () => {
     mockReadClaudeMd.mockResolvedValue('{"mcpServers": {}}');
     renderPage();
     await waitFor(() => {
-      expect(screen.getByTestId("monaco-editor")).toBeInTheDocument();
+      expect(screen.getByText(/no mcp servers configured/i)).toBeInTheDocument();
     });
   });
 

--- a/apps/desktop/src/pages/harness/harness-file/PermissionsSection.tsx
+++ b/apps/desktop/src/pages/harness/harness-file/PermissionsSection.tsx
@@ -6,50 +6,107 @@ interface PermissionsSectionProps {
   permissions: HarnessPermissions;
 }
 
-const subLabelStyle: CSSProperties = {
+// ── Tool categorization ──────────────────────────────────────
+
+const TOOL_CATEGORIES: Array<{ label: string; pattern: RegExp }> = [
+  { label: "File System", pattern: /^(Read|Write|Edit|Glob|Grep|NotebookEdit)$/i },
+  { label: "Shell", pattern: /^(Bash|Terminal)$/i },
+  { label: "MCP", pattern: /^mcp__/i },
+  { label: "Agent & Tasks", pattern: /^(Agent|Task|TodoRead|TodoWrite|SendMessage|TeamCreate|TeamDelete)$/i },
+  { label: "Browser & Web", pattern: /^(WebFetch|WebSearch|Browser)$/i },
+  { label: "LSP & Dev", pattern: /^(LSP|EnterPlanMode|ExitPlanMode|EnterWorktree|ExitWorktree)$/i },
+];
+
+interface ToolGroup {
+  label: string;
+  tools: string[];
+}
+
+function categorizeTools(tools: string[]): ToolGroup[] {
+  const grouped = new Map<string, string[]>();
+  const uncategorized: string[] = [];
+
+  for (const tool of tools) {
+    let matched = false;
+    for (const cat of TOOL_CATEGORIES) {
+      if (cat.pattern.test(tool)) {
+        const existing = grouped.get(cat.label) ?? [];
+        existing.push(tool);
+        grouped.set(cat.label, existing);
+        matched = true;
+        break;
+      }
+    }
+    if (!matched) uncategorized.push(tool);
+  }
+
+  const result: ToolGroup[] = [];
+  for (const cat of TOOL_CATEGORIES) {
+    const items = grouped.get(cat.label);
+    if (items && items.length > 0) result.push({ label: cat.label, tools: items });
+  }
+  if (uncategorized.length > 0) result.push({ label: "Other", tools: uncategorized });
+  return result;
+}
+
+// ── Styles ───────────────────────────────────────────────────
+
+const sectionLabelStyle: CSSProperties = {
   fontSize: "10px",
   fontWeight: 600,
   letterSpacing: "0.06em",
   textTransform: "uppercase",
   color: "var(--fg-subtle)",
-  marginBottom: "6px",
-  marginTop: "12px",
+  marginBottom: "8px",
 };
 
-const firstSubLabelStyle: CSSProperties = {
-  ...subLabelStyle,
+const firstSectionLabelStyle: CSSProperties = {
+  ...sectionLabelStyle,
   marginTop: 0,
 };
 
-const allowBadgeStyle: CSSProperties = {
+const laterSectionLabelStyle: CSSProperties = {
+  ...sectionLabelStyle,
+  marginTop: "14px",
+};
+
+const categoryLabelStyle: CSSProperties = {
+  fontSize: "10px",
+  fontWeight: 500,
+  color: "var(--fg-muted)",
+  marginBottom: "4px",
+  paddingLeft: "2px",
+};
+
+const toolItemStyle: CSSProperties = {
   fontSize: "11px",
-  padding: "1px 8px",
-  borderRadius: "10px",
-  background: "rgba(40,167,69,0.12)",
+  fontFamily: "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace",
+  padding: "2px 8px",
+  borderRadius: "4px",
+  display: "inline-block",
+  marginRight: "4px",
+  marginBottom: "3px",
+};
+
+const allowToolStyle: CSSProperties = {
+  ...toolItemStyle,
+  background: "rgba(40,167,69,0.10)",
   color: "#28a745",
+  border: "1px solid rgba(40,167,69,0.2)",
 };
 
-const denyBadgeStyle: CSSProperties = {
-  fontSize: "11px",
-  padding: "1px 8px",
-  borderRadius: "10px",
-  background: "rgba(220,53,69,0.12)",
+const denyToolStyle: CSSProperties = {
+  ...toolItemStyle,
+  background: "rgba(220,53,69,0.10)",
   color: "var(--danger)",
+  border: "1px solid rgba(220,53,69,0.2)",
 };
 
-const askBadgeStyle: CSSProperties = {
-  fontSize: "11px",
-  padding: "1px 8px",
-  borderRadius: "10px",
-  background: "rgba(255,193,7,0.15)",
+const askToolStyle: CSSProperties = {
+  ...toolItemStyle,
+  background: "rgba(255,193,7,0.10)",
   color: "#856404",
-};
-
-const pillRowStyle: CSSProperties = {
-  display: "flex",
-  flexWrap: "wrap",
-  gap: "4px",
-  marginBottom: "8px",
+  border: "1px solid rgba(255,193,7,0.2)",
 };
 
 const monoPathStyle: CSSProperties = {
@@ -60,16 +117,36 @@ const monoPathStyle: CSSProperties = {
   padding: "1px 0",
 };
 
+// ── Sub-components ───────────────────────────────────────────
+
+function ToolGroupDisplay({ groups, badgeStyle }: { groups: ToolGroup[]; badgeStyle: CSSProperties }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
+      {groups.map((group) => (
+        <div key={group.label}>
+          <div style={categoryLabelStyle}>{group.label}</div>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: "2px" }}>
+            {group.tools.map((t) => (
+              <span key={t} style={badgeStyle}>{t}</span>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Component ────────────────────────────────────────────────
+
 export default function PermissionsSection({ permissions }: PermissionsSectionProps) {
   const { tools, paths, network } = permissions;
   const hasTools = tools && (tools.allow?.length || tools.deny?.length || tools.ask?.length);
   const hasPaths = paths && (paths.writable?.length || paths.readonly?.length);
   const hasNetwork = network?.["allowed-hosts"]?.length;
 
-  // Determine which sub-section renders first so we can zero its top margin.
   const firstSection = hasTools ? "tools" : hasPaths ? "paths" : "network";
   const labelStyle = (section: string): CSSProperties =>
-    section === firstSection ? firstSubLabelStyle : subLabelStyle;
+    section === firstSection ? firstSectionLabelStyle : laterSectionLabelStyle;
 
   return (
     <SectionCard
@@ -79,25 +156,61 @@ export default function PermissionsSection({ permissions }: PermissionsSectionPr
       {hasTools && (
         <div>
           <div style={labelStyle("tools")}>Tools</div>
+
           {tools?.allow && tools.allow.length > 0 && (
-            <div style={pillRowStyle}>
-              {tools.allow.map((t) => (
-                <span key={t} style={allowBadgeStyle}>{t}</span>
-              ))}
+            <div style={{ marginBottom: "10px" }}>
+              <div style={{
+                fontSize: "10px", fontWeight: 600, color: "#28a745",
+                marginBottom: "6px", display: "flex", alignItems: "center", gap: "4px",
+              }}>
+                <span style={{
+                  width: "6px", height: "6px", borderRadius: "50%",
+                  background: "#28a745", display: "inline-block",
+                }} />
+                Allow ({tools.allow.length})
+              </div>
+              <ToolGroupDisplay
+                groups={categorizeTools(tools.allow)}
+                badgeStyle={allowToolStyle}
+              />
             </div>
           )}
+
           {tools?.deny && tools.deny.length > 0 && (
-            <div style={pillRowStyle}>
-              {tools.deny.map((t) => (
-                <span key={t} style={denyBadgeStyle}>{t}</span>
-              ))}
+            <div style={{ marginBottom: "10px" }}>
+              <div style={{
+                fontSize: "10px", fontWeight: 600, color: "var(--danger)",
+                marginBottom: "6px", display: "flex", alignItems: "center", gap: "4px",
+              }}>
+                <span style={{
+                  width: "6px", height: "6px", borderRadius: "50%",
+                  background: "var(--danger)", display: "inline-block",
+                }} />
+                Deny ({tools.deny.length})
+              </div>
+              <ToolGroupDisplay
+                groups={categorizeTools(tools.deny)}
+                badgeStyle={denyToolStyle}
+              />
             </div>
           )}
+
           {tools?.ask && tools.ask.length > 0 && (
-            <div style={pillRowStyle}>
-              {tools.ask.map((t) => (
-                <span key={t} style={askBadgeStyle}>{t}</span>
-              ))}
+            <div style={{ marginBottom: "10px" }}>
+              <div style={{
+                fontSize: "10px", fontWeight: 600, color: "#856404",
+                marginBottom: "6px", display: "flex", alignItems: "center", gap: "4px",
+              }}>
+                <span style={{
+                  width: "6px", height: "6px", borderRadius: "50%",
+                  background: "#d4a017", display: "inline-block",
+                }} />
+                Ask ({tools.ask.length})
+              </div>
+              <ToolGroupDisplay
+                groups={categorizeTools(tools.ask)}
+                badgeStyle={askToolStyle}
+              />
             </div>
           )}
         </div>
@@ -108,6 +221,7 @@ export default function PermissionsSection({ permissions }: PermissionsSectionPr
           <div style={labelStyle("paths")}>Paths</div>
           {paths?.writable && paths.writable.length > 0 && (
             <div style={{ marginBottom: "6px" }}>
+              <div style={{ ...categoryLabelStyle, color: "#28a745" }}>Writable</div>
               {paths.writable.map((p) => (
                 <code key={p} style={{ ...monoPathStyle, color: "#28a745" }}>{p}</code>
               ))}
@@ -115,6 +229,7 @@ export default function PermissionsSection({ permissions }: PermissionsSectionPr
           )}
           {paths?.readonly && paths.readonly.length > 0 && (
             <div style={{ marginBottom: "6px" }}>
+              <div style={categoryLabelStyle}>Read-only</div>
               {paths.readonly.map((p) => (
                 <code key={p} style={monoPathStyle}>{p}</code>
               ))}
@@ -126,6 +241,7 @@ export default function PermissionsSection({ permissions }: PermissionsSectionPr
       {hasNetwork && (
         <div>
           <div style={labelStyle("network")}>Network</div>
+          <div style={categoryLabelStyle}>Allowed Hosts</div>
           {network?.["allowed-hosts"]?.map((host) => (
             <code key={host} style={monoPathStyle}>{host}</code>
           ))}


### PR DESCRIPTION
## Summary

Standardizes all Harness section pages in the desktop app around a shared `EditorPane` component and consistent view-mode switcher. MCP Servers and Hooks now have rich formatted views with icons, logos, and structured metadata instead of raw-editor-only pages. All markdown files get a unified Formatted / Editor / Split toggle matching the harness.yaml treatment.

## Changes

- **`EditorPane`** — new shared component: toolbar + view-mode switcher (Formatted/Editor/Split/Raw) used by every Harness page
- **`viewModes.ts`** — centralised view mode registry; markdown files now use `formatted` (renamed from `preview`) for consistency with harness.yaml
- **`ConfigFilePage`** — generic editor for any `~/.claude/*` config file, with view mode support
- **`ClaudeFileListPanel` + `useClaudeFileList`** — dynamic file tree for the Config Files nav section
- **`mcp-registry.ts`** — metadata + Simple Icons slugs for 20+ known MCP servers (GitHub, Grafana, Slack, Supabase, Linear, Playwright, etc.)
- **`McpServersPage`** — full rewrite: server cards with icons (Simple Icons CDN + letter-avatar fallback), transport badges, command blocks, env var highlighting, and Docs/Source/Homepage links
- **`HooksPage`** — full rewrite: lifecycle event sections (9 types in order), matcher badges, script rows with timeout, settings.json link
- **`PluginsPage`, `SettingsPage`, `ClaudeMdPage`** — simplified to use `EditorPane`; height fix for correct flex layout
- **`AppLayout`** — collapsible Harness section and Config Files tree, Sync moved to top of list with visual separator
- **`PermissionsSection`** — tool grouping by category (File System, Shell, MCP, Agent & Tasks, Browser & Web, LSP & Dev)

## Test Plan

- [x] Local tests pass (594/594)
- [ ] CI checks pass
- [x] MCP Servers page: logos load from Simple Icons CDN, letter avatars fall back correctly, env vars show `${...}` highlighted, links work
- [x] Hooks page: all 7 live event types render with correct icons, matchers, script names, and timeouts
- [x] CLAUDE.md and other .md files show Formatted/Editor/Split toggle matching harness.yaml style
- [x] Config Files nav tree shows dynamic file list, excludes dedicated items (harness.yaml, CLAUDE.md)
- [x] Collapsible Harness section and Config Files header animate correctly

## Notes

- Simple Icons are loaded via CDN (`cdn.simpleicons.org/{slug}/ffffff`) — gracefully degrades to letter avatars when offline or when no slug is registered
- The `preview` view mode key is kept in `EditorPane` as a legacy fallback but is no longer produced by `viewModes.ts`
- `mcp-registry.ts` can be extended with new server entries as the MCP ecosystem grows