### PR TITLE
feat(board): execution engine with centered task dialog and harness-agnostic runner

### DIFF
--- a/apps/desktop/src-tauri/src/commands/git.rs
+++ b/apps/desktop/src-tauri/src/commands/git.rs
@@ -153,6 +153,11 @@ pub async fn get_diff_against_commit(
     worktree_path: String,
     base_commit: String,
 ) -> Result<Vec<FileDiffEntry>, String> {
+    // Validate base_commit to prevent flag injection (e.g. "--output=/tmp/evil")
+    if base_commit.starts_with('-') || !base_commit.chars().all(|c| c.is_alphanumeric() || "~^-_/.".contains(c)) {
+        return Err("Invalid base_commit reference".to_string());
+    }
+
     let shell = app.shell();
 
     // Get list of changed files

--- a/apps/desktop/src-tauri/src/commands/terminal.rs
+++ b/apps/desktop/src-tauri/src/commands/terminal.rs
@@ -255,6 +255,9 @@ pub async fn detect_harnesses(app: AppHandle) -> Result<Vec<HarnessInfo>, String
         ("codex", "Codex CLI", "codex", vec![
             "o4-mini", "gpt-4.1",
         ]),
+        ("opencode", "OpenCode", "opencode", vec![
+            "anthropic/claude-sonnet-4-5", "openai/gpt-4o", "ollama/qwen2.5-coder",
+        ]),
     ];
 
     let mut harnesses = Vec::new();

--- a/apps/desktop/src/components/board/CommentThread.tsx
+++ b/apps/desktop/src/components/board/CommentThread.tsx
@@ -80,7 +80,7 @@ export function CommentThread({ comments, onAdd }: Props) {
         <textarea
           value={body}
           onChange={e => setBody(e.target.value)}
-          placeholder="Add a comment\u2026"
+          placeholder="Add a comment..."
           rows={3}
           style={{
             background: 'var(--bg-base)',
@@ -117,7 +117,7 @@ export function CommentThread({ comments, onAdd }: Props) {
             transition: 'opacity 0.1s',
           }}
         >
-          {submitting ? 'Posting\u2026' : 'Comment'}
+          {submitting ? 'Posting...' : 'Comment'}
         </button>
       </form>
     </div>

--- a/apps/desktop/src/components/board/ProgressBar.tsx
+++ b/apps/desktop/src/components/board/ProgressBar.tsx
@@ -1,0 +1,37 @@
+interface Props {
+  completed: number;
+  total: number;
+  height?: number;
+}
+
+export function ProgressBar({ completed, total, height = 4 }: Props) {
+  if (total === 0) return null;
+  const percent = Math.round((completed / total) * 100);
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+      <div
+        style={{
+          flex: 1,
+          height,
+          borderRadius: height / 2,
+          background: 'var(--bg-base)',
+          overflow: 'hidden',
+        }}
+      >
+        <div
+          style={{
+            width: `${percent}%`,
+            height: '100%',
+            borderRadius: height / 2,
+            background: percent === 100 ? 'var(--success)' : 'var(--accent)',
+            transition: 'width 0.3s ease',
+          }}
+        />
+      </div>
+      <span style={{ fontSize: 10, color: 'var(--text-muted)', fontVariantNumeric: 'tabular-nums', whiteSpace: 'nowrap' }}>
+        {completed}/{total}
+      </span>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/board/SubtaskList.tsx
+++ b/apps/desktop/src/components/board/SubtaskList.tsx
@@ -1,0 +1,297 @@
+import { useState } from 'react';
+import type { Subtask, SubtaskStatus } from '../../lib/board-api';
+import { api } from '../../lib/board-api';
+
+interface Props {
+  subtasks: Subtask[];
+  projectSlug: string;
+  taskId: number;
+  onUpdated: () => void;
+}
+
+// ── Status styling ───────────────────────────────────────────
+
+const STATUS_CONFIG: Record<SubtaskStatus, {
+  icon: string; color: string; bg: string; border: string; label: string;
+}> = {
+  completed: { icon: '✓', color: '#22c55e', bg: 'rgba(34,197,94,0.08)', border: 'rgba(34,197,94,0.3)', label: 'Completed' },
+  in_progress: { icon: '◔', color: '#3b82f6', bg: 'rgba(59,130,246,0.08)', border: 'rgba(59,130,246,0.3)', label: 'In Progress' },
+  failed: { icon: '✗', color: '#ef4444', bg: 'rgba(239,68,68,0.08)', border: 'rgba(239,68,68,0.3)', label: 'Failed' },
+  pending: { icon: '○', color: 'var(--text-muted)', bg: 'rgba(100,116,139,0.05)', border: 'var(--border-subtle)', label: 'Pending' },
+};
+
+function nextStatus(current: SubtaskStatus): SubtaskStatus {
+  if (current === 'pending') return 'in_progress';
+  if (current === 'in_progress') return 'completed';
+  return 'pending';
+}
+
+// ── Component ────────────────────────────────────────────────
+
+export function SubtaskList({ subtasks, projectSlug, taskId, onUpdated }: Props) {
+  const [newTitle, setNewTitle] = useState('');
+  const [newDescription, setNewDescription] = useState('');
+  const [showDescription, setShowDescription] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editTitle, setEditTitle] = useState('');
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+  const [hoveredId, setHoveredId] = useState<number | null>(null);
+
+  const completed = subtasks.filter(s => s.status === 'completed').length;
+  const percent = subtasks.length > 0 ? Math.round((completed / subtasks.length) * 100) : 0;
+
+  async function handleAdd(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = newTitle.trim();
+    if (!trimmed || submitting) return;
+    setSubmitting(true);
+    try {
+      await api.subtasks.create(projectSlug, taskId, {
+        title: trimmed,
+        description: newDescription.trim() || undefined,
+      });
+      setNewTitle('');
+      setNewDescription('');
+      setShowDescription(false);
+      onUpdated();
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleToggleStatus(subtask: Subtask) {
+    await api.subtasks.update(projectSlug, taskId, subtask.id, { status: nextStatus(subtask.status) });
+    onUpdated();
+  }
+
+  async function handleDelete(subtaskId: number) {
+    await api.subtasks.remove(projectSlug, taskId, subtaskId);
+    onUpdated();
+  }
+
+  async function handleSaveTitle(subtaskId: number) {
+    const trimmed = editTitle.trim();
+    if (!trimmed) { setEditingId(null); return; }
+    await api.subtasks.update(projectSlug, taskId, subtaskId, { title: trimmed });
+    setEditingId(null);
+    onUpdated();
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
+      {/* Progress summary */}
+      {subtasks.length > 0 && (
+        <div style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+          paddingBottom: 10, marginBottom: 12,
+          borderBottom: '1px solid rgba(255,255,255,0.06)',
+          fontSize: 12, color: 'var(--text-muted)',
+        }}>
+          <span>{completed} of {subtasks.length} completed</span>
+          <span style={{ fontVariantNumeric: 'tabular-nums' }}>{percent}%</span>
+        </div>
+      )}
+
+      {/* Subtask cards */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {subtasks.map((subtask, index) => {
+          const cfg = STATUS_CONFIG[subtask.status];
+          const isExpanded = expandedId === subtask.id;
+          const hasDetails = !!(subtask.description || subtask.files.length > 0);
+
+          return (
+            <div
+              key={subtask.id}
+              style={{
+                borderRadius: 12,
+                border: `1px solid ${cfg.border}`,
+                background: cfg.bg,
+                transition: 'all 0.2s',
+                overflow: 'hidden',
+                ...(subtask.status === 'in_progress' ? { boxShadow: `0 0 0 1px ${cfg.border}` } : {}),
+              }}
+              onMouseEnter={() => setHoveredId(subtask.id)}
+              onMouseLeave={() => setHoveredId(null)}
+            >
+              {/* Card header */}
+              <div
+                style={{
+                  display: 'flex', alignItems: 'center', gap: 8,
+                  padding: '10px 12px', cursor: hasDetails ? 'pointer' : 'default',
+                  width: '100%', textAlign: 'left',
+                }}
+                onClick={() => hasDetails && setExpandedId(isExpanded ? null : subtask.id)}
+              >
+                {/* Status icon — clickable */}
+                <button
+                  onClick={e => { e.stopPropagation(); handleToggleStatus(subtask); }}
+                  title={`${cfg.label} — click to advance`}
+                  style={{
+                    width: 18, height: 18, display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    fontSize: 13, fontWeight: 700, flexShrink: 0,
+                    color: cfg.color, background: 'transparent', border: 'none',
+                    cursor: 'pointer', borderRadius: 4, padding: 0,
+                    ...(subtask.status === 'in_progress' ? { animation: 'pulse 2s ease-in-out infinite' } : {}),
+                  }}
+                >
+                  {cfg.icon}
+                </button>
+
+                {/* Number badge */}
+                <span style={{
+                  fontSize: 10, fontWeight: 500,
+                  padding: '1px 6px', borderRadius: 9999, flexShrink: 0,
+                  background: subtask.status === 'completed' ? 'rgba(34,197,94,0.15)' :
+                    subtask.status === 'in_progress' ? 'rgba(59,130,246,0.15)' :
+                    subtask.status === 'failed' ? 'rgba(239,68,68,0.15)' : 'rgba(100,116,139,0.1)',
+                  color: cfg.color,
+                }}>
+                  #{index + 1}
+                </span>
+
+                {/* Title */}
+                {editingId === subtask.id ? (
+                  <input
+                    autoFocus
+                    value={editTitle}
+                    onChange={e => setEditTitle(e.target.value)}
+                    onClick={e => e.stopPropagation()}
+                    onBlur={() => handleSaveTitle(subtask.id)}
+                    onKeyDown={e => {
+                      if (e.key === 'Enter') handleSaveTitle(subtask.id);
+                      if (e.key === 'Escape') setEditingId(null);
+                    }}
+                    style={{
+                      flex: 1, minWidth: 0, fontSize: 13, fontWeight: 500,
+                      color: 'var(--text-primary)', background: 'var(--bg-elevated)',
+                      border: '1px solid var(--accent)', borderRadius: 4,
+                      padding: '2px 6px', outline: 'none',
+                    }}
+                  />
+                ) : (
+                  <span
+                    onDoubleClick={e => { e.stopPropagation(); setEditingId(subtask.id); setEditTitle(subtask.title); }}
+                    style={{
+                      flex: 1, minWidth: 0, fontSize: 13, fontWeight: 500,
+                      color: subtask.status === 'completed' ? 'var(--text-muted)' : 'var(--text-primary)',
+                      overflow: 'hidden', textOverflow: 'ellipsis',
+                      display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical',
+                      cursor: 'text',
+                    }}
+                  >
+                    {subtask.title}
+                  </span>
+                )}
+
+                {/* Delete on hover */}
+                {hoveredId === subtask.id && (
+                  <button
+                    onClick={e => { e.stopPropagation(); handleDelete(subtask.id); }}
+                    title="Remove subtask"
+                    style={{
+                      background: 'transparent', border: 'none',
+                      color: 'var(--text-muted)', cursor: 'pointer',
+                      fontSize: 12, lineHeight: 1, padding: '2px 4px', borderRadius: 4, flexShrink: 0,
+                    }}
+                    onMouseEnter={e => { (e.currentTarget as HTMLElement).style.color = '#ef4444'; }}
+                    onMouseLeave={e => { (e.currentTarget as HTMLElement).style.color = 'var(--text-muted)'; }}
+                  >
+                    ✕
+                  </button>
+                )}
+
+                {/* Expand chevron */}
+                {hasDetails && (
+                  <span style={{
+                    fontSize: 11, color: 'var(--text-muted)', flexShrink: 0,
+                    transition: 'transform 0.2s',
+                    transform: isExpanded ? 'rotate(90deg)' : 'rotate(0deg)',
+                    display: 'inline-block',
+                  }}>
+                    ▶
+                  </span>
+                )}
+              </div>
+
+              {/* Expanded details */}
+              {isExpanded && hasDetails && (
+                <div style={{
+                  padding: '0 12px 10px 46px',
+                  borderTop: '1px solid rgba(255,255,255,0.04)',
+                }}>
+                  {subtask.description && (
+                    <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 8, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                      {subtask.description}
+                    </div>
+                  )}
+                  {subtask.files.length > 0 && (
+                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginTop: 8 }}>
+                      {subtask.files.map(f => (
+                        <code key={f} style={{
+                          fontSize: 10, padding: '2px 6px',
+                          background: 'rgba(100,116,139,0.1)', borderRadius: 4,
+                          color: 'var(--text-muted)', border: '1px solid var(--border-subtle)',
+                        }}>
+                          {f.split('/').pop()}
+                        </code>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Add subtask form */}
+      <form onSubmit={handleAdd} style={{ display: 'flex', flexDirection: 'column', gap: 6, marginTop: 12 }}>
+        <input
+          value={newTitle}
+          onChange={e => setNewTitle(e.target.value)}
+          onFocus={() => setShowDescription(true)}
+          placeholder="Add a subtask..."
+          style={{
+            fontSize: 12, color: 'var(--text-primary)', background: 'transparent',
+            border: '1px dashed var(--border-subtle)', borderRadius: 10,
+            padding: '10px 12px', outline: 'none', transition: 'border-color 0.15s',
+          }}
+          onMouseEnter={e => { (e.currentTarget as HTMLElement).style.borderColor = 'var(--accent)'; }}
+          onMouseLeave={e => { if (document.activeElement !== e.currentTarget) (e.currentTarget as HTMLElement).style.borderColor = 'var(--border-subtle)'; }}
+        />
+        {showDescription && newTitle.trim() && (
+          <>
+            <textarea
+              value={newDescription}
+              onChange={e => setNewDescription(e.target.value)}
+              placeholder="Description (optional)"
+              rows={2}
+              style={{
+                fontSize: 11, color: 'var(--text-secondary)', background: 'transparent',
+                border: '1px solid var(--border-subtle)', borderRadius: 8,
+                padding: '6px 10px', outline: 'none', resize: 'vertical',
+              }}
+            />
+            <div style={{ display: 'flex', gap: 6 }}>
+              <button type="submit" disabled={submitting || !newTitle.trim()} style={{
+                fontSize: 11, fontWeight: 500, padding: '5px 14px', borderRadius: 6,
+                border: 'none', background: 'var(--accent)', color: '#fff',
+                cursor: submitting ? 'not-allowed' : 'pointer', opacity: submitting ? 0.5 : 1,
+              }}>
+                {submitting ? 'Adding...' : 'Add'}
+              </button>
+              <button type="button" onClick={() => { setShowDescription(false); setNewTitle(''); setNewDescription(''); }} style={{
+                fontSize: 11, padding: '5px 14px', borderRadius: 6,
+                border: '1px solid var(--border-subtle)', background: 'transparent',
+                color: 'var(--text-muted)', cursor: 'pointer',
+              }}>
+                Cancel
+              </button>
+            </div>
+          </>
+        )}
+      </form>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/board/TaskCard.tsx
+++ b/apps/desktop/src/components/board/TaskCard.tsx
@@ -1,6 +1,8 @@
 import type { Task, TaskPriority } from '../../lib/board-api';
 import { COLUMN_META } from '../../lib/board-columns';
+import { CATEGORY_CONFIG, COMPLEXITY_CONFIG } from '../../lib/board-task-meta';
 import { openInClaudeCode } from '../../lib/open-in-claude';
+import { ProgressBar } from './ProgressBar';
 import { Tooltip } from './Tooltip';
 
 interface Props {
@@ -35,6 +37,10 @@ function relativeTime(dateStr: string): string {
 export function TaskCard({ task, onClick, repoUrl }: Props) {
   const statusMeta = COLUMN_META[task.status];
   const priorityCfg = task.priority ? PRIORITY_CONFIG[task.priority] : null;
+  const completedSubtasks = task.subtasks?.filter(s => s.status === 'completed').length ?? 0;
+  const totalSubtasks = task.subtasks?.length ?? 0;
+  const categoryCfg = task.category ? CATEGORY_CONFIG[task.category] : null;
+  const complexityCfg = task.complexity ? COMPLEXITY_CONFIG[task.complexity] : null;
 
   return (
     <div
@@ -150,7 +156,69 @@ export function TaskCard({ task, onClick, repoUrl }: Props) {
             {task.epic_name}
           </span>
         )}
+
+        {/* Category badge */}
+        {categoryCfg && (
+          <span
+            style={{
+              borderRadius: 9999,
+              border: `1px solid ${categoryCfg.color}33`,
+              background: `${categoryCfg.color}15`,
+              color: categoryCfg.color,
+              padding: '1px 6px',
+              fontSize: 10,
+              fontWeight: 500,
+            }}
+          >
+            {categoryCfg.label}
+          </span>
+        )}
+
+        {/* Complexity badge */}
+        {complexityCfg && (
+          <span
+            style={{
+              borderRadius: 9999,
+              border: '1px solid var(--border-subtle)',
+              background: 'var(--bg-surface)',
+              padding: '1px 6px',
+              fontSize: 10,
+              color: 'var(--text-muted)',
+              fontWeight: 500,
+            }}
+          >
+            {complexityCfg.label}
+          </span>
+        )}
       </div>
+
+      {/* Progress bar */}
+      {totalSubtasks > 0 && (
+        <ProgressBar completed={completedSubtasks} total={totalSubtasks} />
+      )}
+
+      {/* Subtask status dots */}
+      {totalSubtasks > 0 && totalSubtasks <= 10 && (
+        <Tooltip text={`${completedSubtasks}/${totalSubtasks} subtasks complete`} position="top">
+          <span style={{ display: 'inline-flex', gap: 3, alignItems: 'center' }}>
+            {task.subtasks.map(s => (
+              <span
+                key={s.id}
+                style={{
+                  width: 6,
+                  height: 6,
+                  borderRadius: '50%',
+                  background:
+                    s.status === 'completed' ? 'var(--success)' :
+                    s.status === 'in_progress' ? 'var(--status-in-progress)' :
+                    s.status === 'failed' ? 'var(--danger, #ef4444)' :
+                    'var(--fg-subtle)',
+                }}
+              />
+            ))}
+          </span>
+        </Tooltip>
+      )}
 
       {/* Footer row */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 2 }}>

--- a/apps/desktop/src/components/board/TaskDetailDialog.tsx
+++ b/apps/desktop/src/components/board/TaskDetailDialog.tsx
@@ -1,0 +1,778 @@
+import { AnimatePresence, motion } from 'framer-motion';
+import { useEffect, useState, useCallback, lazy, Suspense } from 'react';
+import { createPortal } from 'react-dom';
+import { invoke } from '@tauri-apps/api/core';
+import type { Task, TaskCategory, TaskComplexity, TaskPriority, TaskStatus } from '../../lib/board-api';
+import type { Project } from '../../lib/board-api';
+import { COLUMN_META, COLUMNS } from '../../lib/board-columns';
+import { CATEGORY_CONFIG, COMPLEXITY_CONFIG } from '../../lib/board-task-meta';
+import { CommentThread } from './CommentThread';
+import { ProgressBar } from './ProgressBar';
+import { SubtaskList } from './SubtaskList';
+import { api } from '../../lib/board-api';
+import { useExecution } from '../../contexts/ExecutionContext';
+import type { HarnessInfo } from '@harness-kit/shared';
+
+// Lazy-load xterm (heavy) — only mounted when Logs tab is shown
+const TerminalView = lazy(() => import('../comparator/TerminalView'));
+
+// ── Types ────────────────────────────────────────────────────
+
+interface Props {
+  task: Task | null;
+  project: Project;
+  onClose: () => void;
+  onTaskUpdated: () => void;
+  repoUrl?: string;
+}
+
+type TabId = 'overview' | 'subtasks' | 'logs' | 'files';
+
+interface FileDiffEntry {
+  filePath: string;
+  diffText: string;
+  changeType: string;
+}
+
+// ── Sub-components ───────────────────────────────────────────
+
+const PRIORITY_CONFIG: Record<TaskPriority, { label: string; color: string; bgColor: string; borderColor: string }> = {
+  critical: { label: 'Critical', color: '#dc2626', bgColor: 'rgba(239,68,68,0.1)', borderColor: 'rgba(239,68,68,0.2)' },
+  high: { label: 'High', color: '#ea580c', bgColor: 'rgba(249,115,22,0.1)', borderColor: 'rgba(249,115,22,0.2)' },
+  medium: { label: 'Medium', color: '#ca8a04', bgColor: 'rgba(234,179,8,0.1)', borderColor: 'rgba(234,179,8,0.2)' },
+  low: { label: 'Low', color: 'var(--text-muted)', bgColor: 'rgba(107,114,128,0.1)', borderColor: 'rgba(107,114,128,0.2)' },
+};
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <div style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+        {title}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function EmptyState({ icon, text }: { icon: string; text: string }) {
+  return (
+    <div style={{
+      display: 'flex', flexDirection: 'column', alignItems: 'center',
+      justifyContent: 'center', gap: 12, height: '100%', minHeight: 200,
+      color: 'var(--text-muted)',
+    }}>
+      <span style={{ fontSize: 32 }}>{icon}</span>
+      <span style={{ fontSize: 13 }}>{text}</span>
+    </div>
+  );
+}
+
+// ── Main component ───────────────────────────────────────────
+
+export function TaskDetailDialog({ task, project, onClose, onTaskUpdated, repoUrl }: Props) {
+  const execution = useExecution();
+
+  const [copied, setCopied] = useState(false);
+  const [updatingStatus, setUpdatingStatus] = useState(false);
+  const [updatingPriority, setUpdatingPriority] = useState(false);
+  const [updatingCategory, setUpdatingCategory] = useState(false);
+  const [updatingComplexity, setUpdatingComplexity] = useState(false);
+  const [activeTab, setActiveTab] = useState<TabId>('overview');
+
+  // Harness selection state
+  const [selectedHarness, setSelectedHarness] = useState<string>('claude');
+  const [selectedModel, setSelectedModel] = useState<string>('');
+  const [detectedHarnesses, setDetectedHarnesses] = useState<HarnessInfo[]>([]);
+  const [starting, setStopping] = useState(false);
+
+  // Files tab
+  const [fileDiffs, setFileDiffs] = useState<FileDiffEntry[]>([]);
+  const [expandedFile, setExpandedFile] = useState<string | null>(null);
+
+  const isRunning = task ? execution.isRunning(task.id) : false;
+  const execData = task ? execution.getExecution(task.id) : undefined;
+  const rawChunks = task ? execution.getOutput(task.id) : [];
+  const terminalId = execData?.terminalId ?? '';
+
+  // Reset tab + state when task changes
+  useEffect(() => {
+    setActiveTab('overview');
+    setExpandedFile(null);
+    setFileDiffs([]);
+  }, [task?.id]);
+
+  // Sync harness/model from task defaults
+  useEffect(() => {
+    if (!task) return;
+    setSelectedHarness(task.default_harness ?? project.default_harness ?? 'claude');
+    setSelectedModel(task.default_model ?? project.default_model ?? '');
+  }, [task?.id, project]);
+
+  // Detect installed harnesses once
+  useEffect(() => {
+    invoke<HarnessInfo[]>('detect_harnesses').then(setDetectedHarnesses).catch(console.error);
+  }, []);
+
+  // Load git diff when Files tab active
+  useEffect(() => {
+    if (activeTab !== 'files' || !task?.worktree_path) return;
+    invoke<FileDiffEntry[]>('get_diff_against_commit', {
+      worktreePath: task.worktree_path,
+      baseCommit: 'HEAD~1',
+    }).then(setFileDiffs).catch(console.error);
+  }, [activeTab, task?.worktree_path, execution.outputTick]);
+
+  // Close on Escape
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  // ── Handlers ──────────────────────────────────────────────────
+
+  async function handleStatusChange(newStatus: TaskStatus) {
+    if (!task || updatingStatus) return;
+    setUpdatingStatus(true);
+    try {
+      await api.tasks.update(project.slug, task.id, { status: newStatus });
+      onTaskUpdated();
+    } finally { setUpdatingStatus(false); }
+  }
+
+  async function handlePriorityChange(newPriority: TaskPriority) {
+    if (!task || updatingPriority) return;
+    setUpdatingPriority(true);
+    try {
+      await api.tasks.update(project.slug, task.id, { priority: newPriority });
+      onTaskUpdated();
+    } finally { setUpdatingPriority(false); }
+  }
+
+  async function handleCategoryChange(newCategory: TaskCategory) {
+    if (!task || updatingCategory) return;
+    setUpdatingCategory(true);
+    try {
+      await api.tasks.update(project.slug, task.id, { category: newCategory });
+      onTaskUpdated();
+    } finally { setUpdatingCategory(false); }
+  }
+
+  async function handleComplexityChange(newComplexity: TaskComplexity) {
+    if (!task || updatingComplexity) return;
+    setUpdatingComplexity(true);
+    try {
+      await api.tasks.update(project.slug, task.id, { complexity: newComplexity });
+      onTaskUpdated();
+    } finally { setUpdatingComplexity(false); }
+  }
+
+  async function handleAddComment(body: string) {
+    if (!task) return;
+    await api.comments.create(project.slug, task.id, { author: 'user', body });
+    onTaskUpdated();
+  }
+
+  const handleStartStop = useCallback(async () => {
+    if (!task || starting) return;
+    setStopping(true);
+    try {
+      if (isRunning) {
+        await execution.stopTask(project.slug, task.id);
+        onTaskUpdated();
+      } else {
+        if (!execution.canStartMore(project)) {
+          alert(`Concurrent task limit (${project.max_concurrent ?? 3}) reached.`);
+          return;
+        }
+        await execution.startTask(project.slug, task, project, selectedHarness, selectedModel || undefined);
+        onTaskUpdated();
+        setActiveTab('logs');
+      }
+    } catch (err) {
+      console.error('Start/stop failed:', err);
+    } finally {
+      setStopping(false);
+    }
+  }, [task, starting, isRunning, execution, project, selectedHarness, selectedModel, onTaskUpdated]);
+
+  // ── Styles ────────────────────────────────────────────────────
+
+  const pillBase: React.CSSProperties = {
+    display: 'inline-flex', alignItems: 'center', gap: 6,
+    borderRadius: 9999, border: '1px solid var(--border-subtle)',
+    padding: '4px 10px', fontSize: 11, fontWeight: 500,
+    cursor: 'pointer', background: 'var(--bg-elevated)',
+    color: 'var(--text-muted)', transition: 'all 0.15s',
+  };
+
+  const pillActive: React.CSSProperties = {
+    ...pillBase,
+    borderColor: 'var(--accent)',
+    background: 'rgba(var(--accent-rgb, 99,102,241), 0.1)',
+    color: 'var(--text-primary)',
+  };
+
+  const completedCount = task?.subtasks?.filter(s => s.status === 'completed').length ?? 0;
+  const totalSubtasks = task?.subtasks?.length ?? 0;
+
+  // Execution status
+  const execStatus = task?.execution?.status;
+
+  // Start/Stop button content
+  let startStopLabel: string;
+  if (starting) {
+    startStopLabel = isRunning ? 'Stopping...' : 'Starting...';
+  } else if (isRunning) {
+    startStopLabel = '◼ Stop Task';
+  } else if (execStatus === 'completed') {
+    startStopLabel = '▶ Start Task';
+  } else if (execStatus === 'failed') {
+    startStopLabel = '▶ Retry';
+  } else {
+    startStopLabel = '▶ Start Task';
+  }
+
+  // ── Render ────────────────────────────────────────────────────
+
+  return createPortal(
+    <AnimatePresence>
+      {task && (
+        <div className="board-scope">
+          {/* Backdrop */}
+          <motion.div
+            key="backdrop"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            onClick={onClose}
+            style={{
+              position: 'fixed', inset: 0,
+              background: 'rgba(0,0,0,0.6)',
+              backdropFilter: 'blur(8px)',
+              WebkitBackdropFilter: 'blur(8px)',
+              zIndex: 40,
+            }}
+          />
+
+          {/* Dialog wrapper — uses flexbox centering to avoid transform conflict with Framer Motion */}
+          <motion.div
+            key="dialog-wrapper"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            style={{
+              position: 'fixed',
+              inset: 0,
+              zIndex: 50,
+              display: 'flex',
+              alignItems: 'flex-start',
+              justifyContent: 'center',
+              padding: '16px 0',
+              pointerEvents: 'none',
+            }}
+          >
+          <motion.div
+            key="dialog"
+            initial={{ opacity: 0, scale: 0.95, y: 12 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.95, y: 12 }}
+            transition={{ type: 'spring', stiffness: 400, damping: 36 }}
+            style={{
+              width: '95vw', maxWidth: '64rem',
+              height: 'calc(100vh - 32px)',
+              background: 'var(--bg-surface)',
+              border: '1px solid var(--border)',
+              borderRadius: 12,
+              boxShadow: '0 25px 50px -12px rgba(0,0,0,0.6)',
+              display: 'flex', flexDirection: 'column',
+              overflow: 'hidden',
+              pointerEvents: 'auto',
+            }}
+          >
+            {/* ── Header (Aperant-style) ── */}
+            <div style={{
+              padding: '20px 20px 16px', borderBottom: '1px solid var(--border-subtle)',
+              flexShrink: 0,
+            }}>
+              <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 16 }}>
+                {/* Left: title + metadata */}
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  {/* Title */}
+                  <h2 style={{
+                    margin: 0, fontSize: 20, fontWeight: 600, color: 'var(--text-primary)',
+                    lineHeight: 1.3, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                  }}>
+                    {task.title}
+                  </h2>
+
+                  {/* Metadata row: epic badge, status badge, subtask count */}
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 10, flexWrap: 'wrap' }}>
+                    {task.epic_name && (
+                      <span style={{
+                        fontSize: 11, fontFamily: 'monospace', color: 'var(--text-secondary)',
+                        background: 'var(--bg-elevated)', borderRadius: 6,
+                        padding: '2px 8px', border: '1px solid var(--border-subtle)',
+                      }}>
+                        {task.epic_name}
+                      </span>
+                    )}
+                    {/* Status badge */}
+                    <span style={{
+                      fontSize: 11, fontWeight: 600, borderRadius: 6,
+                      padding: '2px 8px', border: '1px solid transparent',
+                      ...(isRunning ? {
+                        color: '#3b82f6', background: 'rgba(59,130,246,0.1)', borderColor: 'rgba(59,130,246,0.3)',
+                        animation: 'status-pulse 2s ease-in-out infinite',
+                      } : task.status === 'done' ? {
+                        color: '#22c55e', background: 'rgba(34,197,94,0.1)', borderColor: 'rgba(34,197,94,0.3)',
+                      } : task.status === 'human-review' ? {
+                        color: '#a855f7', background: 'rgba(168,85,247,0.1)', borderColor: 'rgba(168,85,247,0.3)',
+                      } : {
+                        color: 'var(--text-muted)', background: 'var(--bg-elevated)', borderColor: 'var(--border-subtle)',
+                      }),
+                    }}>
+                      {isRunning ? 'In Progress' : COLUMN_META[task.status]?.label ?? task.status}
+                    </span>
+                    {/* Subtask count */}
+                    {totalSubtasks > 0 && (
+                      <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>
+                        {completedCount}/{totalSubtasks} subtasks
+                      </span>
+                    )}
+                    {task.blocked && (
+                      <span style={{
+                        fontSize: 10, fontWeight: 700, color: '#ef4444',
+                        background: 'rgba(239,68,68,0.1)', borderRadius: 4, padding: '1px 5px',
+                        textTransform: 'uppercase',
+                      }}>
+                        Blocked
+                      </span>
+                    )}
+                  </div>
+                </div>
+
+                {/* Right: close button */}
+                <button
+                  onClick={onClose}
+                  style={{
+                    background: 'transparent', border: 'none',
+                    color: 'var(--text-muted)', cursor: 'pointer',
+                    fontSize: 20, lineHeight: 1, padding: 4,
+                    borderRadius: 6, flexShrink: 0,
+                  }}
+                  title="Close (Esc)"
+                  onMouseEnter={e => { (e.currentTarget as HTMLElement).style.color = 'var(--text-primary)'; }}
+                  onMouseLeave={e => { (e.currentTarget as HTMLElement).style.color = 'var(--text-muted)'; }}
+                >
+                  ✕
+                </button>
+              </div>
+
+              {/* Progress bar (when running or has progress) */}
+              {totalSubtasks > 0 && (isRunning || completedCount > 0) && (
+                <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginTop: 12 }}>
+                  <ProgressBar completed={completedCount} total={totalSubtasks} height={6} />
+                  <span style={{
+                    fontSize: 12, color: 'var(--text-muted)',
+                    fontVariantNumeric: 'tabular-nums', width: 36, textAlign: 'right', flexShrink: 0,
+                  }}>
+                    {Math.round((completedCount / totalSubtasks) * 100)}%
+                  </span>
+                </div>
+              )}
+            </div>
+
+            {/* ── Tab bar ── */}
+            <div className="tab-bar" style={{ padding: '0 20px', flexShrink: 0 }}>
+              {(['overview', 'subtasks', 'logs', 'files'] as TabId[]).map(tab => {
+                let label = tab.charAt(0).toUpperCase() + tab.slice(1);
+                if (tab === 'subtasks' && totalSubtasks > 0) label = `Subtasks (${totalSubtasks})`;
+                if (tab === 'logs' && execStatus && execStatus !== 'idle') label = `Logs · ${execStatus}`;
+                if (tab === 'files' && fileDiffs.length > 0) label = `Files (${fileDiffs.length})`;
+                return (
+                  <button
+                    key={tab}
+                    className={`tab ${activeTab === tab ? 'active' : ''}`}
+                    onClick={() => setActiveTab(tab)}
+                  >
+                    {label}
+                  </button>
+                );
+              })}
+            </div>
+
+            {/* ── Scrollable body ── */}
+            <div style={{
+              flex: 1, overflowY: activeTab === 'logs' ? 'hidden' : 'auto',
+              padding: activeTab === 'logs' ? 0 : '20px',
+              display: 'flex', flexDirection: 'column',
+              gap: activeTab === 'logs' ? 0 : 24,
+            }}>
+
+              {/* ─── OVERVIEW TAB ─── */}
+              {activeTab === 'overview' && (
+                <>
+                  <Section title="Status">
+                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                      {COLUMNS.map(status => {
+                        const meta = COLUMN_META[status];
+                        const isActive = task.status === status;
+                        return (
+                          <button
+                            key={status}
+                            onClick={() => handleStatusChange(status)}
+                            disabled={updatingStatus}
+                            style={{ ...(isActive ? pillActive : pillBase), opacity: updatingStatus ? 0.5 : 1, cursor: updatingStatus ? 'not-allowed' : 'pointer' }}
+                          >
+                            <span style={{ width: 8, height: 8, borderRadius: '50%', background: meta.color, display: 'inline-block' }} />
+                            {meta.label}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </Section>
+
+                  <Section title="Priority">
+                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                      {(Object.keys(PRIORITY_CONFIG) as TaskPriority[]).map(priority => {
+                        const cfg = PRIORITY_CONFIG[priority];
+                        const isActive = task.priority === priority;
+                        return (
+                          <button
+                            key={priority}
+                            onClick={() => handlePriorityChange(priority)}
+                            disabled={updatingPriority}
+                            style={{
+                              display: 'inline-flex', alignItems: 'center',
+                              borderRadius: 9999, padding: '4px 10px',
+                              fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em',
+                              cursor: updatingPriority ? 'not-allowed' : 'pointer',
+                              opacity: updatingPriority ? 0.5 : 1, transition: 'all 0.15s',
+                              border: isActive ? `1px solid ${cfg.borderColor}` : '1px solid var(--border-subtle)',
+                              background: isActive ? cfg.bgColor : 'var(--bg-elevated)',
+                              color: isActive ? cfg.color : 'var(--text-muted)',
+                            }}
+                          >
+                            {cfg.label}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </Section>
+
+                  <Section title="Category">
+                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                      {(Object.keys(CATEGORY_CONFIG) as TaskCategory[]).map(cat => {
+                        const cfg = CATEGORY_CONFIG[cat];
+                        const isActive = task.category === cat;
+                        return (
+                          <button
+                            key={cat}
+                            onClick={() => handleCategoryChange(cat)}
+                            disabled={updatingCategory}
+                            style={{
+                              ...pillBase,
+                              borderColor: isActive ? `${cfg.color}66` : 'var(--border-subtle)',
+                              background: isActive ? `${cfg.color}15` : 'var(--bg-elevated)',
+                              color: isActive ? cfg.color : 'var(--text-muted)',
+                              fontWeight: isActive ? 600 : 500,
+                              opacity: updatingCategory ? 0.5 : 1,
+                              cursor: updatingCategory ? 'not-allowed' : 'pointer',
+                            }}
+                          >
+                            {cfg.label}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </Section>
+
+                  <Section title="Complexity">
+                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                      {(Object.keys(COMPLEXITY_CONFIG) as TaskComplexity[]).map(cplx => {
+                        const isActive = task.complexity === cplx;
+                        return (
+                          <button
+                            key={cplx}
+                            onClick={() => handleComplexityChange(cplx)}
+                            disabled={updatingComplexity}
+                            style={{ ...(isActive ? pillActive : pillBase), opacity: updatingComplexity ? 0.5 : 1, cursor: updatingComplexity ? 'not-allowed' : 'pointer' }}
+                          >
+                            {COMPLEXITY_CONFIG[cplx].label}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </Section>
+
+                  {task.description && (
+                    <Section title="Description">
+                      <div style={{ fontSize: 13, color: 'var(--text-secondary)', lineHeight: 1.6, whiteSpace: 'pre-wrap' }}>
+                        {task.description}
+                      </div>
+                    </Section>
+                  )}
+
+                  {(task.branch || task.worktree_path) && (
+                    <Section title="Git">
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                        {task.branch && (
+                          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                            <span style={{ fontSize: 11, color: 'var(--text-muted)', width: 60, flexShrink: 0 }}>Branch</span>
+                            {repoUrl ? (
+                              <a href={`${repoUrl}/tree/${task.branch}`} target="_blank" rel="noopener noreferrer"
+                                style={{ fontSize: 12, color: 'var(--text-secondary)', background: 'var(--bg-elevated)', borderRadius: 4, padding: '2px 6px', border: '1px solid var(--border-subtle)', textDecoration: 'none' }}>
+                                {task.branch}
+                              </a>
+                            ) : (
+                              <code style={{ fontSize: 12, color: 'var(--text-secondary)', background: 'var(--bg-elevated)', borderRadius: 4, padding: '2px 6px', border: '1px solid var(--border-subtle)' }}>
+                                {task.branch}
+                              </code>
+                            )}
+                          </div>
+                        )}
+                        {task.worktree_path && (
+                          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                            <span style={{ fontSize: 11, color: 'var(--text-muted)', width: 60, flexShrink: 0 }}>Worktree</span>
+                            <code style={{ fontSize: 11, color: 'var(--text-muted)', background: 'var(--bg-elevated)', borderRadius: 4, padding: '2px 6px', border: '1px solid var(--border-subtle)', wordBreak: 'break-all', flex: 1 }}>
+                              {task.worktree_path}
+                            </code>
+                            <button
+                              onClick={() => { navigator.clipboard.writeText(task.worktree_path!); setCopied(true); setTimeout(() => setCopied(false), 1500); }}
+                              style={{ background: 'transparent', border: 'none', color: 'var(--text-muted)', cursor: 'pointer', fontSize: 11, padding: '2px 4px', borderRadius: 4 }}
+                            >
+                              {copied ? 'Copied!' : '⎘'}
+                            </button>
+                          </div>
+                        )}
+                      </div>
+                    </Section>
+                  )}
+
+                  {task.linked_commits.length > 0 && (
+                    <Section title={`Commits (${task.linked_commits.length})`}>
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                        {task.linked_commits.map(sha => (
+                          <code key={sha} style={{ fontSize: 12, color: 'var(--text-secondary)', background: 'var(--bg-elevated)', borderRadius: 4, padding: '2px 6px', border: '1px solid var(--border-subtle)', fontFamily: 'monospace', width: 'fit-content' }}>
+                            {sha.slice(0, 12)}
+                          </code>
+                        ))}
+                      </div>
+                    </Section>
+                  )}
+
+                  {task.blocked && task.blocked_reason && (
+                    <Section title="Blocked reason">
+                      <div style={{ fontSize: 13, color: 'var(--blocked)', background: 'rgba(220,38,38,0.08)', borderRadius: 6, padding: '8px 10px', border: '1px solid rgba(220,38,38,0.2)' }}>
+                        {task.blocked_reason}
+                      </div>
+                    </Section>
+                  )}
+
+                  <div style={{ fontSize: 11, color: 'var(--text-muted)', display: 'flex', gap: 16 }}>
+                    <span>Created {new Date(task.created_at).toLocaleDateString()}</span>
+                    <span>Updated {new Date(task.updated_at).toLocaleDateString()}</span>
+                  </div>
+
+                  {/* Comments */}
+                  <Section title={`Activity (${task.comments.length})`}>
+                    <CommentThread comments={task.comments} onAdd={handleAddComment} />
+                  </Section>
+                </>
+              )}
+
+              {/* ─── SUBTASKS TAB ─── */}
+              {activeTab === 'subtasks' && (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+                  {totalSubtasks > 0 && (
+                    <ProgressBar completed={completedCount} total={totalSubtasks} height={6} />
+                  )}
+                  <SubtaskList
+                    subtasks={task.subtasks ?? []}
+                    projectSlug={project.slug}
+                    taskId={task.id}
+                    onUpdated={onTaskUpdated}
+                  />
+                </div>
+              )}
+
+              {/* ─── LOGS TAB ─── */}
+              {activeTab === 'logs' && (
+                <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+                  {isRunning && terminalId ? (
+                    <Suspense fallback={<div style={{ padding: 20, color: 'var(--text-muted)' }}>Loading terminal...</div>}>
+                      <TerminalView terminalId={terminalId} rawChunks={rawChunks} />
+                    </Suspense>
+                  ) : execStatus && execStatus !== 'idle' ? (
+                    <div style={{ padding: 20, display: 'flex', flexDirection: 'column', gap: 12 }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 14px', background: 'var(--bg-elevated)', borderRadius: 8, border: '1px solid var(--border-subtle)' }}>
+                        <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>
+                          {execStatus === 'completed' ? '✓ Completed' : execStatus === 'failed' ? '✗ Failed' : '◼ Stopped'}
+                          {task.execution?.harness_id && ` · ${task.execution.harness_id}`}
+                          {task.execution?.model && ` · ${task.execution.model}`}
+                          {task.execution?.started_at && ` · ${new Date(task.execution.started_at).toLocaleTimeString()}`}
+                        </span>
+                      </div>
+                      <div style={{ fontSize: 13, color: 'var(--text-muted)' }}>
+                        Terminal output is not preserved after the process ends. Start the task again to see live output.
+                      </div>
+                    </div>
+                  ) : (
+                    <EmptyState icon="📋" text="No execution logs. Click Start Task to begin." />
+                  )}
+                </div>
+              )}
+
+              {/* ─── FILES TAB ─── */}
+              {activeTab === 'files' && (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                  {!task.worktree_path ? (
+                    <EmptyState icon="📁" text="No worktree linked. Start the task to create one." />
+                  ) : fileDiffs.length === 0 ? (
+                    <EmptyState icon="📄" text="No file changes detected yet." />
+                  ) : (
+                    fileDiffs.map(diff => {
+                      const fileName = diff.filePath.split('/').pop() ?? diff.filePath;
+                      const isExpanded = expandedFile === diff.filePath;
+                      const changeColor = diff.changeType === 'added' ? '#22c55e' : diff.changeType === 'deleted' ? '#ef4444' : '#f59e0b';
+                      return (
+                        <div key={diff.filePath} style={{ border: '1px solid var(--border-subtle)', borderRadius: 8, overflow: 'hidden' }}>
+                          <button
+                            onClick={() => setExpandedFile(isExpanded ? null : diff.filePath)}
+                            style={{
+                              width: '100%', display: 'flex', alignItems: 'center', gap: 10,
+                              padding: '10px 14px', background: 'var(--bg-elevated)',
+                              border: 'none', cursor: 'pointer', textAlign: 'left',
+                            }}
+                          >
+                            <span style={{ fontSize: 10, fontWeight: 700, color: changeColor, textTransform: 'uppercase', width: 52, flexShrink: 0 }}>
+                              {diff.changeType}
+                            </span>
+                            <span style={{ fontSize: 13, color: 'var(--text-primary)', fontFamily: 'monospace', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={diff.filePath}>
+                              {fileName}
+                            </span>
+                            <span style={{ fontSize: 11, color: 'var(--text-muted)', fontFamily: 'monospace' }}>{diff.filePath}</span>
+                            <span style={{ fontSize: 12, color: 'var(--text-muted)', flexShrink: 0 }}>{isExpanded ? '▲' : '▼'}</span>
+                          </button>
+                          {isExpanded && diff.diffText && (
+                            <pre style={{
+                              margin: 0, padding: '12px 14px',
+                              fontSize: 11, fontFamily: 'monospace', lineHeight: 1.5,
+                              background: '#0d0d1a', color: '#d0d0dc',
+                              overflowX: 'auto', maxHeight: 400, overflowY: 'auto',
+                              whiteSpace: 'pre',
+                            }}>
+                              {diff.diffText.split('\n').map((line, i) => {
+                                const color = line.startsWith('+') ? '#22c55e' : line.startsWith('-') ? '#ef4444' : line.startsWith('@@') ? '#60a5fa' : '#d0d0dc';
+                                return <span key={i} style={{ color, display: 'block' }}>{line}</span>;
+                              })}
+                            </pre>
+                          )}
+                        </div>
+                      );
+                    })
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* ── Footer (Aperant-style) ── */}
+            <div style={{
+              padding: '12px 20px', borderTop: '1px solid var(--border-subtle)',
+              display: 'flex', alignItems: 'center', gap: 12, flexShrink: 0,
+            }}>
+              {/* Left: Delete Task */}
+              <button
+                onClick={() => { /* TODO: delete confirmation */ }}
+                disabled={isRunning}
+                style={{
+                  display: 'inline-flex', alignItems: 'center', gap: 6,
+                  padding: '6px 10px', borderRadius: 6, fontSize: 12,
+                  border: 'none', background: 'transparent',
+                  color: 'var(--text-muted)', cursor: isRunning ? 'not-allowed' : 'pointer',
+                  opacity: isRunning ? 0.4 : 1, transition: 'color 0.15s',
+                }}
+                onMouseEnter={e => { if (!isRunning) (e.currentTarget as HTMLElement).style.color = '#ef4444'; }}
+                onMouseLeave={e => { (e.currentTarget as HTMLElement).style.color = 'var(--text-muted)'; }}
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg>
+                Delete Task
+              </button>
+
+              {/* Center: Harness + Model selectors */}
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, flex: 1 }}>
+                <select
+                  value={selectedHarness}
+                  onChange={e => setSelectedHarness(e.target.value)}
+                  disabled={isRunning}
+                  style={{
+                    fontSize: 11, padding: '4px 6px', borderRadius: 6,
+                    background: 'var(--bg-elevated)', border: '1px solid var(--border-subtle)',
+                    color: 'var(--text-muted)', cursor: isRunning ? 'not-allowed' : 'pointer',
+                    opacity: isRunning ? 0.5 : 1,
+                  }}
+                >
+                  {detectedHarnesses.filter(h => h.available).map(h => (
+                    <option key={h.id} value={h.id}>{h.name}</option>
+                  ))}
+                  {detectedHarnesses.filter(h => h.available).length === 0 && (
+                    <option value="claude">Claude Code</option>
+                  )}
+                </select>
+                <input
+                  type="text"
+                  placeholder="Model"
+                  value={selectedModel}
+                  onChange={e => setSelectedModel(e.target.value)}
+                  disabled={isRunning}
+                  style={{
+                    fontSize: 11, padding: '4px 6px', borderRadius: 6, width: 120,
+                    background: 'var(--bg-elevated)', border: '1px solid var(--border-subtle)',
+                    color: 'var(--text-muted)', opacity: isRunning ? 0.5 : 1,
+                  }}
+                />
+              </div>
+
+              {/* Right: Start/Stop + Close */}
+              <button
+                onClick={handleStartStop}
+                disabled={starting}
+                style={{
+                  display: 'inline-flex', alignItems: 'center', gap: 6,
+                  padding: '7px 16px', borderRadius: 8, fontSize: 13, fontWeight: 600,
+                  border: isRunning ? '1px solid rgba(239,68,68,0.3)' : '1px solid transparent',
+                  background: isRunning ? 'rgba(239,68,68,0.1)' : 'var(--accent)',
+                  color: isRunning ? '#ef4444' : '#fff',
+                  cursor: starting ? 'not-allowed' : 'pointer',
+                  opacity: starting ? 0.6 : 1, transition: 'all 0.15s',
+                  flexShrink: 0,
+                }}
+              >
+                {startStopLabel}
+              </button>
+
+              <button
+                onClick={onClose}
+                style={{
+                  padding: '7px 14px', borderRadius: 8, fontSize: 13,
+                  border: '1px solid var(--border-subtle)', background: 'transparent',
+                  color: 'var(--text-secondary)', cursor: 'pointer',
+                  flexShrink: 0, transition: 'all 0.15s',
+                }}
+                onMouseEnter={e => { (e.currentTarget as HTMLElement).style.borderColor = 'var(--border)'; }}
+                onMouseLeave={e => { (e.currentTarget as HTMLElement).style.borderColor = 'var(--border-subtle)'; }}
+              >
+                Close
+              </button>
+            </div>
+          </motion.div>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>,
+    document.body,
+  );
+}

--- a/apps/desktop/src/components/board/TaskDetailPanel.tsx
+++ b/apps/desktop/src/components/board/TaskDetailPanel.tsx
@@ -1,8 +1,11 @@
 import { AnimatePresence, motion } from 'framer-motion';
-import { useState } from 'react';
-import type { Task, TaskPriority, TaskStatus } from '../../lib/board-api';
+import { useEffect, useState } from 'react';
+import type { Task, TaskCategory, TaskComplexity, TaskPriority, TaskStatus } from '../../lib/board-api';
 import { COLUMN_META, COLUMNS } from '../../lib/board-columns';
+import { CATEGORY_CONFIG, COMPLEXITY_CONFIG } from '../../lib/board-task-meta';
 import { CommentThread } from './CommentThread';
+import { ProgressBar } from './ProgressBar';
+import { SubtaskList } from './SubtaskList';
 import { api } from '../../lib/board-api';
 import { openInClaudeCode } from '../../lib/open-in-claude';
 
@@ -36,6 +39,11 @@ export function TaskDetailPanel({ task, projectSlug, onClose, onTaskUpdated, rep
   const [copied, setCopied] = useState(false);
   const [updatingStatus, setUpdatingStatus] = useState(false);
   const [updatingPriority, setUpdatingPriority] = useState(false);
+  const [updatingCategory, setUpdatingCategory] = useState(false);
+  const [updatingComplexity, setUpdatingComplexity] = useState(false);
+  const [activeTab, setActiveTab] = useState<'overview' | 'subtasks' | 'activity'>('overview');
+
+  useEffect(() => { setActiveTab('overview'); }, [task?.id]);
 
   async function handleAddComment(body: string) {
     if (!task) return;
@@ -62,6 +70,28 @@ export function TaskDetailPanel({ task, projectSlug, onClose, onTaskUpdated, rep
       onTaskUpdated();
     } finally {
       setUpdatingPriority(false);
+    }
+  }
+
+  async function handleCategoryChange(newCategory: TaskCategory) {
+    if (!task || updatingCategory) return;
+    setUpdatingCategory(true);
+    try {
+      await api.tasks.update(projectSlug, task.id, { category: newCategory });
+      onTaskUpdated();
+    } finally {
+      setUpdatingCategory(false);
+    }
+  }
+
+  async function handleComplexityChange(newComplexity: TaskComplexity) {
+    if (!task || updatingComplexity) return;
+    setUpdatingComplexity(true);
+    try {
+      await api.tasks.update(projectSlug, task.id, { complexity: newComplexity });
+      onTaskUpdated();
+    } finally {
+      setUpdatingComplexity(false);
     }
   }
 
@@ -238,6 +268,24 @@ export function TaskDetailPanel({ task, projectSlug, onClose, onTaskUpdated, rep
               </button>
             </div>
 
+            {/* Tab bar */}
+            <div className="tab-bar" style={{ padding: '0 20px' }}>
+              {(['overview', 'subtasks', 'activity'] as const).map(tab => {
+                let label = tab.charAt(0).toUpperCase() + tab.slice(1);
+                if (tab === 'subtasks' && task.subtasks?.length > 0) label = `Subtasks (${task.subtasks.length})`;
+                if (tab === 'activity') label = `Activity (${task.comments.length})`;
+                return (
+                  <button
+                    key={tab}
+                    className={`tab ${activeTab === tab ? 'active' : ''}`}
+                    onClick={() => setActiveTab(tab)}
+                  >
+                    {label}
+                  </button>
+                );
+              })}
+            </div>
+
             {/* Scrollable body */}
             <div
               style={{
@@ -249,261 +297,339 @@ export function TaskDetailPanel({ task, projectSlug, onClose, onTaskUpdated, rep
                 gap: 24,
               }}
             >
-              {/* Status */}
-              <Section title="Status">
-                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
-                  {COLUMNS.map(status => {
-                    const meta = COLUMN_META[status];
-                    const isActive = task.status === status;
-                    return (
-                      <button
-                        key={status}
-                        onClick={() => handleStatusChange(status)}
-                        disabled={updatingStatus}
-                        style={{
-                          ...(isActive ? pillActive : pillBase),
-                          opacity: updatingStatus ? 0.5 : 1,
-                          cursor: updatingStatus ? 'not-allowed' : 'pointer',
-                        }}
-                      >
-                        <span
-                          style={{
-                            width: 8,
-                            height: 8,
-                            borderRadius: '50%',
-                            background: meta.color,
-                            display: 'inline-block',
-                          }}
-                        />
-                        {meta.label}
-                      </button>
-                    );
-                  })}
-                </div>
-              </Section>
-
-              {/* Priority */}
-              <Section title="Priority">
-                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
-                  {(Object.keys(PRIORITY_CONFIG) as TaskPriority[]).map(priority => {
-                    const cfg = PRIORITY_CONFIG[priority];
-                    const isActive = task.priority === priority;
-                    return (
-                      <button
-                        key={priority}
-                        onClick={() => handlePriorityChange(priority)}
-                        disabled={updatingPriority}
-                        style={{
-                          display: 'inline-flex',
-                          alignItems: 'center',
-                          borderRadius: 9999,
-                          padding: '4px 10px',
-                          fontSize: 11,
-                          fontWeight: 600,
-                          textTransform: 'uppercase',
-                          letterSpacing: '0.05em',
-                          cursor: updatingPriority ? 'not-allowed' : 'pointer',
-                          opacity: updatingPriority ? 0.5 : 1,
-                          transition: 'all 0.15s',
-                          border: isActive ? `1px solid ${cfg.borderColor}` : '1px solid var(--border-subtle)',
-                          background: isActive ? cfg.bgColor : 'var(--bg-elevated)',
-                          color: isActive ? cfg.color : 'var(--text-muted)',
-                        }}
-                      >
-                        {cfg.label}
-                      </button>
-                    );
-                  })}
-                </div>
-              </Section>
-
-              {/* Description */}
-              {task.description && (
-                <Section title="Description">
-                  <div
-                    style={{
-                      fontSize: 13,
-                      color: 'var(--text-secondary)',
-                      lineHeight: 1.6,
-                      whiteSpace: 'pre-wrap',
-                    }}
-                  >
-                    {task.description}
-                  </div>
-                </Section>
-              )}
-
-              {/* Branch + Worktree */}
-              {(task.branch || task.worktree_path) && (
-                <Section title="Git">
-                  <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-                    {task.branch && (
-                      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                        <span style={{ fontSize: 11, color: 'var(--text-muted)', width: 60, flexShrink: 0 }}>Branch</span>
-                        {repoUrl ? (
-                          <a
-                            href={`${repoUrl}/tree/${task.branch}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
+              {/* ─── OVERVIEW TAB ─── */}
+              {activeTab === 'overview' && (
+                <>
+                  {/* Status */}
+                  <Section title="Status">
+                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                      {COLUMNS.map(status => {
+                        const meta = COLUMN_META[status];
+                        const isActive = task.status === status;
+                        return (
+                          <button
+                            key={status}
+                            onClick={() => handleStatusChange(status)}
+                            disabled={updatingStatus}
                             style={{
-                              fontSize: 12,
-                              color: 'var(--text-secondary)',
-                              background: 'var(--bg-elevated)',
-                              borderRadius: 4,
-                              padding: '2px 6px',
-                              border: '1px solid var(--border-subtle)',
-                              textDecoration: 'none',
+                              ...(isActive ? pillActive : pillBase),
+                              opacity: updatingStatus ? 0.5 : 1,
+                              cursor: updatingStatus ? 'not-allowed' : 'pointer',
+                            }}
+                          >
+                            <span
+                              style={{
+                                width: 8,
+                                height: 8,
+                                borderRadius: '50%',
+                                background: meta.color,
+                                display: 'inline-block',
+                              }}
+                            />
+                            {meta.label}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </Section>
+
+                  {/* Priority */}
+                  <Section title="Priority">
+                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                      {(Object.keys(PRIORITY_CONFIG) as TaskPriority[]).map(priority => {
+                        const cfg = PRIORITY_CONFIG[priority];
+                        const isActive = task.priority === priority;
+                        return (
+                          <button
+                            key={priority}
+                            onClick={() => handlePriorityChange(priority)}
+                            disabled={updatingPriority}
+                            style={{
                               display: 'inline-flex',
                               alignItems: 'center',
-                              gap: 4,
+                              borderRadius: 9999,
+                              padding: '4px 10px',
+                              fontSize: 11,
+                              fontWeight: 600,
+                              textTransform: 'uppercase',
+                              letterSpacing: '0.05em',
+                              cursor: updatingPriority ? 'not-allowed' : 'pointer',
+                              opacity: updatingPriority ? 0.5 : 1,
+                              transition: 'all 0.15s',
+                              border: isActive ? `1px solid ${cfg.borderColor}` : '1px solid var(--border-subtle)',
+                              background: isActive ? cfg.bgColor : 'var(--bg-elevated)',
+                              color: isActive ? cfg.color : 'var(--text-muted)',
                             }}
                           >
-                            {task.branch}
-                            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ opacity: 0.6 }}>
-                              <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6" />
-                              <polyline points="15 3 21 3 21 9" />
-                              <line x1="10" y1="14" x2="21" y2="3" />
-                            </svg>
-                          </a>
-                        ) : (
-                          <code
+                            {cfg.label}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </Section>
+
+                  {/* Category */}
+                  <Section title="Category">
+                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                      {(Object.keys(CATEGORY_CONFIG) as TaskCategory[]).map(cat => {
+                        const cfg = CATEGORY_CONFIG[cat];
+                        const isActive = task.category === cat;
+                        return (
+                          <button
+                            key={cat}
+                            onClick={() => handleCategoryChange(cat)}
+                            disabled={updatingCategory}
                             style={{
-                              fontSize: 12,
-                              color: 'var(--text-secondary)',
-                              background: 'var(--bg-elevated)',
-                              borderRadius: 4,
-                              padding: '2px 6px',
-                              border: '1px solid var(--border-subtle)',
+                              ...pillBase,
+                              borderColor: isActive ? `${cfg.color}66` : 'var(--border-subtle)',
+                              background: isActive ? `${cfg.color}15` : 'var(--bg-elevated)',
+                              color: isActive ? cfg.color : 'var(--text-muted)',
+                              fontSize: 11,
+                              fontWeight: isActive ? 600 : 500,
+                              opacity: updatingCategory ? 0.5 : 1,
+                              cursor: updatingCategory ? 'not-allowed' : 'pointer',
                             }}
                           >
-                            {task.branch}
-                          </code>
+                            {cfg.label}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </Section>
+
+                  {/* Complexity */}
+                  <Section title="Complexity">
+                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                      {(Object.keys(COMPLEXITY_CONFIG) as TaskComplexity[]).map(cplx => {
+                        const isActive = task.complexity === cplx;
+                        return (
+                          <button
+                            key={cplx}
+                            onClick={() => handleComplexityChange(cplx)}
+                            disabled={updatingComplexity}
+                            style={{
+                              ...(isActive ? pillActive : pillBase),
+                              opacity: updatingComplexity ? 0.5 : 1,
+                              cursor: updatingComplexity ? 'not-allowed' : 'pointer',
+                            }}
+                          >
+                            {COMPLEXITY_CONFIG[cplx].label}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </Section>
+
+                  {/* Description */}
+                  {task.description && (
+                    <Section title="Description">
+                      <div
+                        style={{
+                          fontSize: 13,
+                          color: 'var(--text-secondary)',
+                          lineHeight: 1.6,
+                          whiteSpace: 'pre-wrap',
+                        }}
+                      >
+                        {task.description}
+                      </div>
+                    </Section>
+                  )}
+
+                  {/* Branch + Worktree */}
+                  {(task.branch || task.worktree_path) && (
+                    <Section title="Git">
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                        {task.branch && (
+                          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                            <span style={{ fontSize: 11, color: 'var(--text-muted)', width: 60, flexShrink: 0 }}>Branch</span>
+                            {repoUrl ? (
+                              <a
+                                href={`${repoUrl}/tree/${task.branch}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                style={{
+                                  fontSize: 12,
+                                  color: 'var(--text-secondary)',
+                                  background: 'var(--bg-elevated)',
+                                  borderRadius: 4,
+                                  padding: '2px 6px',
+                                  border: '1px solid var(--border-subtle)',
+                                  textDecoration: 'none',
+                                  display: 'inline-flex',
+                                  alignItems: 'center',
+                                  gap: 4,
+                                }}
+                              >
+                                {task.branch}
+                                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ opacity: 0.6 }}>
+                                  <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6" />
+                                  <polyline points="15 3 21 3 21 9" />
+                                  <line x1="10" y1="14" x2="21" y2="3" />
+                                </svg>
+                              </a>
+                            ) : (
+                              <code
+                                style={{
+                                  fontSize: 12,
+                                  color: 'var(--text-secondary)',
+                                  background: 'var(--bg-elevated)',
+                                  borderRadius: 4,
+                                  padding: '2px 6px',
+                                  border: '1px solid var(--border-subtle)',
+                                }}
+                              >
+                                {task.branch}
+                              </code>
+                            )}
+                          </div>
+                        )}
+                        {task.worktree_path && (
+                          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                            <span style={{ fontSize: 11, color: 'var(--text-muted)', width: 60, flexShrink: 0 }}>Worktree</span>
+                            <code
+                              style={{
+                                fontSize: 11,
+                                color: 'var(--text-muted)',
+                                background: 'var(--bg-elevated)',
+                                borderRadius: 4,
+                                padding: '2px 6px',
+                                border: '1px solid var(--border-subtle)',
+                                wordBreak: 'break-all',
+                              }}
+                            >
+                              {task.worktree_path}
+                            </code>
+                            <button
+                              onClick={() => {
+                                navigator.clipboard.writeText(task.worktree_path!);
+                                setCopied(true);
+                                setTimeout(() => setCopied(false), 1500);
+                              }}
+                              title="Copy path"
+                              style={{
+                                background: 'transparent',
+                                border: 'none',
+                                color: 'var(--text-muted)',
+                                cursor: 'pointer',
+                                fontSize: 11,
+                                padding: '2px 4px',
+                                borderRadius: 4,
+                              }}
+                            >
+                              {copied ? 'Copied!' : '\u2398'}
+                            </button>
+                          </div>
                         )}
                       </div>
-                    )}
-                    {task.worktree_path && (
-                      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                        <span style={{ fontSize: 11, color: 'var(--text-muted)', width: 60, flexShrink: 0 }}>Worktree</span>
-                        <code
-                          style={{
-                            fontSize: 11,
-                            color: 'var(--text-muted)',
-                            background: 'var(--bg-elevated)',
-                            borderRadius: 4,
-                            padding: '2px 6px',
-                            border: '1px solid var(--border-subtle)',
-                            wordBreak: 'break-all',
-                          }}
-                        >
-                          {task.worktree_path}
-                        </code>
-                        <button
-                          onClick={() => {
-                            navigator.clipboard.writeText(task.worktree_path!);
-                            setCopied(true);
-                            setTimeout(() => setCopied(false), 1500);
-                          }}
-                          title="Copy path"
-                          style={{
-                            background: 'transparent',
-                            border: 'none',
-                            color: 'var(--text-muted)',
-                            cursor: 'pointer',
-                            fontSize: 11,
-                            padding: '2px 4px',
-                            borderRadius: 4,
-                          }}
-                        >
-                          {copied ? 'Copied!' : '\u2398'}
-                        </button>
+                    </Section>
+                  )}
+
+                  {/* Linked commits */}
+                  {task.linked_commits.length > 0 && (
+                    <Section title={`Commits (${task.linked_commits.length})`}>
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                        {task.linked_commits.map(sha => (
+                          repoUrl ? (
+                            <a
+                              key={sha}
+                              href={`${repoUrl}/commit/${sha}`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              style={{
+                                fontSize: 12,
+                                color: 'var(--text-secondary)',
+                                background: 'var(--bg-elevated)',
+                                borderRadius: 4,
+                                padding: '2px 6px',
+                                border: '1px solid var(--border-subtle)',
+                                fontFamily: 'monospace',
+                                textDecoration: 'none',
+                                display: 'inline-flex',
+                                alignItems: 'center',
+                                gap: 4,
+                                width: 'fit-content',
+                              }}
+                            >
+                              {sha.slice(0, 8)}
+                              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ opacity: 0.6 }}>
+                                <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6" />
+                                <polyline points="15 3 21 3 21 9" />
+                                <line x1="10" y1="14" x2="21" y2="3" />
+                              </svg>
+                            </a>
+                          ) : (
+                            <code
+                              key={sha}
+                              style={{
+                                fontSize: 12,
+                                color: 'var(--text-secondary)',
+                                background: 'var(--bg-elevated)',
+                                borderRadius: 4,
+                                padding: '2px 6px',
+                                border: '1px solid var(--border-subtle)',
+                                fontFamily: 'monospace',
+                              }}
+                            >
+                              {sha.slice(0, 12)}
+                            </code>
+                          )
+                        ))}
                       </div>
-                    )}
+                    </Section>
+                  )}
+
+                  {/* Blocked reason */}
+                  {task.blocked && task.blocked_reason && (
+                    <Section title="Blocked reason">
+                      <div
+                        style={{
+                          fontSize: 13,
+                          color: 'var(--blocked)',
+                          background: 'rgba(220,38,38,0.08)',
+                          borderRadius: 6,
+                          padding: '8px 10px',
+                          border: '1px solid rgba(220,38,38,0.2)',
+                        }}
+                      >
+                        {task.blocked_reason}
+                      </div>
+                    </Section>
+                  )}
+
+                  {/* Timestamps */}
+                  <div style={{ fontSize: 11, color: 'var(--text-muted)', display: 'flex', gap: 16 }}>
+                    <span>Created {new Date(task.created_at).toLocaleDateString()}</span>
+                    <span>Updated {new Date(task.updated_at).toLocaleDateString()}</span>
                   </div>
-                </Section>
+                </>
               )}
 
-              {/* Linked commits */}
-              {task.linked_commits.length > 0 && (
-                <Section title={`Commits (${task.linked_commits.length})`}>
-                  <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-                    {task.linked_commits.map(sha => (
-                      repoUrl ? (
-                        <a
-                          key={sha}
-                          href={`${repoUrl}/commit/${sha}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          style={{
-                            fontSize: 12,
-                            color: 'var(--text-secondary)',
-                            background: 'var(--bg-elevated)',
-                            borderRadius: 4,
-                            padding: '2px 6px',
-                            border: '1px solid var(--border-subtle)',
-                            fontFamily: 'monospace',
-                            textDecoration: 'none',
-                            display: 'inline-flex',
-                            alignItems: 'center',
-                            gap: 4,
-                            width: 'fit-content',
-                          }}
-                        >
-                          {sha.slice(0, 8)}
-                          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ opacity: 0.6 }}>
-                            <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6" />
-                            <polyline points="15 3 21 3 21 9" />
-                            <line x1="10" y1="14" x2="21" y2="3" />
-                          </svg>
-                        </a>
-                      ) : (
-                        <code
-                          key={sha}
-                          style={{
-                            fontSize: 12,
-                            color: 'var(--text-secondary)',
-                            background: 'var(--bg-elevated)',
-                            borderRadius: 4,
-                            padding: '2px 6px',
-                            border: '1px solid var(--border-subtle)',
-                            fontFamily: 'monospace',
-                          }}
-                        >
-                          {sha.slice(0, 12)}
-                        </code>
-                      )
-                    ))}
-                  </div>
-                </Section>
+              {/* ─── SUBTASKS TAB ─── */}
+              {activeTab === 'subtasks' && (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+                  {(task.subtasks?.length ?? 0) > 0 && (
+                    <ProgressBar
+                      completed={task.subtasks?.filter(s => s.status === 'completed').length ?? 0}
+                      total={task.subtasks?.length ?? 0}
+                      height={6}
+                    />
+                  )}
+                  <SubtaskList
+                    subtasks={task.subtasks ?? []}
+                    projectSlug={projectSlug}
+                    taskId={task.id}
+                    onUpdated={onTaskUpdated}
+                  />
+                </div>
               )}
 
-              {/* Blocked reason */}
-              {task.blocked && task.blocked_reason && (
-                <Section title="Blocked reason">
-                  <div
-                    style={{
-                      fontSize: 13,
-                      color: 'var(--blocked)',
-                      background: 'rgba(220,38,38,0.08)',
-                      borderRadius: 6,
-                      padding: '8px 10px',
-                      border: '1px solid rgba(220,38,38,0.2)',
-                    }}
-                  >
-                    {task.blocked_reason}
-                  </div>
+              {/* ─── ACTIVITY TAB ─── */}
+              {activeTab === 'activity' && (
+                <Section title={`Comments (${task.comments.length})`}>
+                  <CommentThread comments={task.comments} onAdd={handleAddComment} />
                 </Section>
               )}
-
-              {/* Comments */}
-              <Section title={`Comments (${task.comments.length})`}>
-                <CommentThread comments={task.comments} onAdd={handleAddComment} />
-              </Section>
-
-              {/* Timestamps */}
-              <div style={{ fontSize: 11, color: 'var(--text-muted)', display: 'flex', gap: 16 }}>
-                <span>Created {new Date(task.created_at).toLocaleDateString()}</span>
-                <span>Updated {new Date(task.updated_at).toLocaleDateString()}</span>
-              </div>
             </div>
           </motion.aside>
         </div>

--- a/apps/desktop/src/components/board/TaskForm.tsx
+++ b/apps/desktop/src/components/board/TaskForm.tsx
@@ -292,7 +292,7 @@ export function TaskForm({ open, projectSlug, epics, defaultEpicId, defaultStatu
                     opacity: submitting ? 0.6 : 1,
                   }}
                 >
-                  {submitting ? 'Creating\u2026' : 'Create task'}
+                  {submitting ? 'Creating...' : 'Create task'}
                 </button>
               </div>
             </form>

--- a/apps/desktop/src/contexts/ExecutionContext.tsx
+++ b/apps/desktop/src/contexts/ExecutionContext.tsx
@@ -1,0 +1,19 @@
+import { createContext, useContext, type ReactNode } from 'react';
+import { useTaskExecution, type UseTaskExecutionReturn } from '../hooks/useTaskExecution';
+
+const ExecutionContext = createContext<UseTaskExecutionReturn | null>(null);
+
+export function ExecutionProvider({ children }: { children: ReactNode }) {
+  const execution = useTaskExecution();
+  return (
+    <ExecutionContext.Provider value={execution}>
+      {children}
+    </ExecutionContext.Provider>
+  );
+}
+
+export function useExecution(): UseTaskExecutionReturn {
+  const ctx = useContext(ExecutionContext);
+  if (!ctx) throw new Error('useExecution must be used inside ExecutionProvider');
+  return ctx;
+}

--- a/apps/desktop/src/hooks/useTaskExecution.ts
+++ b/apps/desktop/src/hooks/useTaskExecution.ts
@@ -1,0 +1,197 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
+import { api } from '../lib/board-api';
+import { buildInvokeCommand } from '../lib/harness-definitions';
+import type { Task, Project, ExecutionStatus } from '../lib/board-api';
+
+// ── Types ────────────────────────────────────────────────────
+
+interface ActiveExecution {
+  terminalId: string;
+  rawChunks: string[];
+  harnessId: string;
+  model?: string;
+  startedAt: number;
+}
+
+interface TerminalOutputPayload {
+  terminalId: string;
+  data: string;
+}
+
+interface TerminalExitPayload {
+  terminalId: string;
+  exitCode: number;
+}
+
+export interface UseTaskExecutionReturn {
+  startTask: (projectSlug: string, task: Task, project: Project, harnessId?: string, model?: string) => Promise<void>;
+  stopTask: (projectSlug: string, taskId: number) => Promise<void>;
+  getOutput: (taskId: number) => string[];
+  isRunning: (taskId: number) => boolean;
+  getExecution: (taskId: number) => ActiveExecution | undefined;
+  canStartMore: (project: Project) => boolean;
+  outputTick: number;
+}
+
+// ── Constants ────────────────────────────────────────────────
+
+const MAX_RAW_CHUNKS = 5000;
+const DEFAULT_MAX_CONCURRENT = 3;
+
+// ── Prompt builder ───────────────────────────────────────────
+
+function buildPrompt(task: Task): string {
+  let prompt = `Work on board task #${task.id}: ${task.title}`;
+  if (task.description) prompt += `\n\n${task.description}`;
+  const pending = task.subtasks.filter(s => s.status === 'pending' || s.status === 'in_progress');
+  if (pending.length > 0) {
+    prompt += `\n\nPending subtasks:\n${pending.map(s => `- ${s.title}`).join('\n')}`;
+  }
+  return prompt;
+}
+
+// ── Hook ─────────────────────────────────────────────────────
+
+export function useTaskExecution(): UseTaskExecutionReturn {
+  // taskId → ActiveExecution
+  const executionsRef = useRef<Map<number, ActiveExecution>>(new Map());
+  // terminalId → taskId (for reverse lookup in event handlers)
+  const terminalToTaskRef = useRef<Map<string, number>>(new Map());
+  // projectSlug for each taskId (needed in exit handler)
+  const taskProjectRef = useRef<Map<number, string>>(new Map());
+
+  const [outputTick, setOutputTick] = useState(0);
+
+  // ── Event listeners (registered once) ───────────────────────
+
+  useEffect(() => {
+    const unlistenOutput = listen<TerminalOutputPayload>('terminal://output', (event) => {
+      const { terminalId, data } = event.payload;
+      const taskId = terminalToTaskRef.current.get(terminalId);
+      if (taskId === undefined) return;
+      const exec = executionsRef.current.get(taskId);
+      if (!exec) return;
+      exec.rawChunks.push(data);
+      if (exec.rawChunks.length > MAX_RAW_CHUNKS) {
+        exec.rawChunks.splice(0, exec.rawChunks.length - MAX_RAW_CHUNKS);
+      }
+      setOutputTick(t => (t + 1) & 0x7fffffff);
+    });
+
+    const unlistenExit = listen<TerminalExitPayload>('terminal://exit', async (event) => {
+      const { terminalId, exitCode } = event.payload;
+      const taskId = terminalToTaskRef.current.get(terminalId);
+      if (taskId === undefined) return;
+
+      const slug = taskProjectRef.current.get(taskId);
+      executionsRef.current.delete(taskId);
+      terminalToTaskRef.current.delete(terminalId);
+      taskProjectRef.current.delete(taskId);
+      setOutputTick(t => (t + 1) & 0x7fffffff);
+
+      if (slug) {
+        const status: ExecutionStatus = exitCode === 0 ? 'completed' : 'failed';
+        await api.tasks.updateExecution(slug, taskId, {
+          status,
+          finished_at: new Date().toISOString(),
+          exit_code: exitCode,
+        }).catch(console.error);
+      }
+    });
+
+    return () => {
+      unlistenOutput.then(fn => fn());
+      unlistenExit.then(fn => fn());
+    };
+  }, []);
+
+  // ── startTask ────────────────────────────────────────────────
+
+  const startTask = useCallback(async (
+    projectSlug: string,
+    task: Task,
+    project: Project,
+    harnessId?: string,
+    model?: string,
+  ) => {
+    const maxConcurrent = project.max_concurrent ?? DEFAULT_MAX_CONCURRENT;
+    if (executionsRef.current.size >= maxConcurrent) {
+      throw new Error(`Concurrent task limit (${maxConcurrent}) reached`);
+    }
+
+    const resolvedHarness = harnessId ?? task.default_harness ?? project.default_harness ?? 'claude';
+    const resolvedModel = model ?? task.default_model ?? project.default_model ?? undefined;
+
+    const workDir = task.worktree_path ?? undefined;
+    const terminalId = await invoke<string>('create_terminal', { projectPath: workDir ?? '' });
+
+    const prompt = buildPrompt(task);
+    const command = buildInvokeCommand(resolvedHarness, prompt, resolvedModel);
+    if (!command) throw new Error(`Unknown harness: ${resolvedHarness}`);
+
+    executionsRef.current.set(task.id, {
+      terminalId,
+      rawChunks: [],
+      harnessId: resolvedHarness,
+      model: resolvedModel,
+      startedAt: Date.now(),
+    });
+    terminalToTaskRef.current.set(terminalId, task.id);
+    taskProjectRef.current.set(task.id, projectSlug);
+    setOutputTick(t => (t + 1) & 0x7fffffff);
+
+    await invoke('write_terminal', { terminalId, data: command + '\n' });
+
+    await Promise.all([
+      api.tasks.updateExecution(projectSlug, task.id, {
+        status: 'running',
+        harness_id: resolvedHarness,
+        model: resolvedModel,
+        started_at: new Date().toISOString(),
+      }),
+      api.tasks.update(projectSlug, task.id, { status: 'in-progress' }),
+    ]);
+  }, []);
+
+  // ── stopTask ─────────────────────────────────────────────────
+
+  const stopTask = useCallback(async (projectSlug: string, taskId: number) => {
+    const exec = executionsRef.current.get(taskId);
+    if (!exec) return;
+
+    await invoke('destroy_terminal', { terminalId: exec.terminalId }).catch(console.error);
+
+    executionsRef.current.delete(taskId);
+    terminalToTaskRef.current.delete(exec.terminalId);
+    taskProjectRef.current.delete(taskId);
+    setOutputTick(t => (t + 1) & 0x7fffffff);
+
+    await api.tasks.updateExecution(projectSlug, taskId, {
+      status: 'stopped',
+      finished_at: new Date().toISOString(),
+    }).catch(console.error);
+  }, []);
+
+  // ── Accessors ────────────────────────────────────────────────
+
+  const getOutput = useCallback((taskId: number): string[] => {
+    return executionsRef.current.get(taskId)?.rawChunks ?? [];
+  }, []);
+
+  const isRunning = useCallback((taskId: number): boolean => {
+    return executionsRef.current.has(taskId);
+  }, []);
+
+  const getExecution = useCallback((taskId: number): ActiveExecution | undefined => {
+    return executionsRef.current.get(taskId);
+  }, []);
+
+  const canStartMore = useCallback((project: Project): boolean => {
+    const max = project.max_concurrent ?? DEFAULT_MAX_CONCURRENT;
+    return executionsRef.current.size < max;
+  }, []);
+
+  return { startTask, stopTask, getOutput, isRunning, getExecution, canStartMore, outputTick };
+}

--- a/apps/desktop/src/lib/board-api.ts
+++ b/apps/desktop/src/lib/board-api.ts
@@ -22,6 +22,8 @@ export const api = {
       apiFetch<Project>('/projects', { method: 'POST', body: JSON.stringify(body) }),
     update: (slug: string, body: Partial<Pick<Project, 'description' | 'color' | 'repo_url'>>) =>
       apiFetch<Project>(`/projects/${slug}`, { method: 'PATCH', body: JSON.stringify(body) }),
+    updateSettings: (slug: string, body: Partial<Pick<Project, 'default_harness' | 'default_model' | 'max_concurrent'>>) =>
+      apiFetch<Project>(`/projects/${slug}/settings`, { method: 'PATCH', body: JSON.stringify(body) }),
   },
   epics: {
     create: (slug: string, body: { name: string; description?: string }) =>
@@ -39,10 +41,31 @@ export const api = {
         method: 'POST',
         body: JSON.stringify(body),
       }),
-    update: (slug: string, taskId: number, body: Partial<Pick<Task, 'title' | 'description' | 'status' | 'priority' | 'no_worktree'>>) =>
+    update: (slug: string, taskId: number, body: Partial<Pick<Task, 'title' | 'description' | 'status' | 'priority' | 'category' | 'complexity' | 'no_worktree' | 'default_harness' | 'default_model'>>) =>
       apiFetch<Task>(`/projects/${slug}/tasks/${taskId}`, {
         method: 'PATCH',
         body: JSON.stringify(body),
+      }),
+    updateExecution: (slug: string, taskId: number, body: Partial<Omit<TaskExecution, 'terminal_id'>>) =>
+      apiFetch<Task>(`/projects/${slug}/tasks/${taskId}/execution`, {
+        method: 'PATCH',
+        body: JSON.stringify(body),
+      }),
+  },
+  subtasks: {
+    create: (slug: string, taskId: number, body: { title: string; description?: string }) =>
+      apiFetch<Subtask>(`/projects/${slug}/tasks/${taskId}/subtasks`, {
+        method: 'POST',
+        body: JSON.stringify(body),
+      }),
+    update: (slug: string, taskId: number, subtaskId: number, body: Partial<Pick<Subtask, 'title' | 'description' | 'status'>>) =>
+      apiFetch<Subtask>(`/projects/${slug}/tasks/${taskId}/subtasks/${subtaskId}`, {
+        method: 'PATCH',
+        body: JSON.stringify(body),
+      }),
+    remove: (slug: string, taskId: number, subtaskId: number) =>
+      apiFetch<void>(`/projects/${slug}/tasks/${taskId}/subtasks/${subtaskId}`, {
+        method: 'DELETE',
       }),
   },
   comments: {
@@ -58,6 +81,27 @@ export const api = {
 export type TaskPriority = 'low' | 'medium' | 'high' | 'critical';
 export type TaskStatus = 'backlog' | 'planning' | 'in-progress' | 'ai-review' | 'human-review' | 'done';
 export type EpicStatus = 'active' | 'completed' | 'archived';
+export type SubtaskStatus = 'pending' | 'in_progress' | 'completed' | 'failed';
+export type TaskCategory = 'feature' | 'bug_fix' | 'refactoring' | 'docs' | 'security' | 'performance' | 'ui_ux' | 'infrastructure' | 'testing';
+export type TaskComplexity = 'trivial' | 'small' | 'medium' | 'large' | 'complex';
+export type ExecutionStatus = 'idle' | 'running' | 'completed' | 'failed' | 'stopped';
+
+export interface TaskExecution {
+  status: ExecutionStatus;
+  harness_id: string;
+  model?: string;
+  started_at?: string;
+  finished_at?: string;
+  exit_code?: number;
+}
+
+export interface Subtask {
+  id: number;
+  title: string;
+  description?: string;
+  status: SubtaskStatus;
+  files: string[];
+}
 
 export interface Comment {
   author: 'claude' | 'user';
@@ -78,6 +122,13 @@ export interface Task {
   no_worktree?: boolean;
   blocked?: boolean;
   blocked_reason?: string;
+  category?: TaskCategory;
+  complexity?: TaskComplexity;
+  subtasks: Subtask[];
+  next_subtask_id: number;
+  execution?: TaskExecution;
+  default_harness?: string;
+  default_model?: string;
   created_at: string;
   updated_at: string;
   // enriched by list_tasks
@@ -105,6 +156,9 @@ export interface Project {
   next_id: number;
   version: 1;
   epics: Epic[];
+  default_harness?: string;
+  default_model?: string;
+  max_concurrent?: number;
   created_at: string;
   updated_at: string;
 }

--- a/apps/desktop/src/lib/board-task-meta.ts
+++ b/apps/desktop/src/lib/board-task-meta.ts
@@ -1,0 +1,21 @@
+import type { TaskCategory, TaskComplexity } from './board-api';
+
+export const CATEGORY_CONFIG: Record<TaskCategory, { label: string; color: string }> = {
+  feature:        { label: 'Feature',  color: '#8b5cf6' },
+  bug_fix:        { label: 'Bug Fix',  color: '#ef4444' },
+  refactoring:    { label: 'Refactor', color: '#06b6d4' },
+  docs:           { label: 'Docs',     color: '#64748b' },
+  security:       { label: 'Security', color: '#f97316' },
+  performance:    { label: 'Perf',     color: '#eab308' },
+  ui_ux:          { label: 'UI/UX',    color: '#ec4899' },
+  infrastructure: { label: 'Infra',    color: '#6366f1' },
+  testing:        { label: 'Testing',  color: '#14b8a6' },
+};
+
+export const COMPLEXITY_CONFIG: Record<TaskComplexity, { label: string; dots: number }> = {
+  trivial: { label: 'Trivial', dots: 1 },
+  small:   { label: 'Small',   dots: 2 },
+  medium:  { label: 'Medium',  dots: 3 },
+  large:   { label: 'Large',   dots: 4 },
+  complex: { label: 'Complex', dots: 5 },
+};

--- a/apps/desktop/src/lib/harness-definitions.ts
+++ b/apps/desktop/src/lib/harness-definitions.ts
@@ -3,10 +3,12 @@
 /** Wrap a string in single quotes with proper escaping for POSIX shells. */
 export function shellQuote(s: string): string {
   if (s.length === 0) return "''";
+  // Strip null bytes (would truncate shell arguments and enable injection)
+  const clean = s.replace(/\0/g, '');
   // If the string contains no special characters, return as-is.
-  if (!/['\s"\\$`!#&|;()<>]/.test(s)) return s;
+  if (!/['\s"\\$`!#&|;()<>]/.test(clean)) return clean;
   // Wrap in single quotes, escaping embedded single quotes: ' → '\''
-  return "'" + s.replace(/'/g, "'\\''") + "'";
+  return "'" + clean.replace(/'/g, "'\\''") + "'";
 }
 
 // ── Harness definition type ─────────────────────────────────

--- a/apps/desktop/src/lib/harness-definitions.ts
+++ b/apps/desktop/src/lib/harness-definitions.ts
@@ -29,8 +29,13 @@ export const BUILTIN_HARNESSES: HarnessDefinition[] = [
     name: "Claude Code",
     command: "claude",
     buildCommand: (prompt, model) => {
-      // Interactive mode (no -p) gives full TUI with live streaming.
-      const parts = ["claude", shellQuote(prompt)];
+      // Interactive mode with pre-approved tools so the user doesn't have to
+      // click through permission prompts for every standard coding tool.
+      const allowedTools = [
+        'Read', 'Grep', 'Glob',
+        'Agent', 'Skill',
+      ].join(',');
+      const parts = ["claude", shellQuote(prompt), "--allowedTools", allowedTools];
       if (model) parts.push("--model", shellQuote(model));
       return parts.join(" ");
     },
@@ -66,6 +71,16 @@ export const BUILTIN_HARNESSES: HarnessDefinition[] = [
       return parts.join(" ");
     },
   },
+  {
+    id: "opencode",
+    name: "OpenCode",
+    command: "opencode",
+    buildCommand: (prompt, model) => {
+      const parts = ["opencode", shellQuote(prompt)];
+      if (model) parts.push("--model", shellQuote(model));
+      return parts.join(" ");
+    },
+  },
 ];
 
 // ── Lookup + command builder ────────────────────────────────
@@ -84,4 +99,12 @@ export function buildInvokeCommand(
   const def = harnessMap.get(harnessId);
   if (!def) return null;
   return def.buildCommand(prompt, model);
+}
+
+export function getHarness(id: string): HarnessDefinition | undefined {
+  return harnessMap.get(id);
+}
+
+export function getAllHarnesses(): HarnessDefinition[] {
+  return [...BUILTIN_HARNESSES];
 }

--- a/apps/desktop/src/pages/board/BoardKanbanPage.tsx
+++ b/apps/desktop/src/pages/board/BoardKanbanPage.tsx
@@ -17,8 +17,9 @@ import { DroppableColumn } from '../../components/board/DroppableColumn';
 import { SwimlaneView } from '../../components/board/SwimlaneView';
 import { ViewToggle, type ViewMode } from '../../components/board/ViewToggle';
 import { TaskCard } from '../../components/board/TaskCard';
-import { TaskDetailPanel } from '../../components/board/TaskDetailPanel';
+import { TaskDetailDialog } from '../../components/board/TaskDetailDialog';
 import { TaskForm } from '../../components/board/TaskForm';
+import { ExecutionProvider } from '../../contexts/ExecutionContext';
 import { api } from '../../lib/board-api';
 import type { Task, Epic, TaskStatus, Project } from '../../lib/board-api';
 import { COLUMNS } from '../../lib/board-columns';
@@ -205,6 +206,7 @@ export default function BoardKanbanPage() {
   }
 
   return (
+    <ExecutionProvider>
     <div className="board-scope" style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
       {/* Header */}
       <div
@@ -434,9 +436,9 @@ export default function BoardKanbanPage() {
         </DragOverlay>
       </DndContext>
 
-      <TaskDetailPanel
+      <TaskDetailDialog
         task={selectedTask}
-        projectSlug={projectSlug}
+        project={project}
         onClose={() => setSelectedTask(null)}
         onTaskUpdated={refetch}
         repoUrl={project.repo_url}
@@ -452,5 +454,6 @@ export default function BoardKanbanPage() {
         onCreated={refetch}
       />
     </div>
+    </ExecutionProvider>
   );
 }

--- a/packages/board-server/src/http/routes.ts
+++ b/packages/board-server/src/http/routes.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import * as store from '../store/yaml-store.js';
-import type { TaskStatus, TaskPriority, EpicStatus } from '../types.js';
+import type { TaskStatus, TaskPriority, TaskCategory, TaskComplexity, SubtaskStatus, EpicStatus, ExecutionStatus } from '../types.js';
 
 export function createRouter(): Router {
   const router = Router();
@@ -39,6 +39,20 @@ export function createRouter(): Router {
         repo_url?: string;
       };
       const project = store.updateProject(req.params.slug, { description, color, repo_url });
+      res.json(project);
+    } catch (err) {
+      res.status(400).json({ error: String(err) });
+    }
+  });
+
+  router.patch('/projects/:slug/settings', (req, res) => {
+    try {
+      const { default_harness, default_model, max_concurrent } = req.body as {
+        default_harness?: string;
+        default_model?: string;
+        max_concurrent?: number;
+      };
+      const project = store.updateProjectSettings(req.params.slug, { default_harness, default_model, max_concurrent });
       res.json(project);
     } catch (err) {
       res.status(400).json({ error: String(err) });
@@ -107,20 +121,46 @@ export function createRouter(): Router {
   router.patch('/projects/:slug/tasks/:taskId', (req, res) => {
     try {
       const taskId = Number(req.params.taskId);
-      const { title, description, status, priority, no_worktree } = req.body as {
+      const { title, description, status, priority, category, complexity, no_worktree, default_harness, default_model } = req.body as {
         title?: string;
         description?: string;
         status?: TaskStatus;
         priority?: TaskPriority;
+        category?: TaskCategory;
+        complexity?: TaskComplexity;
         no_worktree?: boolean;
+        default_harness?: string;
+        default_model?: string;
       };
-      const updates: Partial<Pick<import('../types.js').Task, 'title' | 'description' | 'status' | 'priority' | 'no_worktree'>> = {};
+      const updates: Partial<Pick<import('../types.js').Task, 'title' | 'description' | 'status' | 'priority' | 'category' | 'complexity' | 'no_worktree' | 'default_harness' | 'default_model'>> = {};
       if (title !== undefined) updates.title = title;
       if (description !== undefined) updates.description = description;
       if (status !== undefined) updates.status = status;
       if (priority !== undefined) updates.priority = priority;
+      if (category !== undefined) updates.category = category;
+      if (complexity !== undefined) updates.complexity = complexity;
       if (no_worktree !== undefined) updates.no_worktree = no_worktree;
+      if (default_harness !== undefined) updates.default_harness = default_harness;
+      if (default_model !== undefined) updates.default_model = default_model;
       const task = store.updateTask(req.params.slug, taskId, updates);
+      res.json(task);
+    } catch (err) {
+      res.status(400).json({ error: String(err) });
+    }
+  });
+
+  router.patch('/projects/:slug/tasks/:taskId/execution', (req, res) => {
+    try {
+      const taskId = Number(req.params.taskId);
+      const { status, harness_id, model, started_at, finished_at, exit_code } = req.body as {
+        status?: ExecutionStatus;
+        harness_id?: string;
+        model?: string;
+        started_at?: string;
+        finished_at?: string;
+        exit_code?: number;
+      };
+      const task = store.updateTaskExecution(req.params.slug, taskId, { status, harness_id, model, started_at, finished_at, exit_code });
       res.json(task);
     } catch (err) {
       res.status(400).json({ error: String(err) });
@@ -136,6 +176,47 @@ export function createRouter(): Router {
       if (!author || !body) return res.status(400).json({ error: 'author and body are required' });
       const comment = store.addComment(req.params.slug, taskId, author, body);
       res.status(201).json(comment);
+    } catch (err) {
+      res.status(400).json({ error: String(err) });
+    }
+  });
+
+  // --- Subtasks ---
+
+  router.post('/projects/:slug/tasks/:taskId/subtasks', (req, res) => {
+    try {
+      const taskId = Number(req.params.taskId);
+      const { title, description } = req.body as { title: string; description?: string };
+      if (!title) return res.status(400).json({ error: 'title is required' });
+      const subtask = store.addSubtask(req.params.slug, taskId, title, description);
+      res.status(201).json(subtask);
+    } catch (err) {
+      res.status(400).json({ error: String(err) });
+    }
+  });
+
+  router.patch('/projects/:slug/tasks/:taskId/subtasks/:subtaskId', (req, res) => {
+    try {
+      const taskId = Number(req.params.taskId);
+      const subtaskId = Number(req.params.subtaskId);
+      const { title, description, status } = req.body as {
+        title?: string;
+        description?: string;
+        status?: SubtaskStatus;
+      };
+      const subtask = store.updateSubtask(req.params.slug, taskId, subtaskId, { title, description, status });
+      res.json(subtask);
+    } catch (err) {
+      res.status(400).json({ error: String(err) });
+    }
+  });
+
+  router.delete('/projects/:slug/tasks/:taskId/subtasks/:subtaskId', (req, res) => {
+    try {
+      const taskId = Number(req.params.taskId);
+      const subtaskId = Number(req.params.subtaskId);
+      store.removeSubtask(req.params.slug, taskId, subtaskId);
+      res.status(204).send();
     } catch (err) {
       res.status(400).json({ error: String(err) });
     }

--- a/packages/board-server/src/http/server.ts
+++ b/packages/board-server/src/http/server.ts
@@ -4,10 +4,15 @@ import { createRouter } from './routes.js';
 export function createHttpApp(): Express {
   const app = express();
 
-  // CORS — allow the Next.js dev server and any localhost origin
+  // CORS — allow localhost origins and the Tauri webview (tauri://localhost)
   app.use((_req, res, next) => {
     const origin = _req.headers.origin;
-    if (origin && (origin.startsWith('http://localhost') || origin.startsWith('http://127.0.0.1'))) {
+    if (
+      origin &&
+      (origin.startsWith('http://localhost') ||
+        origin.startsWith('http://127.0.0.1') ||
+        origin === 'tauri://localhost')
+    ) {
       res.setHeader('Access-Control-Allow-Origin', origin);
     }
     res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PATCH,DELETE,OPTIONS');

--- a/packages/board-server/src/mcp/tools/task.ts
+++ b/packages/board-server/src/mcp/tools/task.ts
@@ -37,7 +37,7 @@ export const taskTools = [
   },
   {
     name: 'update_task',
-    description: 'Update task title, description, or no_worktree flag',
+    description: 'Update task fields: title, description, category, complexity, or no_worktree flag',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -45,6 +45,8 @@ export const taskTools = [
         task_id: { type: 'number', description: 'Task ID' },
         title: { type: 'string', description: 'New title' },
         description: { type: 'string', description: 'New description' },
+        category: { type: 'string', enum: ['feature', 'bug_fix', 'refactoring', 'docs', 'security', 'performance', 'ui_ux', 'infrastructure', 'testing'], description: 'Task category' },
+        complexity: { type: 'string', enum: ['trivial', 'small', 'medium', 'large', 'complex'], description: 'Task complexity' },
         no_worktree: { type: 'boolean', description: 'Disable auto-worktree for this task' },
       },
       required: ['project', 'task_id'],
@@ -54,12 +56,16 @@ export const taskTools = [
       task_id: z.number(),
       title: z.string().optional(),
       description: z.string().optional(),
+      category: z.enum(['feature', 'bug_fix', 'refactoring', 'docs', 'security', 'performance', 'ui_ux', 'infrastructure', 'testing']).optional(),
+      complexity: z.enum(['trivial', 'small', 'medium', 'large', 'complex']).optional(),
       no_worktree: z.boolean().optional(),
     }),
-    handler: async (args: { project: string; task_id: number; title?: string; description?: string; no_worktree?: boolean }) => {
+    handler: async (args: { project: string; task_id: number; title?: string; description?: string; category?: string; complexity?: string; no_worktree?: boolean }) => {
       const task = store.updateTask(args.project, args.task_id, {
         title: args.title,
         description: args.description,
+        category: args.category as import('../../types.js').TaskCategory,
+        complexity: args.complexity as import('../../types.js').TaskComplexity,
         no_worktree: args.no_worktree,
       });
       return { content: [{ type: 'text' as const, text: JSON.stringify(task, null, 2) }] };
@@ -275,6 +281,119 @@ export const taskTools = [
     handler: async (args: { project: string; task_id: number }) => {
       const task = store.unblockTask(args.project, args.task_id);
       return { content: [{ type: 'text' as const, text: JSON.stringify(task, null, 2) }] };
+    },
+  },
+  // --- Subtask tools ---
+  {
+    name: 'add_subtask',
+    description: 'Add a subtask to a task. Subtasks track implementation steps with their own status and associated files.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        project: { type: 'string', description: 'Project slug' },
+        task_id: { type: 'number', description: 'Task ID' },
+        title: { type: 'string', description: 'Subtask title (3-10 words)' },
+        description: { type: 'string', description: 'Detailed implementation notes' },
+      },
+      required: ['project', 'task_id', 'title'],
+    },
+    schema: z.object({
+      project: z.string(),
+      task_id: z.number(),
+      title: z.string(),
+      description: z.string().optional(),
+    }),
+    handler: async (args: { project: string; task_id: number; title: string; description?: string }) => {
+      const subtask = store.addSubtask(args.project, args.task_id, args.title, args.description);
+      const project = store.readProject(args.project);
+      const found = project ? store.findTask(project, args.task_id) : undefined;
+      const task = found?.task;
+      const completed = task?.subtasks.filter(s => s.status === 'completed').length ?? 0;
+      const total = task?.subtasks.length ?? 0;
+      const text = [
+        JSON.stringify(subtask, null, 2),
+        '',
+        `Progress: ${completed}/${total} subtasks complete (${total > 0 ? Math.round(completed / total * 100) : 0}%)`,
+      ].join('\n');
+      return { content: [{ type: 'text' as const, text }] };
+    },
+  },
+  {
+    name: 'update_subtask',
+    description: 'Update a subtask title, description, or status (pending → in_progress → completed/failed)',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        project: { type: 'string', description: 'Project slug' },
+        task_id: { type: 'number', description: 'Task ID' },
+        subtask_id: { type: 'number', description: 'Subtask ID' },
+        title: { type: 'string', description: 'New subtask title' },
+        description: { type: 'string', description: 'New subtask description' },
+        status: { type: 'string', enum: ['pending', 'in_progress', 'completed', 'failed'], description: 'New subtask status' },
+      },
+      required: ['project', 'task_id', 'subtask_id'],
+    },
+    schema: z.object({
+      project: z.string(),
+      task_id: z.number(),
+      subtask_id: z.number(),
+      title: z.string().optional(),
+      description: z.string().optional(),
+      status: z.enum(['pending', 'in_progress', 'completed', 'failed']).optional(),
+    }),
+    handler: async (args: { project: string; task_id: number; subtask_id: number; title?: string; description?: string; status?: string }) => {
+      const subtask = store.updateSubtask(args.project, args.task_id, args.subtask_id, {
+        title: args.title,
+        description: args.description,
+        status: args.status as import('../../types.js').SubtaskStatus,
+      });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(subtask, null, 2) }] };
+    },
+  },
+  {
+    name: 'remove_subtask',
+    description: 'Delete a subtask from a task',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        project: { type: 'string', description: 'Project slug' },
+        task_id: { type: 'number', description: 'Task ID' },
+        subtask_id: { type: 'number', description: 'Subtask ID' },
+      },
+      required: ['project', 'task_id', 'subtask_id'],
+    },
+    schema: z.object({
+      project: z.string(),
+      task_id: z.number(),
+      subtask_id: z.number(),
+    }),
+    handler: async (args: { project: string; task_id: number; subtask_id: number }) => {
+      store.removeSubtask(args.project, args.task_id, args.subtask_id);
+      return { content: [{ type: 'text' as const, text: `Subtask ${args.subtask_id} removed from task ${args.task_id}` }] };
+    },
+  },
+  {
+    name: 'add_subtask_file',
+    description: 'Associate a file path with a subtask (tracks which files a subtask modifies)',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        project: { type: 'string', description: 'Project slug' },
+        task_id: { type: 'number', description: 'Task ID' },
+        subtask_id: { type: 'number', description: 'Subtask ID' },
+        file_path: { type: 'string', description: 'Relative file path' },
+      },
+      required: ['project', 'task_id', 'subtask_id', 'file_path'],
+    },
+    schema: z.object({
+      project: z.string(),
+      task_id: z.number(),
+      subtask_id: z.number(),
+      file_path: z.string(),
+    }),
+    handler: async (args: { project: string; task_id: number; subtask_id: number; file_path: string }) => {
+      const subtask = store.addSubtaskFile(args.project, args.task_id, args.subtask_id, args.file_path);
+      return { content: [{ type: 'text' as const, text: JSON.stringify(subtask, null, 2) }] };
     },
   },
 ] as const;

--- a/packages/board-server/src/store/yaml-store.ts
+++ b/packages/board-server/src/store/yaml-store.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import yaml from 'js-yaml';
-import type { Project, Epic, Task, Comment, TaskStatus, EpicStatus } from '../types.js';
+import type { Project, Epic, Task, Subtask, Comment, TaskStatus, SubtaskStatus, TaskCategory, TaskComplexity, EpicStatus, TaskExecution } from '../types.js';
 
 function getBoardDir(): string {
   if (process.env.NODE_ENV === 'test' && process.env.BOARD_TEST_DIR) {
@@ -38,13 +38,26 @@ function now(): string {
   return new Date().toISOString();
 }
 
+/** Ensure tasks loaded from old YAML files have all required array fields */
+function normalizeTask(task: Task): Task {
+  if (!task.subtasks) task.subtasks = [];
+  if (!task.next_subtask_id) task.next_subtask_id = 1;
+  if (!task.linked_commits) task.linked_commits = [];
+  if (!task.comments) task.comments = [];
+  return task;
+}
+
 // --- Read/Write ---
 
 export function readProject(slug: string): Project | null {
   const filePath = projectPath(slug);
   if (!fs.existsSync(filePath)) return null;
   const raw = fs.readFileSync(filePath, 'utf-8');
-  return yaml.load(raw) as Project;
+  const project = yaml.load(raw) as Project;
+  for (const epic of project.epics) {
+    for (const task of epic.tasks) normalizeTask(task);
+  }
+  return project;
 }
 
 export function writeProject(project: Project): void {
@@ -63,7 +76,11 @@ export function listProjects(): Project[] {
   const files = fs.readdirSync(boardDir).filter(f => f.endsWith('.yaml'));
   return files.map(f => {
     const raw = fs.readFileSync(path.join(boardDir, f), 'utf-8');
-    return yaml.load(raw) as Project;
+    const project = yaml.load(raw) as Project;
+    for (const epic of project.epics) {
+      for (const task of epic.tasks) normalizeTask(task);
+    }
+    return project;
   });
 }
 
@@ -167,6 +184,8 @@ export function createTask(
     status: 'planning',
     linked_commits: [],
     comments: [],
+    subtasks: [],
+    next_subtask_id: 1,
     created_at: ts,
     updated_at: ts,
   };
@@ -202,7 +221,7 @@ function withTask(projectSlug: string, taskId: number, fn: (task: Task, epic: Ep
 export function updateTask(
   projectSlug: string,
   taskId: number,
-  updates: Partial<Pick<Task, 'title' | 'description' | 'status' | 'no_worktree'>>,
+  updates: Partial<Pick<Task, 'title' | 'description' | 'status' | 'priority' | 'category' | 'complexity' | 'no_worktree' | 'default_harness' | 'default_model'>>,
 ): Task {
   // Strip undefined values so we don't wipe existing fields
   const cleanUpdates = Object.fromEntries(Object.entries(updates).filter(([, v]) => v !== undefined));
@@ -253,6 +272,100 @@ export function unblockTask(projectSlug: string, taskId: number): Task {
     task.blocked = false;
     task.blocked_reason = undefined;
   });
+}
+
+export function updateTaskExecution(
+  projectSlug: string,
+  taskId: number,
+  updates: Partial<Omit<TaskExecution, 'terminal_id'>>,
+): Task {
+  const cleanUpdates = Object.fromEntries(Object.entries(updates).filter(([, v]) => v !== undefined));
+  return withTask(projectSlug, taskId, (task) => {
+    if (!task.execution) task.execution = { status: 'idle', harness_id: 'claude' };
+    Object.assign(task.execution, cleanUpdates);
+  });
+}
+
+export function updateProjectSettings(
+  slug: string,
+  updates: Partial<Pick<Project, 'default_harness' | 'default_model' | 'max_concurrent'>>,
+): Project {
+  const project = readProject(slug);
+  if (!project) throw new Error(`Project "${slug}" not found`);
+  const cleanUpdates = Object.fromEntries(Object.entries(updates).filter(([, v]) => v !== undefined));
+  Object.assign(project, cleanUpdates);
+  project.updated_at = now();
+  writeProject(project);
+  return project;
+}
+
+// --- Subtask operations ---
+
+export function addSubtask(
+  projectSlug: string,
+  taskId: number,
+  title: string,
+  description?: string,
+): Subtask {
+  let subtask!: Subtask;
+  withTask(projectSlug, taskId, (task) => {
+    subtask = {
+      id: task.next_subtask_id++,
+      title,
+      description,
+      status: 'pending',
+      files: [],
+    };
+    task.subtasks.push(subtask);
+  });
+  return subtask;
+}
+
+export function updateSubtask(
+  projectSlug: string,
+  taskId: number,
+  subtaskId: number,
+  updates: Partial<Pick<Subtask, 'title' | 'description' | 'status'>>,
+): Subtask {
+  let subtask!: Subtask;
+  const cleanUpdates = Object.fromEntries(
+    Object.entries(updates).filter(([, v]) => v !== undefined),
+  );
+  withTask(projectSlug, taskId, (task) => {
+    const found = task.subtasks.find(s => s.id === subtaskId);
+    if (!found) throw new Error(`Subtask ${subtaskId} not found on task ${taskId}`);
+    Object.assign(found, cleanUpdates);
+    subtask = found;
+  });
+  return subtask;
+}
+
+export function removeSubtask(
+  projectSlug: string,
+  taskId: number,
+  subtaskId: number,
+): void {
+  withTask(projectSlug, taskId, (task) => {
+    const idx = task.subtasks.findIndex(s => s.id === subtaskId);
+    if (idx === -1) throw new Error(`Subtask ${subtaskId} not found on task ${taskId}`);
+    task.subtasks.splice(idx, 1);
+  });
+}
+
+export function addSubtaskFile(
+  projectSlug: string,
+  taskId: number,
+  subtaskId: number,
+  filePath: string,
+): Subtask {
+  let subtask!: Subtask;
+  withTask(projectSlug, taskId, (task) => {
+    const found = task.subtasks.find(s => s.id === subtaskId);
+    if (!found) throw new Error(`Subtask ${subtaskId} not found on task ${taskId}`);
+    if (!found.files.includes(filePath)) found.files.push(filePath);
+    subtask = found;
+  });
+  return subtask;
 }
 
 export type TaskFilter = {

--- a/packages/board-server/src/types.ts
+++ b/packages/board-server/src/types.ts
@@ -2,6 +2,27 @@ export type TaskStatus = 'backlog' | 'planning' | 'in-progress' | 'ai-review' | 
 export type TaskPriority = 'low' | 'medium' | 'high' | 'critical';
 export type EpicStatus = 'active' | 'completed' | 'archived';
 export type CommentAuthor = 'claude' | 'user';
+export type SubtaskStatus = 'pending' | 'in_progress' | 'completed' | 'failed';
+export type TaskCategory = 'feature' | 'bug_fix' | 'refactoring' | 'docs' | 'security' | 'performance' | 'ui_ux' | 'infrastructure' | 'testing';
+export type TaskComplexity = 'trivial' | 'small' | 'medium' | 'large' | 'complex';
+export type ExecutionStatus = 'idle' | 'running' | 'completed' | 'failed' | 'stopped';
+
+export interface TaskExecution {
+  status: ExecutionStatus;
+  harness_id: string;
+  model?: string;
+  started_at?: string;
+  finished_at?: string;
+  exit_code?: number;
+}
+
+export interface Subtask {
+  id: number;
+  title: string;
+  description?: string;
+  status: SubtaskStatus;
+  files: string[];
+}
 
 export interface Comment {
   author: CommentAuthor;
@@ -22,6 +43,13 @@ export interface Task {
   no_worktree?: boolean;
   blocked?: boolean;
   blocked_reason?: string;
+  category?: TaskCategory;
+  complexity?: TaskComplexity;
+  subtasks: Subtask[];
+  next_subtask_id: number;
+  execution?: TaskExecution;
+  default_harness?: string;
+  default_model?: string;
   created_at: string; // ISO 8601
   updated_at: string; // ISO 8601
 }
@@ -45,6 +73,9 @@ export interface Project {
   next_id: number;
   version: 1;
   epics: Epic[];
+  default_harness?: string;
+  default_model?: string;
+  max_concurrent?: number;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary

Adds a harness-agnostic execution engine to the Kanban board, modeled after Aperant's task runner experience. Users can start any CLI harness (Claude Code, OpenCode, Cursor Agent, Copilot, Codex) directly from a task card, with streaming terminal output in a centered Aperant-style dialog.

## Changes

### Execution Engine (Phases 5-7)
- `ExecutionStatus`, `TaskExecution` types with harness/model tracking
- `updateTaskExecution` and `updateProjectSettings` store functions + REST endpoints
- `useTaskExecution` hook managing PTY lifecycle per-task (follows `useComparator` pattern)
- `ExecutionContext` provider sharing execution state across board components
- OpenCode added to harness registry alongside Claude Code, Cursor Agent, Copilot, Codex
- Claude Code pre-approves read-only tools (Read, Grep, Glob) via `--allowedTools` to reduce permission prompts

### Centered Task Dialog (Phases 8-10)
- Replaces right-sliding `TaskDetailPanel` with Aperant-style centered full-height modal
- Portal-rendered (`createPortal`) to bypass layout overflow constraints
- 4 tabs: Overview, Subtasks, Logs, Files
- Logs tab: live xterm.js terminal via `TerminalView` when running
- Files tab: git diff viewer with collapsible syntax-highlighted diffs
- Footer: harness selector, model input, Start/Stop + Close buttons, Delete Task

### Subtask Cards (Aperant-style)
- Card-based layout with status-colored borders and backgrounds
- Status icons (checkmark, clock with pulse, X, circle) + numbered badges (#1, #2)
- "X of Y completed · XX%" progress summary
- Collapsible details with chevron rotation + file pills
- Inline title editing, status cycling, add/delete subtask CRUD

### Data Model Enrichment (Phases 1-4, prior work)
- `Subtask`, `TaskCategory`, `TaskComplexity` types across all 5 layers
- Category (9 values) and complexity (5 values) pill-button selectors
- Progress bar component with fractional display
- Subtask REST endpoints + 4 MCP tools (add/update/remove subtask, add file)

## Test Plan
- [x] Board-server: 130/130 tests passing
- [x] Desktop TypeScript: clean compilation
- [x] Tauri debug build succeeds
- [x] Task card click opens centered dialog (not side panel)
- [x] Start Task spawns Claude Code in PTY with streaming output
- [x] Logs tab shows live xterm.js terminal
- [x] Subtask CRUD works (add, toggle status, edit, delete)
- [ ] CI checks pass

## Notes
- Phases 11-12 (card execution indicators, project settings dialog) are follow-up work
- `execution` field is only written to YAML when explicitly set (not during normalization) to avoid YAML serialization issues
- Files tab uses `get_diff_against_commit` Tauri command — requires a worktree to be linked

---
Generated with [Claude Code](https://claude.com/claude-code)