### PR TITLE
feat(roadmap): AI-driven product roadmap with competitor analysis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ harness-kit/
 │   ├── core/                     ← harness.yaml compile/parse/detect logic
 │   ├── shared/                   ← shared TypeScript types used across apps
 │   ├── ui/                       ← shared React components
-│   ├── board-server/             ← WebSocket server for the kanban board feature
+│   ├── board-server/             ← WebSocket + HTTP server for the Kanban board and Roadmap/Competitor Analysis features
 │   ├── chat-relay/               ← self-hosted WebSocket relay for team chat
 │   └── membrain/                 ← git submodule (siracusa5/membrain) — graph-based memory, excluded from pnpm workspace
 ├── apps/                         ← end-user applications

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -22,6 +22,8 @@ import SecretsPage from "./pages/security/SecretsPage";
 import AuditLogPage from "./pages/security/AuditLogPage";
 import BoardProjectsPage from "./pages/board/BoardProjectsPage";
 import BoardKanbanPage from "./pages/board/BoardKanbanPage";
+import RoadmapProjectsPage from "./pages/roadmap/RoadmapProjectsPage";
+import RoadmapPage from "./pages/roadmap/RoadmapPage";
 import ParityDashboardPage from "./pages/parity/ParityDashboardPage";
 import MemoryDashboardPage from "./pages/memory/MemoryDashboardPage";
 import MemoryGraphPage from "./pages/memory/MemoryGraphPage";
@@ -93,6 +95,10 @@ export default function App() {
           {/* Board */}
           <Route path="board" element={<BoardProjectsPage />} />
           <Route path="board/:slug" element={<BoardKanbanPage />} />
+
+          {/* Roadmap */}
+          <Route path="roadmap" element={<RoadmapProjectsPage />} />
+          <Route path="roadmap/:slug" element={<RoadmapPage />} />
 
           {/* Memory */}
           <Route path="memory" element={<MemoryDashboardPage />} />

--- a/apps/desktop/src/components/board/TaskDetailDialog.tsx
+++ b/apps/desktop/src/components/board/TaskDetailDialog.tsx
@@ -1,6 +1,7 @@
 import { AnimatePresence, motion } from 'framer-motion';
 import { useEffect, useState, useCallback, lazy, Suspense } from 'react';
 import { createPortal } from 'react-dom';
+import { useNavigate } from 'react-router-dom';
 import { invoke } from '@tauri-apps/api/core';
 import type { Task, TaskCategory, TaskComplexity, TaskPriority, TaskStatus } from '../../lib/board-api';
 import type { Project } from '../../lib/board-api';
@@ -71,6 +72,7 @@ function EmptyState({ icon, text }: { icon: string; text: string }) {
 
 export function TaskDetailDialog({ task, project, onClose, onTaskUpdated, repoUrl }: Props) {
   const execution = useExecution();
+  const navigate = useNavigate();
 
   const [copied, setCopied] = useState(false);
   const [updatingStatus, setUpdatingStatus] = useState(false);
@@ -350,6 +352,25 @@ export function TaskDetailDialog({ task, project, onClose, onTaskUpdated, repoUr
                       }}>
                         Blocked
                       </span>
+                    )}
+                    {task.linkedFeatureId && (
+                      <button
+                        onClick={() => { onClose(); navigate(`/roadmap/${project.slug}`); }}
+                        style={{
+                          display: 'inline-flex', alignItems: 'center', gap: 4,
+                          fontSize: 11, fontWeight: 500, cursor: 'pointer',
+                          background: 'rgba(37,99,235,0.08)',
+                          color: '#2563eb',
+                          border: '1px solid rgba(37,99,235,0.25)',
+                          borderRadius: 6, padding: '2px 8px',
+                          transition: 'background 0.1s',
+                        }}
+                        onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(37,99,235,0.15)'; }}
+                        onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(37,99,235,0.08)'; }}
+                        title="View linked roadmap feature"
+                      >
+                        {'↗'} View on Roadmap
+                      </button>
                     )}
                   </div>
                 </div>

--- a/apps/desktop/src/components/roadmap/AddCompetitorDialog.tsx
+++ b/apps/desktop/src/components/roadmap/AddCompetitorDialog.tsx
@@ -1,0 +1,274 @@
+import { useState, useEffect, useRef } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { createPortal } from 'react-dom';
+import type { Competitor, CompetitorRelevance } from '../../lib/roadmap-types';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onAdd: (competitor: Omit<Competitor, 'id'>) => void;
+}
+
+const inputStyle: React.CSSProperties = {
+  background: 'var(--bg-base)',
+  border: '1px solid var(--border)',
+  borderRadius: 6,
+  color: 'var(--fg-base)',
+  fontSize: 13,
+  padding: '8px 10px',
+  fontFamily: 'inherit',
+  outline: 'none',
+  width: '100%',
+  boxSizing: 'border-box',
+};
+
+const labelStyle: React.CSSProperties = {
+  fontSize: 11, fontWeight: 600,
+  color: 'var(--fg-muted)',
+  textTransform: 'uppercase',
+  letterSpacing: '0.06em',
+};
+
+const pillBase: React.CSSProperties = {
+  display: 'inline-flex', alignItems: 'center',
+  borderRadius: 9999, border: '1px solid var(--border-subtle)',
+  padding: '4px 10px', fontSize: 11, fontWeight: 500,
+  cursor: 'pointer', background: 'var(--bg-elevated)',
+  color: 'var(--fg-muted)', transition: 'all 0.12s',
+};
+
+const RELEVANCE_OPTIONS: { value: CompetitorRelevance; label: string; color: string; bg: string; border: string }[] = [
+  { value: 'high',   label: 'High',   color: '#16a34a', bg: 'rgba(22,163,74,0.12)',   border: 'rgba(22,163,74,0.3)' },
+  { value: 'medium', label: 'Medium', color: '#d97706', bg: 'rgba(217,119,6,0.12)',   border: 'rgba(217,119,6,0.3)' },
+  { value: 'low',    label: 'Low',    color: '#9a9892', bg: 'rgba(154,152,146,0.12)', border: 'rgba(154,152,146,0.3)' },
+];
+
+function normalizeUrl(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return trimmed;
+  if (!/^https?:\/\//i.test(trimmed)) return `https://${trimmed}`;
+  return trimmed;
+}
+
+function isValidUrl(url: string): boolean {
+  try { new URL(url); return true; } catch { return false; }
+}
+
+export function AddCompetitorDialog({ open, onOpenChange, onAdd }: Props) {
+  const [name, setName] = useState('');
+  const [url, setUrl] = useState('');
+  const [description, setDescription] = useState('');
+  const [relevance, setRelevance] = useState<CompetitorRelevance>('medium');
+  const [error, setError] = useState('');
+  const nameRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      setName('');
+      setUrl('');
+      setDescription('');
+      setRelevance('medium');
+      setError('');
+      setTimeout(() => nameRef.current?.focus(), 50);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onOpenChange(false);
+    }
+    if (open) window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onOpenChange]);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!name.trim()) { setError('Name is required'); return; }
+    if (!url.trim()) { setError('URL is required'); return; }
+    const normalized = normalizeUrl(url);
+    if (!isValidUrl(normalized)) { setError('Enter a valid URL'); return; }
+    onAdd({
+      name: name.trim(),
+      url: normalized,
+      description: description.trim(),
+      relevance,
+      painPoints: [],
+      strengths: [],
+      marketPosition: '',
+      source: 'manual',
+    });
+    onOpenChange(false);
+  }
+
+  return createPortal(
+    <AnimatePresence>
+      {open && (
+        <div className="board-scope">
+          <motion.div
+            key="backdrop"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            onClick={() => onOpenChange(false)}
+            style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)', zIndex: 50 }}
+          />
+          <motion.div
+            key="dialog"
+            initial={{ opacity: 0, scale: 0.96, y: 8 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.96, y: 8 }}
+            transition={{ type: 'spring', stiffness: 420, damping: 36 }}
+            style={{
+              position: 'fixed',
+              top: '50%', left: '50%',
+              transform: 'translate(-50%, -50%)',
+              width: 460, maxWidth: 'calc(100vw - 32px)',
+              maxHeight: '90vh',
+              background: 'var(--bg-surface)',
+              border: '1px solid var(--border)',
+              borderRadius: 12,
+              boxShadow: 'var(--shadow-popover)',
+              display: 'flex', flexDirection: 'column',
+              overflow: 'hidden',
+              zIndex: 51,
+            }}
+          >
+            <div style={{
+              padding: '18px 20px',
+              borderBottom: '1px solid var(--border-subtle)',
+              display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+              flexShrink: 0,
+            }}>
+              <span style={{ fontSize: 15, fontWeight: 600, color: 'var(--fg-base)' }}>
+                Add Competitor
+              </span>
+              <button
+                onClick={() => onOpenChange(false)}
+                aria-label="Close"
+                style={{
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  width: 28, height: 28, borderRadius: 6,
+                  border: '1px solid var(--border-subtle)',
+                  background: 'transparent',
+                  color: 'var(--fg-muted)', cursor: 'pointer', fontSize: 16,
+                }}
+              >
+                ×
+              </button>
+            </div>
+
+            <form
+              onSubmit={handleSubmit}
+              style={{ flex: 1, overflowY: 'auto', padding: '16px 20px', display: 'flex', flexDirection: 'column', gap: 14 }}
+            >
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                <label style={labelStyle}>
+                  Name <span style={{ color: '#dc2626' }}>*</span>
+                </label>
+                <input
+                  ref={nameRef}
+                  value={name}
+                  onChange={e => setName(e.target.value)}
+                  placeholder="Competitor name"
+                  style={inputStyle}
+                  onFocus={e => { (e.target as HTMLElement).style.borderColor = 'var(--accent)'; }}
+                  onBlur={e => { (e.target as HTMLElement).style.borderColor = 'var(--border)'; }}
+                />
+              </div>
+
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                <label style={labelStyle}>
+                  URL <span style={{ color: '#dc2626' }}>*</span>
+                </label>
+                <input
+                  value={url}
+                  onChange={e => setUrl(e.target.value)}
+                  placeholder="competitor.com"
+                  style={inputStyle}
+                  onFocus={e => { (e.target as HTMLElement).style.borderColor = 'var(--accent)'; }}
+                  onBlur={e => { (e.target as HTMLElement).style.borderColor = 'var(--border)'; }}
+                />
+              </div>
+
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                <label style={labelStyle}>
+                  Description <span style={{ fontWeight: 400, textTransform: 'none', letterSpacing: 0, color: 'var(--fg-muted)' }}>(optional)</span>
+                </label>
+                <textarea
+                  value={description}
+                  onChange={e => setDescription(e.target.value)}
+                  placeholder="Brief description of this competitor"
+                  rows={3}
+                  style={{ ...inputStyle, resize: 'vertical' }}
+                  onFocus={e => { (e.target as HTMLElement).style.borderColor = 'var(--accent)'; }}
+                  onBlur={e => { (e.target as HTMLElement).style.borderColor = 'var(--border)'; }}
+                />
+              </div>
+
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                <label style={labelStyle}>Relevance</label>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                  {RELEVANCE_OPTIONS.map(opt => {
+                    const isActive = relevance === opt.value;
+                    return (
+                      <button
+                        key={opt.value}
+                        type="button"
+                        onClick={() => setRelevance(opt.value)}
+                        style={{
+                          ...pillBase,
+                          border: isActive ? `1px solid ${opt.border}` : '1px solid var(--border-subtle)',
+                          background: isActive ? opt.bg : 'var(--bg-elevated)',
+                          color: isActive ? opt.color : 'var(--fg-muted)',
+                          fontWeight: isActive ? 600 : 500,
+                        }}
+                      >
+                        {opt.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {error && (
+                <div style={{
+                  fontSize: 12, color: '#dc2626',
+                  background: 'rgba(220,38,38,0.08)',
+                  borderRadius: 6, padding: '6px 10px',
+                }}>
+                  {error}
+                </div>
+              )}
+
+              <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, paddingTop: 4 }}>
+                <button
+                  type="button"
+                  onClick={() => onOpenChange(false)}
+                  style={{
+                    padding: '7px 16px', background: 'transparent',
+                    border: '1px solid var(--border)', borderRadius: 6,
+                    color: 'var(--fg-muted)', fontSize: 13, cursor: 'pointer',
+                  }}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  style={{
+                    padding: '7px 20px', background: 'var(--accent)',
+                    border: 'none', borderRadius: 6,
+                    color: '#fff', fontSize: 13, fontWeight: 500, cursor: 'pointer',
+                  }}
+                >
+                  Add Competitor
+                </button>
+              </div>
+            </form>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>,
+    document.body
+  );
+}

--- a/apps/desktop/src/components/roadmap/AddFeatureDialog.tsx
+++ b/apps/desktop/src/components/roadmap/AddFeatureDialog.tsx
@@ -1,0 +1,335 @@
+import { useState, useEffect, useRef } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { createPortal } from 'react-dom';
+import type { RoadmapPhase, RoadmapFeature, RoadmapFeaturePriority } from '../../lib/roadmap-types';
+import { ROADMAP_PRIORITY_CONFIG, ROADMAP_COMPLEXITY_CONFIG, ROADMAP_IMPACT_CONFIG } from '../../lib/roadmap-constants';
+
+interface Props {
+  phases: RoadmapPhase[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onAdd: (feature: Omit<RoadmapFeature, 'id'>) => void;
+}
+
+const inputStyle: React.CSSProperties = {
+  background: 'var(--bg-base)',
+  border: '1px solid var(--border)',
+  borderRadius: 6,
+  color: 'var(--fg-base)',
+  fontSize: 13,
+  padding: '8px 10px',
+  fontFamily: 'inherit',
+  outline: 'none',
+  width: '100%',
+  boxSizing: 'border-box',
+};
+
+const labelStyle: React.CSSProperties = {
+  fontSize: 11, fontWeight: 600,
+  color: 'var(--fg-muted)',
+  textTransform: 'uppercase',
+  letterSpacing: '0.06em',
+};
+
+const pillBase: React.CSSProperties = {
+  display: 'inline-flex', alignItems: 'center', gap: 5,
+  borderRadius: 9999, border: '1px solid var(--border-subtle)',
+  padding: '4px 10px', fontSize: 11, fontWeight: 500,
+  cursor: 'pointer', background: 'var(--bg-elevated)',
+  color: 'var(--fg-muted)', transition: 'all 0.12s',
+};
+
+const PRIORITIES: RoadmapFeaturePriority[] = ['must', 'should', 'could', 'wont'];
+const LEVELS = ['low', 'medium', 'high'] as const;
+
+export function AddFeatureDialog({ phases, open, onOpenChange, onAdd }: Props) {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [rationale, setRationale] = useState('');
+  const [priority, setPriority] = useState<RoadmapFeaturePriority>('should');
+  const [complexity, setComplexity] = useState<'low' | 'medium' | 'high'>('medium');
+  const [impact, setImpact] = useState<'low' | 'medium' | 'high'>('medium');
+  const [phaseId, setPhaseId] = useState('');
+  const [error, setError] = useState('');
+  const titleRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      setTitle('');
+      setDescription('');
+      setRationale('');
+      setPriority('should');
+      setComplexity('medium');
+      setImpact('medium');
+      setPhaseId(phases.length > 0 ? phases[0].id : '');
+      setError('');
+      setTimeout(() => titleRef.current?.focus(), 50);
+    }
+  }, [open, phases]);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onOpenChange(false);
+    }
+    if (open) window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onOpenChange]);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!title.trim()) { setError('Title is required'); return; }
+    if (!phaseId) { setError('Phase is required'); return; }
+    onAdd({
+      title: title.trim(),
+      description: description.trim(),
+      rationale: rationale.trim(),
+      priority,
+      complexity,
+      impact,
+      phaseId,
+      status: 'backlog',
+      dependencies: [],
+      acceptanceCriteria: [],
+      userStories: [],
+      competitorInsightIds: [],
+    });
+    onOpenChange(false);
+  }
+
+  return createPortal(
+    <AnimatePresence>
+      {open && (
+        <div className="board-scope">
+          <motion.div
+            key="backdrop"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            onClick={() => onOpenChange(false)}
+            style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)', zIndex: 50 }}
+          />
+          <motion.div
+            key="dialog"
+            initial={{ opacity: 0, scale: 0.96, y: 8 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.96, y: 8 }}
+            transition={{ type: 'spring', stiffness: 420, damping: 36 }}
+            style={{
+              position: 'fixed',
+              top: '50%', left: '50%',
+              transform: 'translate(-50%, -50%)',
+              width: 520, maxWidth: 'calc(100vw - 32px)',
+              maxHeight: '90vh',
+              background: 'var(--bg-surface)',
+              border: '1px solid var(--border)',
+              borderRadius: 12,
+              boxShadow: 'var(--shadow-popover)',
+              display: 'flex', flexDirection: 'column',
+              overflow: 'hidden',
+              zIndex: 51,
+            }}
+          >
+            <div style={{
+              padding: '18px 20px',
+              borderBottom: '1px solid var(--border-subtle)',
+              display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+              flexShrink: 0,
+            }}>
+              <span style={{ fontSize: 15, fontWeight: 600, color: 'var(--fg-base)' }}>
+                Add Feature
+              </span>
+              <button
+                onClick={() => onOpenChange(false)}
+                aria-label="Close"
+                style={{
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  width: 28, height: 28, borderRadius: 6,
+                  border: '1px solid var(--border-subtle)',
+                  background: 'transparent',
+                  color: 'var(--fg-muted)', cursor: 'pointer', fontSize: 16,
+                }}
+              >
+                ×
+              </button>
+            </div>
+
+            <form
+              onSubmit={handleSubmit}
+              style={{ flex: 1, overflowY: 'auto', padding: '16px 20px', display: 'flex', flexDirection: 'column', gap: 14 }}
+            >
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                <label style={labelStyle}>
+                  Title <span style={{ color: '#dc2626' }}>*</span>
+                </label>
+                <input
+                  ref={titleRef}
+                  value={title}
+                  onChange={e => setTitle(e.target.value)}
+                  placeholder="Feature name"
+                  style={inputStyle}
+                  onFocus={e => { (e.target as HTMLElement).style.borderColor = 'var(--accent)'; }}
+                  onBlur={e => { (e.target as HTMLElement).style.borderColor = 'var(--border)'; }}
+                />
+              </div>
+
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                <label style={labelStyle}>Description</label>
+                <textarea
+                  value={description}
+                  onChange={e => setDescription(e.target.value)}
+                  placeholder="What should this feature do?"
+                  rows={3}
+                  style={{ ...inputStyle, resize: 'vertical' }}
+                  onFocus={e => { (e.target as HTMLElement).style.borderColor = 'var(--accent)'; }}
+                  onBlur={e => { (e.target as HTMLElement).style.borderColor = 'var(--border)'; }}
+                />
+              </div>
+
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                <label style={labelStyle}>Rationale</label>
+                <textarea
+                  value={rationale}
+                  onChange={e => setRationale(e.target.value)}
+                  placeholder="Why is this feature needed?"
+                  rows={2}
+                  style={{ ...inputStyle, resize: 'vertical' }}
+                  onFocus={e => { (e.target as HTMLElement).style.borderColor = 'var(--accent)'; }}
+                  onBlur={e => { (e.target as HTMLElement).style.borderColor = 'var(--border)'; }}
+                />
+              </div>
+
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                <label style={labelStyle}>
+                  Phase <span style={{ color: '#dc2626' }}>*</span>
+                </label>
+                <select
+                  value={phaseId}
+                  onChange={e => setPhaseId(e.target.value)}
+                  style={{ ...inputStyle, appearance: 'none' }}
+                >
+                  {phases.map(p => (
+                    <option key={p.id} value={p.id}>{p.order}. {p.name}</option>
+                  ))}
+                </select>
+              </div>
+
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                <label style={labelStyle}>Priority</label>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                  {PRIORITIES.map(p => {
+                    const cfg = ROADMAP_PRIORITY_CONFIG[p];
+                    const isActive = priority === p;
+                    return (
+                      <button
+                        key={p}
+                        type="button"
+                        onClick={() => setPriority(p)}
+                        style={{
+                          ...pillBase,
+                          border: isActive ? `1px solid ${cfg.border}` : '1px solid var(--border-subtle)',
+                          background: isActive ? cfg.bg : 'var(--bg-elevated)',
+                          color: isActive ? cfg.color : 'var(--fg-muted)',
+                          fontWeight: isActive ? 600 : 500,
+                        }}
+                      >
+                        {cfg.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                <label style={labelStyle}>Complexity</label>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                  {LEVELS.map(l => {
+                    const cfg = ROADMAP_COMPLEXITY_CONFIG[l];
+                    const isActive = complexity === l;
+                    return (
+                      <button
+                        key={l}
+                        type="button"
+                        onClick={() => setComplexity(l)}
+                        style={{
+                          ...pillBase,
+                          border: isActive ? `1px solid ${cfg.color}40` : '1px solid var(--border-subtle)',
+                          background: isActive ? `${cfg.color}18` : 'var(--bg-elevated)',
+                          color: isActive ? cfg.color : 'var(--fg-muted)',
+                          fontWeight: isActive ? 600 : 500,
+                        }}
+                      >
+                        {cfg.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                <label style={labelStyle}>Impact</label>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                  {LEVELS.map(l => {
+                    const cfg = ROADMAP_IMPACT_CONFIG[l];
+                    const isActive = impact === l;
+                    return (
+                      <button
+                        key={l}
+                        type="button"
+                        onClick={() => setImpact(l)}
+                        style={{
+                          ...pillBase,
+                          border: isActive ? `1px solid ${cfg.color}40` : '1px solid var(--border-subtle)',
+                          background: isActive ? `${cfg.color}18` : 'var(--bg-elevated)',
+                          color: isActive ? cfg.color : 'var(--fg-muted)',
+                          fontWeight: isActive ? 600 : 500,
+                        }}
+                      >
+                        {cfg.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {error && (
+                <div style={{
+                  fontSize: 12, color: '#dc2626',
+                  background: 'rgba(220,38,38,0.08)',
+                  borderRadius: 6, padding: '6px 10px',
+                }}>
+                  {error}
+                </div>
+              )}
+
+              <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, paddingTop: 4 }}>
+                <button
+                  type="button"
+                  onClick={() => onOpenChange(false)}
+                  style={{
+                    padding: '7px 16px', background: 'transparent',
+                    border: '1px solid var(--border)', borderRadius: 6,
+                    color: 'var(--fg-muted)', fontSize: 13, cursor: 'pointer',
+                  }}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  style={{
+                    padding: '7px 20px', background: 'var(--accent)',
+                    border: 'none', borderRadius: 6,
+                    color: '#fff', fontSize: 13, fontWeight: 500, cursor: 'pointer',
+                  }}
+                >
+                  Add Feature
+                </button>
+              </div>
+            </form>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>,
+    document.body
+  );
+}

--- a/apps/desktop/src/components/roadmap/CompetitorAnalysisViewer.tsx
+++ b/apps/desktop/src/components/roadmap/CompetitorAnalysisViewer.tsx
@@ -1,0 +1,328 @@
+import { useEffect } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { createPortal } from 'react-dom';
+import type { CompetitorAnalysis, Competitor, PainPointSeverity, CompetitorRelevance } from '../../lib/roadmap-types';
+
+interface Props {
+  analysis: CompetitorAnalysis | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onAddCompetitor: () => void;
+}
+
+const SEVERITY_CONFIG: Record<PainPointSeverity, { color: string; bg: string; border: string }> = {
+  high:   { color: '#dc2626', bg: 'rgba(220,38,38,0.1)',   border: 'rgba(220,38,38,0.2)' },
+  medium: { color: '#d97706', bg: 'rgba(217,119,6,0.1)',   border: 'rgba(217,119,6,0.2)' },
+  low:    { color: '#2563eb', bg: 'rgba(37,99,235,0.1)',   border: 'rgba(37,99,235,0.2)' },
+};
+
+const RELEVANCE_CONFIG: Record<CompetitorRelevance, { color: string; bg: string; border: string }> = {
+  high:   { color: '#16a34a', bg: 'rgba(22,163,74,0.1)',   border: 'rgba(22,163,74,0.2)' },
+  medium: { color: '#d97706', bg: 'rgba(217,119,6,0.1)',   border: 'rgba(217,119,6,0.2)' },
+  low:    { color: '#9a9892', bg: 'rgba(154,152,146,0.1)', border: 'rgba(154,152,146,0.2)' },
+};
+
+function Badge({ label, color, bg, border }: { label: string; color: string; bg: string; border: string }) {
+  return (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center',
+      padding: '2px 8px', borderRadius: 9999,
+      fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em',
+      color, background: bg, border: `1px solid ${border}`,
+    }}>
+      {label}
+    </span>
+  );
+}
+
+function CompetitorCard({ competitor }: { competitor: Competitor }) {
+  const relCfg = RELEVANCE_CONFIG[competitor.relevance];
+
+  return (
+    <div style={{
+      border: '1px solid var(--border)',
+      borderRadius: 10,
+      padding: '16px 18px',
+      display: 'flex', flexDirection: 'column', gap: 14,
+      background: 'var(--bg-elevated)',
+    }}>
+      <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginBottom: 4 }}>
+            <span style={{ fontSize: 15, fontWeight: 600, color: 'var(--fg-base)' }}>
+              {competitor.name}
+            </span>
+            <Badge label={competitor.relevance} {...relCfg} />
+            {competitor.source === 'manual' && (
+              <span style={{
+                display: 'inline-flex', alignItems: 'center',
+                padding: '2px 8px', borderRadius: 9999,
+                fontSize: 11, fontWeight: 500,
+                color: 'var(--fg-muted)', background: 'var(--bg-base)',
+                border: '1px solid var(--border-base)',
+              }}>
+                Manual
+              </span>
+            )}
+            {competitor.marketPosition && (
+              <span style={{
+                display: 'inline-flex', alignItems: 'center',
+                padding: '2px 8px', borderRadius: 9999,
+                fontSize: 11, fontWeight: 500,
+                color: 'var(--fg-muted)', background: 'var(--bg-base)',
+                border: '1px solid var(--border-base)',
+              }}>
+                {competitor.marketPosition}
+              </span>
+            )}
+          </div>
+          {competitor.description && (
+            <p style={{ fontSize: 13, color: 'var(--fg-muted)', margin: 0 }}>
+              {competitor.description}
+            </p>
+          )}
+        </div>
+        {competitor.url && (
+          <a
+            href={competitor.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{
+              fontSize: 12, color: 'var(--accent)',
+              textDecoration: 'none', flexShrink: 0,
+              display: 'flex', alignItems: 'center', gap: 4,
+            }}
+          >
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+              <polyline points="15 3 21 3 21 9" />
+              <line x1="10" y1="14" x2="21" y2="3" />
+            </svg>
+            Visit
+          </a>
+        )}
+      </div>
+
+      {competitor.painPoints.length > 0 && (
+        <div>
+          <div style={{ fontSize: 11, fontWeight: 600, color: 'var(--fg-muted)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 8 }}>
+            Pain Points ({competitor.painPoints.length})
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {competitor.painPoints.map(pp => {
+              const svCfg = SEVERITY_CONFIG[pp.severity];
+              return (
+                <div key={pp.id} style={{
+                  background: 'var(--bg-base)',
+                  border: '1px solid var(--border-subtle)',
+                  borderRadius: 8, padding: '10px 12px',
+                  display: 'flex', flexDirection: 'column', gap: 6,
+                }}>
+                  <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
+                    <Badge label={pp.severity} {...svCfg} />
+                    <span style={{ fontSize: 13, color: 'var(--fg-base)', flex: 1 }}>{pp.description}</span>
+                  </div>
+                  <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap' }}>
+                    {pp.source && (
+                      <span style={{ fontSize: 11, color: 'var(--fg-muted)' }}>
+                        Source: <em>{pp.source}</em>
+                      </span>
+                    )}
+                    {pp.frequency && (
+                      <span style={{ fontSize: 11, color: 'var(--fg-muted)' }}>
+                        Frequency: {pp.frequency}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {competitor.strengths.length > 0 && (
+        <div>
+          <div style={{ fontSize: 11, fontWeight: 600, color: 'var(--fg-muted)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 6 }}>
+            Strengths
+          </div>
+          <ul style={{ margin: 0, paddingLeft: 16, display: 'flex', flexDirection: 'column', gap: 4 }}>
+            {competitor.strengths.map((s, i) => (
+              <li key={i} style={{ fontSize: 13, color: 'var(--fg-base)' }}>{s}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function CompetitorAnalysisViewer({ analysis, open, onOpenChange, onAddCompetitor }: Props) {
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onOpenChange(false);
+    }
+    if (open) window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onOpenChange]);
+
+  return createPortal(
+    <AnimatePresence>
+      {open && (
+        <div className="board-scope">
+          <motion.div
+            key="backdrop"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            onClick={() => onOpenChange(false)}
+            style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)', zIndex: 50 }}
+          />
+          <motion.div
+            key="dialog"
+            initial={{ opacity: 0, scale: 0.96, y: 8 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.96, y: 8 }}
+            transition={{ type: 'spring', stiffness: 420, damping: 36 }}
+            style={{
+              position: 'fixed',
+              top: '50%', left: '50%',
+              transform: 'translate(-50%, -50%)',
+              width: 680, maxWidth: 'calc(100vw - 32px)',
+              maxHeight: '80vh',
+              background: 'var(--bg-surface)',
+              border: '1px solid var(--border)',
+              borderRadius: 12,
+              boxShadow: 'var(--shadow-popover)',
+              display: 'flex', flexDirection: 'column',
+              overflow: 'hidden',
+              zIndex: 51,
+            }}
+          >
+            <div style={{
+              padding: '18px 20px',
+              borderBottom: '1px solid var(--border-subtle)',
+              display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+              flexShrink: 0,
+            }}>
+              <div>
+                <div style={{ fontSize: 16, fontWeight: 600, color: 'var(--fg-base)' }}>
+                  Competitor Analysis
+                </div>
+                {analysis && (
+                  <div style={{ fontSize: 12, color: 'var(--fg-muted)', marginTop: 2 }}>
+                    {analysis.competitors.length} competitor{analysis.competitors.length !== 1 ? 's' : ''} analyzed
+                  </div>
+                )}
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <button
+                  onClick={onAddCompetitor}
+                  style={{
+                    display: 'inline-flex', alignItems: 'center', gap: 6,
+                    padding: '6px 12px', borderRadius: 6,
+                    border: '1px solid var(--border)',
+                    background: 'var(--bg-elevated)',
+                    color: 'var(--fg-base)', fontSize: 12, fontWeight: 500,
+                    cursor: 'pointer',
+                  }}
+                >
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                    <line x1="12" y1="5" x2="12" y2="19" />
+                    <line x1="5" y1="12" x2="19" y2="12" />
+                  </svg>
+                  Add Competitor
+                </button>
+                <button
+                  onClick={() => onOpenChange(false)}
+                  aria-label="Close"
+                  style={{
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    width: 28, height: 28, borderRadius: 6,
+                    border: '1px solid var(--border-subtle)',
+                    background: 'transparent',
+                    color: 'var(--fg-muted)', cursor: 'pointer', fontSize: 16,
+                  }}
+                >
+                  ×
+                </button>
+              </div>
+            </div>
+
+            <div style={{ flex: 1, overflowY: 'auto', padding: '16px 20px', display: 'flex', flexDirection: 'column', gap: 16 }}>
+              {!analysis ? (
+                <div style={{
+                  display: 'flex', flexDirection: 'column', alignItems: 'center',
+                  justifyContent: 'center', gap: 10, minHeight: 200,
+                  color: 'var(--fg-muted)',
+                }}>
+                  <span style={{ fontSize: 13 }}>No analysis available</span>
+                </div>
+              ) : (
+                <>
+                  {analysis.competitors.map(c => (
+                    <CompetitorCard key={c.id} competitor={c} />
+                  ))}
+
+                  {analysis.insightsSummary && (
+                    <div style={{
+                      border: '1px solid var(--border)',
+                      borderRadius: 10, padding: '16px 18px',
+                      background: 'rgba(var(--accent-rgb, 99,102,241), 0.04)',
+                      display: 'flex', flexDirection: 'column', gap: 14,
+                    }}>
+                      <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--fg-base)' }}>
+                        Market Insights
+                      </div>
+
+                      {analysis.insightsSummary.topPainPoints.length > 0 && (
+                        <div>
+                          <div style={{ fontSize: 11, fontWeight: 600, color: 'var(--fg-muted)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 6 }}>
+                            Top Pain Points
+                          </div>
+                          <ul style={{ margin: 0, paddingLeft: 16, display: 'flex', flexDirection: 'column', gap: 4 }}>
+                            {analysis.insightsSummary.topPainPoints.map((p, i) => (
+                              <li key={i} style={{ fontSize: 13, color: 'var(--fg-muted)' }}>{p}</li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+
+                      {analysis.insightsSummary.differentiatorOpportunities.length > 0 && (
+                        <div>
+                          <div style={{ fontSize: 11, fontWeight: 600, color: 'var(--fg-muted)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 6 }}>
+                            Differentiator Opportunities
+                          </div>
+                          <ul style={{ margin: 0, paddingLeft: 16, display: 'flex', flexDirection: 'column', gap: 4 }}>
+                            {analysis.insightsSummary.differentiatorOpportunities.map((o, i) => (
+                              <li key={i} style={{ fontSize: 13, color: 'var(--fg-muted)' }}>{o}</li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+
+                      {analysis.insightsSummary.marketTrends.length > 0 && (
+                        <div>
+                          <div style={{ fontSize: 11, fontWeight: 600, color: 'var(--fg-muted)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 6 }}>
+                            Market Trends
+                          </div>
+                          <ul style={{ margin: 0, paddingLeft: 16, display: 'flex', flexDirection: 'column', gap: 4 }}>
+                            {analysis.insightsSummary.marketTrends.map((t, i) => (
+                              <li key={i} style={{ fontSize: 13, color: 'var(--fg-muted)' }}>{t}</li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>,
+    document.body
+  );
+}

--- a/apps/desktop/src/components/roadmap/FeatureCard.tsx
+++ b/apps/desktop/src/components/roadmap/FeatureCard.tsx
@@ -1,0 +1,165 @@
+import { useState } from 'react';
+import type { RoadmapFeature } from '../../lib/roadmap-types';
+import {
+  ROADMAP_PRIORITY_CONFIG,
+  ROADMAP_COMPLEXITY_CONFIG,
+  ROADMAP_IMPACT_CONFIG,
+} from '../../lib/roadmap-constants';
+
+interface Props {
+  feature: RoadmapFeature;
+  onSelect: (f: RoadmapFeature) => void;
+  isDragging?: boolean;
+}
+
+export function FeatureCard({ feature, onSelect, isDragging }: Props) {
+  const [hovered, setHovered] = useState(false);
+  const priorityCfg = ROADMAP_PRIORITY_CONFIG[feature.priority];
+  const complexityCfg = ROADMAP_COMPLEXITY_CONFIG[feature.complexity];
+  const impactCfg = ROADMAP_IMPACT_CONFIG[feature.impact];
+  const hasInsights = (feature.competitorInsightIds?.length ?? 0) > 0;
+
+  return (
+    <div
+      onClick={() => onSelect(feature)}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{
+        background: isDragging ? 'var(--bg-hover)' : hovered ? 'var(--bg-hover)' : 'var(--bg-elevated)',
+        border: `1px solid ${hovered && !isDragging ? 'var(--accent)' : 'var(--border)'}`,
+        borderRadius: 8,
+        padding: 10,
+        cursor: 'pointer',
+        transition: 'border-color 0.1s, background 0.1s',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 6,
+        opacity: isDragging ? 0.85 : 1,
+      }}
+    >
+      {/* Title */}
+      <span style={{ fontSize: 13, fontWeight: 500, lineHeight: 1.4, color: 'var(--text-primary)' }}>
+        {feature.title}
+      </span>
+
+      {/* Description — 2-line clamp */}
+      {feature.description && (
+        <p
+          style={{
+            margin: 0,
+            fontSize: 11,
+            lineHeight: 1.6,
+            color: 'var(--text-secondary)',
+            overflow: 'hidden',
+            display: '-webkit-box',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+          }}
+        >
+          {feature.description}
+        </p>
+      )}
+
+      {/* Badges row */}
+      <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 5 }}>
+        {/* Priority badge */}
+        <span
+          style={{
+            borderRadius: 9999,
+            border: `1px solid ${priorityCfg.border}`,
+            background: priorityCfg.bg,
+            color: priorityCfg.color,
+            padding: '1px 6px',
+            fontSize: 10,
+            fontWeight: 600,
+            textTransform: 'uppercase',
+            letterSpacing: '0.05em',
+          }}
+        >
+          {priorityCfg.label}
+        </span>
+
+        {/* Complexity badge */}
+        <span
+          style={{
+            borderRadius: 9999,
+            border: '1px solid var(--border-subtle)',
+            background: 'var(--bg-surface)',
+            padding: '1px 6px',
+            fontSize: 10,
+            fontWeight: 500,
+            color: complexityCfg.color,
+          }}
+        >
+          {complexityCfg.label}
+        </span>
+
+        {/* Impact badge */}
+        <span
+          style={{
+            borderRadius: 9999,
+            border: '1px solid var(--border-subtle)',
+            background: 'var(--bg-surface)',
+            padding: '1px 6px',
+            fontSize: 10,
+            fontWeight: 500,
+            color: impactCfg.color,
+          }}
+        >
+          {impactCfg.label} impact
+        </span>
+
+        {/* Phase badge */}
+        {feature.phaseId && (
+          <span
+            style={{
+              borderRadius: 9999,
+              border: '1px solid var(--border-subtle)',
+              background: 'var(--bg-surface)',
+              padding: '1px 6px',
+              fontSize: 10,
+              color: 'var(--text-muted)',
+            }}
+          >
+            {feature.phaseId}
+          </span>
+        )}
+
+        {/* Competitor insight indicator */}
+        {hasInsights && (
+          <span
+            style={{
+              borderRadius: 9999,
+              border: '1px solid rgba(37,99,235,0.3)',
+              background: 'rgba(37,99,235,0.08)',
+              color: '#2563eb',
+              padding: '1px 6px',
+              fontSize: 10,
+              fontWeight: 500,
+            }}
+            title="Has competitor insights"
+          >
+            {'↗'} Insight
+          </span>
+        )}
+
+        {/* Linked task badge */}
+        {feature.linkedTaskId != null && (
+          <span
+            style={{
+              borderRadius: 9999,
+              border: '1px solid rgba(22,163,74,0.3)',
+              background: 'rgba(22,163,74,0.08)',
+              color: '#16a34a',
+              padding: '1px 6px',
+              fontSize: 10,
+              fontWeight: 500,
+            }}
+          >
+            #{feature.linkedTaskId}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/roadmap/FeatureDetailPanel.tsx
+++ b/apps/desktop/src/components/roadmap/FeatureDetailPanel.tsx
@@ -1,0 +1,488 @@
+import { useState } from 'react';
+import type { RoadmapFeature, CompetitorPainPoint } from '../../lib/roadmap-types';
+import {
+  ROADMAP_PRIORITY_CONFIG,
+  ROADMAP_COMPLEXITY_CONFIG,
+  ROADMAP_IMPACT_CONFIG,
+} from '../../lib/roadmap-constants';
+
+interface Props {
+  feature: RoadmapFeature;
+  competitorInsights: CompetitorPainPoint[];
+  onClose: () => void;
+  onConvertToTask: (f: RoadmapFeature) => void;
+  onGoToTask?: (taskId: number) => void;
+  onDelete: (featureId: string) => void;
+}
+
+const SEVERITY_COLOR: Record<string, string> = {
+  high:   '#dc2626',
+  medium: '#d97706',
+  low:    '#16a34a',
+};
+
+export function FeatureDetailPanel({
+  feature,
+  competitorInsights,
+  onClose,
+  onConvertToTask,
+  onGoToTask,
+  onDelete,
+}: Props) {
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const priorityCfg = ROADMAP_PRIORITY_CONFIG[feature.priority];
+  const complexityCfg = ROADMAP_COMPLEXITY_CONFIG[feature.complexity];
+  const impactCfg = ROADMAP_IMPACT_CONFIG[feature.impact];
+
+  function handleDelete() {
+    onDelete(feature.id);
+    onClose();
+  }
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        right: 0,
+        bottom: 0,
+        width: 384,
+        background: 'var(--bg-surface)',
+        borderLeft: '1px solid var(--border)',
+        display: 'flex',
+        flexDirection: 'column',
+        zIndex: 50,
+        boxShadow: '-4px 0 24px rgba(0,0,0,0.12)',
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          flexShrink: 0,
+          padding: '14px 16px',
+          borderBottom: '1px solid var(--border-subtle)',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 8 }}>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            {/* Priority + complexity + impact badges */}
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 5, marginBottom: 8 }}>
+              <span
+                style={{
+                  borderRadius: 9999,
+                  border: `1px solid ${priorityCfg.border}`,
+                  background: priorityCfg.bg,
+                  color: priorityCfg.color,
+                  padding: '1px 7px',
+                  fontSize: 10,
+                  fontWeight: 600,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.05em',
+                }}
+              >
+                {priorityCfg.label}
+              </span>
+              <span
+                style={{
+                  borderRadius: 9999,
+                  border: '1px solid var(--border-subtle)',
+                  background: 'var(--bg-elevated)',
+                  padding: '1px 7px',
+                  fontSize: 10,
+                  fontWeight: 500,
+                  color: complexityCfg.color,
+                }}
+              >
+                {complexityCfg.label} complexity
+              </span>
+              <span
+                style={{
+                  borderRadius: 9999,
+                  border: '1px solid var(--border-subtle)',
+                  background: 'var(--bg-elevated)',
+                  padding: '1px 7px',
+                  fontSize: 10,
+                  fontWeight: 500,
+                  color: impactCfg.color,
+                }}
+              >
+                {impactCfg.label} impact
+              </span>
+            </div>
+            <h2
+              style={{
+                margin: 0,
+                fontSize: 14,
+                fontWeight: 600,
+                color: 'var(--text-primary)',
+                lineHeight: 1.4,
+              }}
+            >
+              {feature.title}
+            </h2>
+          </div>
+
+          {/* Control buttons */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 2, flexShrink: 0 }}>
+            {/* Delete button */}
+            <button
+              onClick={() => setShowDeleteConfirm(true)}
+              title="Delete feature"
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: 28,
+                height: 28,
+                background: 'transparent',
+                border: 'none',
+                borderRadius: 5,
+                color: 'var(--text-muted)',
+                cursor: 'pointer',
+                fontSize: 14,
+                transition: 'color 0.1s, background 0.1s',
+              }}
+              onMouseEnter={e => {
+                (e.currentTarget as HTMLElement).style.color = '#dc2626';
+                (e.currentTarget as HTMLElement).style.background = 'rgba(220,38,38,0.08)';
+              }}
+              onMouseLeave={e => {
+                (e.currentTarget as HTMLElement).style.color = 'var(--text-muted)';
+                (e.currentTarget as HTMLElement).style.background = 'transparent';
+              }}
+            >
+              {'🗑'}
+            </button>
+
+            {/* Close button */}
+            <button
+              onClick={onClose}
+              title="Close"
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: 28,
+                height: 28,
+                background: 'transparent',
+                border: 'none',
+                borderRadius: 5,
+                color: 'var(--text-muted)',
+                cursor: 'pointer',
+                fontSize: 16,
+                transition: 'color 0.1s',
+              }}
+              onMouseEnter={e => { (e.currentTarget as HTMLElement).style.color = 'var(--text-primary)'; }}
+              onMouseLeave={e => { (e.currentTarget as HTMLElement).style.color = 'var(--text-muted)'; }}
+            >
+              {'›'}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Scrollable content */}
+      <div style={{ flex: 1, overflowY: 'auto', padding: '16px' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+
+          {/* Description */}
+          <section>
+            <h3 style={{ margin: '0 0 6px', fontSize: 12, fontWeight: 600, color: 'var(--text-primary)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+              Description
+            </h3>
+            <p style={{ margin: 0, fontSize: 13, lineHeight: 1.6, color: 'var(--text-secondary)' }}>
+              {feature.description}
+            </p>
+          </section>
+
+          {/* Rationale */}
+          {feature.rationale && (
+            <section>
+              <h3 style={{ margin: '0 0 6px', fontSize: 12, fontWeight: 600, color: 'var(--text-primary)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+                Rationale
+              </h3>
+              <div
+                style={{
+                  borderLeft: '3px solid var(--accent)',
+                  paddingLeft: 10,
+                  margin: 0,
+                }}
+              >
+                <p style={{ margin: 0, fontSize: 13, lineHeight: 1.6, color: 'var(--text-secondary)' }}>
+                  {feature.rationale}
+                </p>
+              </div>
+            </section>
+          )}
+
+          {/* Metrics grid */}
+          <section>
+            <h3 style={{ margin: '0 0 8px', fontSize: 12, fontWeight: 600, color: 'var(--text-primary)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+              Metrics
+            </h3>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 8 }}>
+              {[
+                { label: 'Complexity', value: complexityCfg.label, color: complexityCfg.color },
+                { label: 'Impact', value: impactCfg.label, color: impactCfg.color },
+                { label: 'Dependencies', value: String(feature.dependencies.length), color: 'var(--text-primary)' },
+              ].map(m => (
+                <div
+                  key={m.label}
+                  style={{
+                    background: 'var(--bg-elevated)',
+                    border: '1px solid var(--border-subtle)',
+                    borderRadius: 7,
+                    padding: '10px 8px',
+                    textAlign: 'center',
+                  }}
+                >
+                  <div style={{ fontSize: 15, fontWeight: 700, color: m.color, marginBottom: 2 }}>
+                    {m.value}
+                  </div>
+                  <div style={{ fontSize: 10, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.04em' }}>
+                    {m.label}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* User Stories */}
+          {feature.userStories.length > 0 && (
+            <section>
+              <h3 style={{ margin: '0 0 8px', fontSize: 12, fontWeight: 600, color: 'var(--text-primary)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+                User Stories
+              </h3>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                {feature.userStories.map((story, i) => (
+                  <div
+                    key={i}
+                    style={{
+                      background: 'var(--bg-elevated)',
+                      border: '1px solid var(--border-subtle)',
+                      borderRadius: 6,
+                      padding: '8px 10px',
+                      fontSize: 12,
+                      lineHeight: 1.5,
+                      color: 'var(--text-secondary)',
+                      fontStyle: 'italic',
+                    }}
+                  >
+                    "{story}"
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Acceptance Criteria */}
+          {feature.acceptanceCriteria.length > 0 && (
+            <section>
+              <h3 style={{ margin: '0 0 8px', fontSize: 12, fontWeight: 600, color: 'var(--text-primary)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+                Acceptance Criteria
+              </h3>
+              <ul style={{ margin: 0, padding: 0, listStyle: 'none', display: 'flex', flexDirection: 'column', gap: 5 }}>
+                {feature.acceptanceCriteria.map((criterion, i) => (
+                  <li
+                    key={i}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'flex-start',
+                      gap: 7,
+                      fontSize: 12,
+                      lineHeight: 1.5,
+                      color: 'var(--text-secondary)',
+                    }}
+                  >
+                    <span style={{ color: 'var(--text-muted)', flexShrink: 0, marginTop: 2, fontSize: 11 }}>○</span>
+                    {criterion}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {/* Competitor Insights */}
+          {competitorInsights.length > 0 && (
+            <section>
+              <h3 style={{ margin: '0 0 8px', fontSize: 12, fontWeight: 600, color: '#2563eb', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+                {'↗'} Competitor Pain Points
+              </h3>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                {competitorInsights.map(insight => (
+                  <div
+                    key={insight.id}
+                    style={{
+                      background: 'rgba(37,99,235,0.05)',
+                      border: '1px solid rgba(37,99,235,0.2)',
+                      borderRadius: 7,
+                      padding: '10px 12px',
+                    }}
+                  >
+                    <p style={{ margin: '0 0 6px', fontSize: 12, lineHeight: 1.5, color: 'var(--text-primary)' }}>
+                      {insight.description}
+                    </p>
+                    <div style={{ display: 'flex', gap: 5, flexWrap: 'wrap' }}>
+                      <span
+                        style={{
+                          borderRadius: 9999,
+                          border: '1px solid var(--border-subtle)',
+                          background: 'var(--bg-elevated)',
+                          padding: '1px 6px',
+                          fontSize: 10,
+                          color: 'var(--text-muted)',
+                        }}
+                      >
+                        {insight.source}
+                      </span>
+                      <span
+                        style={{
+                          borderRadius: 9999,
+                          border: `1px solid ${SEVERITY_COLOR[insight.severity] ?? 'var(--border-subtle)'}44`,
+                          background: `${SEVERITY_COLOR[insight.severity] ?? 'transparent'}15`,
+                          padding: '1px 6px',
+                          fontSize: 10,
+                          fontWeight: 500,
+                          color: SEVERITY_COLOR[insight.severity] ?? 'var(--text-muted)',
+                        }}
+                      >
+                        {insight.severity} severity
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+        </div>
+      </div>
+
+      {/* Actions footer */}
+      <div style={{ flexShrink: 0, padding: '12px 16px', borderTop: '1px solid var(--border-subtle)', display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {feature.linkedTaskId != null ? (
+          <button
+            onClick={() => onGoToTask?.(feature.linkedTaskId!)}
+            style={{
+              width: '100%',
+              padding: '8px 12px',
+              background: 'var(--bg-elevated)',
+              border: '1px solid var(--border)',
+              borderRadius: 7,
+              fontSize: 13,
+              fontWeight: 500,
+              color: 'var(--text-primary)',
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 6,
+              transition: 'border-color 0.1s',
+            }}
+            onMouseEnter={e => { (e.currentTarget as HTMLElement).style.borderColor = 'var(--accent)'; }}
+            onMouseLeave={e => { (e.currentTarget as HTMLElement).style.borderColor = 'var(--border)'; }}
+          >
+            <span>{'↗'}</span>
+            Go to Task #{feature.linkedTaskId}
+          </button>
+        ) : (
+          <button
+            onClick={() => onConvertToTask(feature)}
+            style={{
+              width: '100%',
+              padding: '8px 12px',
+              background: 'var(--accent)',
+              border: 'none',
+              borderRadius: 7,
+              fontSize: 13,
+              fontWeight: 600,
+              color: '#fff',
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 6,
+              transition: 'opacity 0.1s',
+            }}
+            onMouseEnter={e => { (e.currentTarget as HTMLElement).style.opacity = '0.85'; }}
+            onMouseLeave={e => { (e.currentTarget as HTMLElement).style.opacity = '1'; }}
+          >
+            <span>{'⚡'}</span>
+            Convert to Task
+          </button>
+        )}
+      </div>
+
+      {/* Delete confirmation overlay */}
+      {showDeleteConfirm && (
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            background: 'var(--bg-surface)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: 24,
+            zIndex: 10,
+          }}
+        >
+          <div style={{ textAlign: 'center', maxWidth: 280 }}>
+            <div
+              style={{
+                width: 48,
+                height: 48,
+                borderRadius: '50%',
+                background: 'rgba(220,38,38,0.1)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                margin: '0 auto 12px',
+                fontSize: 22,
+              }}
+            >
+              {'🗑'}
+            </div>
+            <h3 style={{ margin: '0 0 6px', fontSize: 15, fontWeight: 600, color: 'var(--text-primary)' }}>
+              Delete Feature?
+            </h3>
+            <p style={{ margin: '0 0 16px', fontSize: 12, color: 'var(--text-secondary)', lineHeight: 1.5 }}>
+              This will permanently remove "{feature.title}" from your roadmap.
+            </p>
+            <div style={{ display: 'flex', gap: 8, justifyContent: 'center' }}>
+              <button
+                onClick={() => setShowDeleteConfirm(false)}
+                style={{
+                  padding: '6px 16px',
+                  background: 'transparent',
+                  border: '1px solid var(--border)',
+                  borderRadius: 6,
+                  fontSize: 12,
+                  fontWeight: 500,
+                  color: 'var(--text-primary)',
+                  cursor: 'pointer',
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleDelete}
+                style={{
+                  padding: '6px 16px',
+                  background: '#dc2626',
+                  border: 'none',
+                  borderRadius: 6,
+                  fontSize: 12,
+                  fontWeight: 600,
+                  color: '#fff',
+                  cursor: 'pointer',
+                }}
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/roadmap/PhaseCard.tsx
+++ b/apps/desktop/src/components/roadmap/PhaseCard.tsx
@@ -1,0 +1,312 @@
+import { useState } from 'react';
+import type { RoadmapPhase, RoadmapFeature } from '../../lib/roadmap-types';
+import { ROADMAP_PRIORITY_CONFIG } from '../../lib/roadmap-constants';
+
+interface Props {
+  phase: RoadmapPhase;
+  features: RoadmapFeature[];
+  onFeatureSelect: (f: RoadmapFeature) => void;
+  onBuild: (f: RoadmapFeature) => void;
+}
+
+const INITIAL_VISIBLE = 5;
+
+const PHASE_STATUS_CONFIG: Record<string, { color: string; bg: string; border: string }> = {
+  completed:   { color: '#16a34a', bg: 'rgba(22,163,74,0.1)',   border: 'rgba(22,163,74,0.2)' },
+  in_progress: { color: '#2563eb', bg: 'rgba(37,99,235,0.1)',   border: 'rgba(37,99,235,0.2)' },
+  planned:     { color: '#9a9892', bg: 'rgba(154,152,146,0.1)', border: 'rgba(154,152,146,0.2)' },
+};
+
+export function PhaseCard({ phase, features, onFeatureSelect, onBuild }: Props) {
+  const [expanded, setExpanded] = useState(false);
+
+  const completedCount = features.filter(f => f.status === 'done').length;
+  const totalCount = features.length;
+  const progress = totalCount > 0 ? (completedCount / totalCount) * 100 : 0;
+  const visibleFeatures = expanded ? features : features.slice(0, INITIAL_VISIBLE);
+  const hiddenCount = totalCount - INITIAL_VISIBLE;
+
+  const statusCfg = PHASE_STATUS_CONFIG[phase.status] ?? PHASE_STATUS_CONFIG['planned'];
+
+  return (
+    <div
+      style={{
+        background: 'var(--bg-elevated)',
+        border: '1px solid var(--border-subtle)',
+        borderRadius: 10,
+        padding: 16,
+      }}
+    >
+      {/* Phase header */}
+      <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+          {/* Phase number / check badge */}
+          <div
+            style={{
+              width: 32,
+              height: 32,
+              borderRadius: '50%',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexShrink: 0,
+              background: statusCfg.bg,
+              border: `1px solid ${statusCfg.border}`,
+              fontSize: 13,
+              fontWeight: 700,
+              color: statusCfg.color,
+            }}
+          >
+            {phase.status === 'completed' ? '✓' : phase.order}
+          </div>
+
+          <div>
+            <h3 style={{ margin: '0 0 2px', fontSize: 14, fontWeight: 600, color: 'var(--text-primary)' }}>
+              {phase.name}
+            </h3>
+            <p style={{ margin: 0, fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.4 }}>
+              {phase.description}
+            </p>
+          </div>
+        </div>
+
+        {/* Status badge */}
+        <span
+          style={{
+            borderRadius: 9999,
+            border: `1px solid ${statusCfg.border}`,
+            background: statusCfg.bg,
+            color: statusCfg.color,
+            padding: '1px 8px',
+            fontSize: 10,
+            fontWeight: 600,
+            textTransform: 'uppercase',
+            letterSpacing: '0.05em',
+            flexShrink: 0,
+          }}
+        >
+          {phase.status.replace('_', ' ')}
+        </span>
+      </div>
+
+      {/* Progress bar */}
+      <div style={{ marginBottom: 14 }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 4 }}>
+          <span style={{ fontSize: 11, color: 'var(--text-muted)' }}>Progress</span>
+          <span style={{ fontSize: 11, color: 'var(--text-muted)' }}>
+            {completedCount}/{totalCount} features
+          </span>
+        </div>
+        <div
+          style={{
+            height: 5,
+            background: 'var(--bg-surface)',
+            borderRadius: 3,
+            overflow: 'hidden',
+            border: '1px solid var(--border-subtle)',
+          }}
+        >
+          <div
+            style={{
+              height: '100%',
+              width: `${progress}%`,
+              background: 'var(--accent)',
+              borderRadius: 3,
+              transition: 'width 0.3s ease',
+            }}
+          />
+        </div>
+      </div>
+
+      {/* Milestones */}
+      {phase.milestones.length > 0 && (
+        <div style={{ marginBottom: 14 }}>
+          <h4 style={{ margin: '0 0 8px', fontSize: 11, fontWeight: 600, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+            Milestones
+          </h4>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+            {phase.milestones.map(milestone => (
+              <div
+                key={milestone.id}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 7,
+                  fontSize: 12,
+                  color: milestone.status === 'achieved' ? 'var(--text-muted)' : 'var(--text-secondary)',
+                }}
+              >
+                <span
+                  style={{
+                    fontSize: 12,
+                    flexShrink: 0,
+                    color: milestone.status === 'achieved' ? '#16a34a' : 'var(--text-muted)',
+                  }}
+                >
+                  {milestone.status === 'achieved' ? '✓' : '○'}
+                </span>
+                <span
+                  style={{
+                    textDecoration: milestone.status === 'achieved' ? 'line-through' : 'none',
+                    lineHeight: 1.4,
+                  }}
+                >
+                  {milestone.title}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Features list */}
+      <div>
+        <h4 style={{ margin: '0 0 8px', fontSize: 11, fontWeight: 600, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+          Features ({totalCount})
+        </h4>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+          {visibleFeatures.map(feature => {
+            const priorityCfg = ROADMAP_PRIORITY_CONFIG[feature.priority];
+            const hasInsights = (feature.competitorInsightIds?.length ?? 0) > 0;
+            return (
+              <div
+                key={feature.id}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  padding: '6px 8px',
+                  borderRadius: 6,
+                  background: 'var(--bg-surface)',
+                  border: '1px solid var(--border-subtle)',
+                  gap: 8,
+                }}
+              >
+                {/* Clickable left side */}
+                <button
+                  onClick={() => onFeatureSelect(feature)}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 6,
+                    flex: 1,
+                    minWidth: 0,
+                    background: 'none',
+                    border: 'none',
+                    padding: 0,
+                    cursor: 'pointer',
+                    textAlign: 'left',
+                  }}
+                >
+                  <span
+                    style={{
+                      borderRadius: 9999,
+                      border: `1px solid ${priorityCfg.border}`,
+                      background: priorityCfg.bg,
+                      color: priorityCfg.color,
+                      padding: '0px 5px',
+                      fontSize: 9,
+                      fontWeight: 600,
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.05em',
+                      flexShrink: 0,
+                    }}
+                  >
+                    {priorityCfg.label}
+                  </span>
+                  <span
+                    style={{
+                      fontSize: 12,
+                      color: 'var(--text-primary)',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {feature.title}
+                  </span>
+                  {hasInsights && (
+                    <span style={{ fontSize: 11, color: '#2563eb', flexShrink: 0 }} title="Competitor insights">↗</span>
+                  )}
+                </button>
+
+                {/* Right side: task badge or build button */}
+                {feature.linkedTaskId != null ? (
+                  <span
+                    style={{
+                      borderRadius: 9999,
+                      border: '1px solid rgba(22,163,74,0.3)',
+                      background: 'rgba(22,163,74,0.08)',
+                      color: '#16a34a',
+                      padding: '1px 6px',
+                      fontSize: 10,
+                      fontWeight: 500,
+                      flexShrink: 0,
+                    }}
+                  >
+                    #{feature.linkedTaskId}
+                  </span>
+                ) : (
+                  <button
+                    onClick={e => {
+                      e.stopPropagation();
+                      onBuild(feature);
+                    }}
+                    style={{
+                      padding: '2px 8px',
+                      background: 'transparent',
+                      border: '1px solid var(--border)',
+                      borderRadius: 4,
+                      fontSize: 10,
+                      fontWeight: 500,
+                      color: 'var(--text-muted)',
+                      cursor: 'pointer',
+                      flexShrink: 0,
+                      transition: 'border-color 0.1s, color 0.1s',
+                    }}
+                    onMouseEnter={e => {
+                      (e.currentTarget as HTMLElement).style.borderColor = 'var(--accent)';
+                      (e.currentTarget as HTMLElement).style.color = 'var(--accent)';
+                    }}
+                    onMouseLeave={e => {
+                      (e.currentTarget as HTMLElement).style.borderColor = 'var(--border)';
+                      (e.currentTarget as HTMLElement).style.color = 'var(--text-muted)';
+                    }}
+                  >
+                    Build
+                  </button>
+                )}
+              </div>
+            );
+          })}
+
+          {/* Show more / less toggle */}
+          {hiddenCount > 0 && (
+            <button
+              onClick={() => setExpanded(prev => !prev)}
+              style={{
+                width: '100%',
+                padding: '6px',
+                background: 'transparent',
+                border: 'none',
+                borderRadius: 5,
+                fontSize: 12,
+                color: 'var(--text-muted)',
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: 4,
+                transition: 'color 0.1s',
+              }}
+              onMouseEnter={e => { (e.currentTarget as HTMLElement).style.color = 'var(--text-primary)'; }}
+              onMouseLeave={e => { (e.currentTarget as HTMLElement).style.color = 'var(--text-muted)'; }}
+            >
+              {expanded ? '↑ Show less' : `↓ Show ${hiddenCount} more`}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/roadmap/RoadmapEmptyState.tsx
+++ b/apps/desktop/src/components/roadmap/RoadmapEmptyState.tsx
@@ -1,0 +1,92 @@
+interface Props {
+  onGenerate: () => void;
+}
+
+export function RoadmapEmptyState({ onGenerate }: Props) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        height: '100%',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <div
+        style={{
+          width: '100%',
+          maxWidth: 480,
+          padding: 32,
+          background: 'var(--bg-elevated)',
+          border: '1px solid var(--border-subtle)',
+          borderRadius: 12,
+          textAlign: 'center',
+        }}
+      >
+        {/* Icon */}
+        <div
+          style={{
+            width: 48,
+            height: 48,
+            borderRadius: '50%',
+            background: 'var(--bg-surface)',
+            border: '1px solid var(--border-subtle)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            margin: '0 auto 16px',
+            fontSize: 24,
+          }}
+        >
+          {'🗺'}
+        </div>
+
+        <h2
+          style={{
+            margin: '0 0 8px',
+            fontSize: 18,
+            fontWeight: 600,
+            color: 'var(--text-primary)',
+          }}
+        >
+          No Roadmap Yet
+        </h2>
+
+        <p
+          style={{
+            margin: '0 0 24px',
+            fontSize: 13,
+            lineHeight: 1.6,
+            color: 'var(--text-secondary)',
+          }}
+        >
+          Generate an AI-powered roadmap that understands your project's target audience and creates
+          a strategic feature plan.
+        </p>
+
+        <button
+          onClick={onGenerate}
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+            padding: '8px 20px',
+            background: 'var(--accent)',
+            color: '#fff',
+            border: 'none',
+            borderRadius: 7,
+            fontSize: 13,
+            fontWeight: 600,
+            cursor: 'pointer',
+            transition: 'opacity 0.1s',
+          }}
+          onMouseEnter={e => { (e.currentTarget as HTMLElement).style.opacity = '0.85'; }}
+          onMouseLeave={e => { (e.currentTarget as HTMLElement).style.opacity = '1'; }}
+        >
+          <span style={{ fontSize: 14 }}>{'✦'}</span>
+          Generate Roadmap
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/roadmap/RoadmapHeader.tsx
+++ b/apps/desktop/src/components/roadmap/RoadmapHeader.tsx
@@ -1,0 +1,223 @@
+import type { Roadmap, CompetitorAnalysis } from '../../lib/roadmap-types';
+import { ROADMAP_PRIORITY_CONFIG } from '../../lib/roadmap-constants';
+
+interface Props {
+  roadmap: Roadmap;
+  competitorAnalysis: CompetitorAnalysis | null;
+  onAddFeature: () => void;
+  onRefresh: () => void;
+  onViewCompetitors: () => void;
+}
+
+const STATUS_CONFIG: Record<string, { label: string; color: string; bg: string; border: string }> = {
+  active:   { label: 'Active',    color: '#16a34a', bg: 'rgba(22,163,74,0.1)',   border: 'rgba(22,163,74,0.2)' },
+  draft:    { label: 'Draft',     color: '#d97706', bg: 'rgba(217,119,6,0.1)',   border: 'rgba(217,119,6,0.2)' },
+  archived: { label: 'Archived',  color: '#9a9892', bg: 'rgba(154,152,146,0.1)', border: 'rgba(154,152,146,0.2)' },
+};
+
+export function RoadmapHeader({ roadmap, competitorAnalysis, onAddFeature, onRefresh, onViewCompetitors }: Props) {
+  const statusCfg = STATUS_CONFIG[roadmap.status] ?? STATUS_CONFIG['draft'];
+
+  const totalFeatures = roadmap.features.length;
+  const byPriority = (['must', 'should', 'could', 'wont'] as const).map(p => ({
+    priority: p,
+    count: roadmap.features.filter(f => f.priority === p).length,
+    config: ROADMAP_PRIORITY_CONFIG[p],
+  })).filter(x => x.count > 0);
+
+  const competitorCount = competitorAnalysis?.competitors.length ?? 0;
+  const painPointCount = competitorAnalysis?.competitors.reduce((sum, c) => sum + c.painPoints.length, 0) ?? 0;
+
+  return (
+    <div
+      style={{
+        flexShrink: 0,
+        borderBottom: '1px solid var(--border-subtle)',
+        padding: '14px 20px',
+        background: 'var(--bg-surface)',
+      }}
+    >
+      {/* Top row: title + status + actions */}
+      <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          {/* Name + status badge */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4, flexWrap: 'wrap' }}>
+            <h2 style={{ margin: 0, fontSize: 15, fontWeight: 700, color: 'var(--text-primary)' }}>
+              {roadmap.projectName}
+            </h2>
+            <span
+              style={{
+                borderRadius: 9999,
+                border: `1px solid ${statusCfg.border}`,
+                background: statusCfg.bg,
+                color: statusCfg.color,
+                padding: '1px 8px',
+                fontSize: 10,
+                fontWeight: 600,
+                textTransform: 'uppercase',
+                letterSpacing: '0.05em',
+              }}
+            >
+              {statusCfg.label}
+            </span>
+
+            {/* Competitor analysis chip */}
+            {competitorAnalysis && (
+              <button
+                onClick={onViewCompetitors}
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 4,
+                  borderRadius: 9999,
+                  border: '1px solid rgba(37,99,235,0.3)',
+                  background: 'rgba(37,99,235,0.08)',
+                  color: '#2563eb',
+                  padding: '1px 8px',
+                  fontSize: 10,
+                  fontWeight: 600,
+                  cursor: 'pointer',
+                  transition: 'background 0.1s',
+                }}
+                title={`${competitorCount} competitors · ${painPointCount} pain points`}
+                onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(37,99,235,0.15)'; }}
+                onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(37,99,235,0.08)'; }}
+              >
+                <span style={{ fontSize: 11 }}>{'↗'}</span>
+                {competitorCount} Competitor{competitorCount !== 1 ? 's' : ''}
+              </button>
+            )}
+          </div>
+
+          {/* Vision */}
+          <p
+            style={{
+              margin: 0,
+              fontSize: 12,
+              lineHeight: 1.5,
+              color: 'var(--text-secondary)',
+              maxWidth: 560,
+            }}
+          >
+            {roadmap.vision}
+          </p>
+
+          {/* Target audience + meta chips */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 8, flexWrap: 'wrap' }}>
+            {roadmap.targetAudience?.primary && (
+              <span
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 4,
+                  borderRadius: 9999,
+                  border: '1px solid var(--border-subtle)',
+                  background: 'var(--bg-elevated)',
+                  padding: '1px 8px',
+                  fontSize: 11,
+                  color: 'var(--text-secondary)',
+                }}
+              >
+                <span style={{ fontSize: 12 }}>{'◎'}</span>
+                {roadmap.targetAudience.primary}
+              </span>
+            )}
+
+            {/* Feature count */}
+            <span
+              style={{
+                borderRadius: 9999,
+                border: '1px solid var(--border-subtle)',
+                background: 'var(--bg-elevated)',
+                padding: '1px 8px',
+                fontSize: 11,
+                color: 'var(--text-muted)',
+              }}
+            >
+              {totalFeatures} feature{totalFeatures !== 1 ? 's' : ''}
+            </span>
+
+            {/* Priority breakdown badges */}
+            {byPriority.map(({ priority, count, config }) => (
+              <span
+                key={priority}
+                style={{
+                  borderRadius: 9999,
+                  border: `1px solid ${config.border}`,
+                  background: config.bg,
+                  color: config.color,
+                  padding: '1px 7px',
+                  fontSize: 10,
+                  fontWeight: 600,
+                }}
+              >
+                {count} {config.label}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        {/* Action buttons */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0 }}>
+          <button
+            onClick={onAddFeature}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 4,
+              padding: '5px 12px',
+              background: 'transparent',
+              border: '1px solid var(--border)',
+              borderRadius: 6,
+              fontSize: 12,
+              fontWeight: 500,
+              color: 'var(--text-primary)',
+              cursor: 'pointer',
+              transition: 'border-color 0.1s, color 0.1s',
+            }}
+            onMouseEnter={e => {
+              (e.currentTarget as HTMLElement).style.borderColor = 'var(--accent)';
+              (e.currentTarget as HTMLElement).style.color = 'var(--accent)';
+            }}
+            onMouseLeave={e => {
+              (e.currentTarget as HTMLElement).style.borderColor = 'var(--border)';
+              (e.currentTarget as HTMLElement).style.color = 'var(--text-primary)';
+            }}
+          >
+            <span style={{ fontSize: 14, lineHeight: 1 }}>+</span>
+            Add Feature
+          </button>
+
+          <button
+            onClick={onRefresh}
+            title="Regenerate roadmap"
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 30,
+              height: 30,
+              background: 'transparent',
+              border: '1px solid var(--border)',
+              borderRadius: 6,
+              fontSize: 14,
+              color: 'var(--text-muted)',
+              cursor: 'pointer',
+              transition: 'border-color 0.1s, color 0.1s',
+            }}
+            onMouseEnter={e => {
+              (e.currentTarget as HTMLElement).style.borderColor = 'var(--accent)';
+              (e.currentTarget as HTMLElement).style.color = 'var(--accent)';
+            }}
+            onMouseLeave={e => {
+              (e.currentTarget as HTMLElement).style.borderColor = 'var(--border)';
+              (e.currentTarget as HTMLElement).style.color = 'var(--text-muted)';
+            }}
+          >
+            {'↺'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/roadmap/RoadmapKanbanView.tsx
+++ b/apps/desktop/src/components/roadmap/RoadmapKanbanView.tsx
@@ -1,0 +1,231 @@
+import { useState, useMemo } from 'react';
+import {
+  DndContext,
+  DragOverlay,
+  closestCorners,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  useDroppable,
+  type DragStartEvent,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import type { Roadmap, RoadmapFeature, RoadmapFeatureStatus } from '../../lib/roadmap-types';
+import { ROADMAP_COLUMNS } from '../../lib/roadmap-constants';
+import { SortableFeatureCard } from './SortableFeatureCard';
+import { FeatureCard } from './FeatureCard';
+
+interface Props {
+  roadmap: Roadmap;
+  onFeatureSelect: (f: RoadmapFeature) => void;
+  onSave: (roadmap: Roadmap) => void;
+}
+
+interface ColumnProps {
+  status: RoadmapFeatureStatus;
+  label: string;
+  color: string;
+  features: RoadmapFeature[];
+  onFeatureSelect: (f: RoadmapFeature) => void;
+}
+
+function DroppableFeatureColumn({ status, label, color, features, onFeatureSelect }: ColumnProps) {
+  const { setNodeRef, isOver } = useDroppable({ id: `col-${status}` });
+  const featureIds = features.map(f => `feature-${f.id}`);
+
+  return (
+    <div
+      style={{
+        minWidth: 220,
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        background: isOver ? 'var(--bg-elevated)' : 'var(--bg-surface)',
+        borderRadius: 10,
+        border: `1px solid ${isOver ? 'var(--accent)' : 'var(--border-subtle)'}`,
+        overflow: 'hidden',
+        maxHeight: '100%',
+        transition: 'background 0.15s, border-color 0.15s',
+      }}
+    >
+      {/* Column header */}
+      <div
+        style={{
+          padding: '12px 14px 10px',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          borderBottom: '1px solid var(--border-subtle)',
+          flexShrink: 0,
+        }}
+      >
+        <span
+          style={{
+            width: 8,
+            height: 8,
+            borderRadius: '50%',
+            background: color,
+            flexShrink: 0,
+          }}
+        />
+        <span style={{ fontWeight: 600, fontSize: 13, color: 'var(--text-primary)' }}>
+          {label}
+        </span>
+        <span
+          style={{
+            marginLeft: 'auto',
+            fontSize: 11,
+            fontWeight: 600,
+            color: 'var(--text-muted)',
+            background: 'var(--bg-elevated)',
+            borderRadius: 10,
+            padding: '1px 7px',
+          }}
+        >
+          {features.length}
+        </span>
+      </div>
+
+      {/* Feature list — droppable zone */}
+      <div
+        ref={setNodeRef}
+        style={{
+          flex: 1,
+          overflowY: 'auto',
+          padding: 10,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 8,
+          minHeight: 80,
+        }}
+      >
+        <SortableContext items={featureIds} strategy={verticalListSortingStrategy}>
+          {features.length === 0 ? (
+            <div
+              style={{
+                padding: '24px 12px',
+                textAlign: 'center',
+                color: isOver ? 'var(--accent)' : 'var(--text-muted)',
+                fontSize: 12,
+                borderRadius: 6,
+                border: `1px dashed ${isOver ? 'var(--accent)' : 'var(--border-subtle)'}`,
+                transition: 'all 0.15s',
+              }}
+            >
+              {isOver ? 'Drop here' : 'No features'}
+            </div>
+          ) : (
+            features.map(feature => (
+              <SortableFeatureCard
+                key={feature.id}
+                feature={feature}
+                onSelect={onFeatureSelect}
+              />
+            ))
+          )}
+        </SortableContext>
+      </div>
+    </div>
+  );
+}
+
+export function RoadmapKanbanView({ roadmap, onFeatureSelect, onSave }: Props) {
+  const [activeFeature, setActiveFeature] = useState<RoadmapFeature | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  );
+
+  const featuresByStatus = useMemo(() => {
+    const map: Record<RoadmapFeatureStatus, RoadmapFeature[]> = {
+      backlog: [],
+      planning: [],
+      in_progress: [],
+      done: [],
+    };
+    for (const f of roadmap.features) {
+      if (map[f.status]) {
+        map[f.status].push(f);
+      } else {
+        map['backlog'].push(f);
+      }
+    }
+    return map;
+  }, [roadmap.features]);
+
+  function handleDragStart(event: DragStartEvent) {
+    const id = String(event.active.id).replace('feature-', '');
+    const feature = roadmap.features.find(f => f.id === id);
+    if (feature) setActiveFeature(feature);
+  }
+
+  function handleDragEnd(event: DragEndEvent) {
+    setActiveFeature(null);
+    const { active, over } = event;
+    if (!over) return;
+
+    const featureId = String(active.id).replace('feature-', '');
+    let targetStatus: RoadmapFeatureStatus | null = null;
+
+    const overId = String(over.id);
+    if (overId.startsWith('col-')) {
+      targetStatus = overId.replace('col-', '') as RoadmapFeatureStatus;
+    } else if (overId.startsWith('feature-')) {
+      const targetFeatureId = overId.replace('feature-', '');
+      const targetFeature = roadmap.features.find(f => f.id === targetFeatureId);
+      targetStatus = targetFeature?.status ?? null;
+    }
+
+    if (!targetStatus) return;
+
+    const feature = roadmap.features.find(f => f.id === featureId);
+    if (!feature || feature.status === targetStatus) return;
+
+    const updatedFeatures = roadmap.features.map(f =>
+      f.id === featureId ? { ...f, status: targetStatus as RoadmapFeatureStatus } : f
+    );
+    onSave({ ...roadmap, features: updatedFeatures });
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCorners}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+    >
+      <div
+        style={{
+          flex: 1,
+          display: 'flex',
+          gap: 16,
+          padding: 20,
+          overflowX: 'auto',
+          overflowY: 'hidden',
+          alignItems: 'flex-start',
+          minHeight: 0,
+        }}
+      >
+        {ROADMAP_COLUMNS.map(col => (
+          <DroppableFeatureColumn
+            key={col.id}
+            status={col.id}
+            label={col.label}
+            color={col.color}
+            features={featuresByStatus[col.id] ?? []}
+            onFeatureSelect={onFeatureSelect}
+          />
+        ))}
+      </div>
+
+      <DragOverlay dropAnimation={{ duration: 150, easing: 'ease' }}>
+        {activeFeature ? (
+          <div style={{ opacity: 0.85, transform: 'rotate(1.5deg)' }}>
+            <FeatureCard feature={activeFeature} onSelect={() => {}} isDragging />
+          </div>
+        ) : null}
+      </DragOverlay>
+    </DndContext>
+  );
+}

--- a/apps/desktop/src/components/roadmap/RoadmapTabs.tsx
+++ b/apps/desktop/src/components/roadmap/RoadmapTabs.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+
+interface Props {
+  activeTab: string;
+  onTabChange: (tab: string) => void;
+}
+
+const TABS = [
+  { id: 'kanban',     label: 'Kanban' },
+  { id: 'phases',     label: 'Phases' },
+  { id: 'features',   label: 'All Features' },
+  { id: 'priorities', label: 'By Priority' },
+];
+
+export function RoadmapTabs({ activeTab, onTabChange }: Props) {
+  const [hovered, setHovered] = useState<string | null>(null);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        gap: 0,
+        padding: '0 20px',
+        borderBottom: '1px solid var(--border-subtle)',
+        flexShrink: 0,
+        background: 'var(--bg-surface)',
+      }}
+    >
+      {TABS.map(tab => {
+        const isActive = tab.id === activeTab;
+        const isHovered = hovered === tab.id;
+        return (
+          <button
+            key={tab.id}
+            onClick={() => onTabChange(tab.id)}
+            onMouseEnter={() => setHovered(tab.id)}
+            onMouseLeave={() => setHovered(null)}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              padding: '8px 12px',
+              fontSize: 12,
+              fontWeight: isActive ? 600 : 400,
+              color: isActive ? 'var(--text-primary)' : isHovered ? 'var(--text-primary)' : 'var(--text-muted)',
+              background: 'transparent',
+              border: 'none',
+              borderBottom: isActive ? '2px solid var(--accent)' : '2px solid transparent',
+              cursor: 'pointer',
+              whiteSpace: 'nowrap',
+              transition: 'color 0.1s, border-color 0.1s',
+              marginBottom: -1,
+            }}
+          >
+            {tab.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/roadmap/SortableFeatureCard.tsx
+++ b/apps/desktop/src/components/roadmap/SortableFeatureCard.tsx
@@ -1,0 +1,36 @@
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import type { RoadmapFeature } from '../../lib/roadmap-types';
+import { FeatureCard } from './FeatureCard';
+
+interface Props {
+  feature: RoadmapFeature;
+  onSelect: (f: RoadmapFeature) => void;
+}
+
+export function SortableFeatureCard({ feature, onSelect }: Props) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: `feature-${feature.id}` });
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.4 : 1,
+        cursor: isDragging ? 'grabbing' : 'grab',
+      }}
+      {...attributes}
+      {...listeners}
+    >
+      <FeatureCard feature={feature} onSelect={onSelect} isDragging={isDragging} />
+    </div>
+  );
+}

--- a/apps/desktop/src/hooks/useGlobalShortcuts.ts
+++ b/apps/desktop/src/hooks/useGlobalShortcuts.ts
@@ -9,6 +9,7 @@ export const NAV_PATHS = [
   "/security/permissions",
   "/parity",
   "/board",
+  "/roadmap",
   "/memory",
 ] as const;
 

--- a/apps/desktop/src/hooks/useRoadmapData.ts
+++ b/apps/desktop/src/hooks/useRoadmapData.ts
@@ -1,0 +1,55 @@
+import { useState, useEffect, useCallback } from 'react';
+import { roadmapApi } from '../lib/roadmap-api';
+import type { Roadmap, CompetitorAnalysis } from '../lib/roadmap-types';
+import { useWebSocket } from './useWebSocket';
+
+type RoadmapEvent =
+  | { type: 'roadmap_updated'; slug: string; roadmap: Roadmap }
+  | { type: 'competitors_updated'; slug: string; competitorAnalysis: CompetitorAnalysis }
+  | { type: 'connected'; message: string };
+
+export function useRoadmapData(slug: string, ready = true) {
+  const [roadmap, setRoadmap] = useState<Roadmap | null>(null);
+  const [competitorAnalysis, setCompetitorAnalysis] = useState<CompetitorAnalysis | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [lastSyncedAt, setLastSyncedAt] = useState<Date | null>(null);
+
+  const fetchAll = useCallback(() => {
+    Promise.all([
+      roadmapApi.roadmap.get(slug),
+      roadmapApi.competitors.get(slug),
+    ])
+      .then(([r, c]) => {
+        setRoadmap(r);
+        setCompetitorAnalysis(c);
+        setError(null);
+        setLastSyncedAt(new Date());
+      })
+      .catch(err => setError(String(err)))
+      .finally(() => setLoading(false));
+  }, [slug]);
+
+  useEffect(() => {
+    if (!ready) return;
+    setLoading(true);
+    fetchAll();
+  }, [ready, fetchAll]);
+
+  useWebSocket((evt) => {
+    try {
+      const event = JSON.parse(evt.data as string) as RoadmapEvent;
+      if (event.type === 'roadmap_updated' && event.slug === slug && event.roadmap) {
+        setRoadmap(event.roadmap);
+        setLastSyncedAt(new Date());
+      } else if (event.type === 'competitors_updated' && event.slug === slug && event.competitorAnalysis) {
+        setCompetitorAnalysis(event.competitorAnalysis);
+        setLastSyncedAt(new Date());
+      }
+    } catch {
+      // ignore malformed messages
+    }
+  });
+
+  return { roadmap, competitorAnalysis, loading, error, refetch: fetchAll, lastSyncedAt };
+}

--- a/apps/desktop/src/hooks/useRoadmapData.ts
+++ b/apps/desktop/src/hooks/useRoadmapData.ts
@@ -4,8 +4,8 @@ import type { Roadmap, CompetitorAnalysis } from '../lib/roadmap-types';
 import { useWebSocket } from './useWebSocket';
 
 type RoadmapEvent =
-  | { type: 'roadmap_updated'; slug: string; roadmap: Roadmap }
-  | { type: 'competitors_updated'; slug: string; competitorAnalysis: CompetitorAnalysis }
+  | { type: 'roadmap_updated'; slug: string }
+  | { type: 'competitors_updated'; slug: string }
   | { type: 'connected'; message: string };
 
 export function useRoadmapData(slug: string, ready = true) {
@@ -38,13 +38,12 @@ export function useRoadmapData(slug: string, ready = true) {
 
   useWebSocket((evt) => {
     try {
-      const event = JSON.parse(evt.data as string) as RoadmapEvent;
-      if (event.type === 'roadmap_updated' && event.slug === slug && event.roadmap) {
-        setRoadmap(event.roadmap);
-        setLastSyncedAt(new Date());
-      } else if (event.type === 'competitors_updated' && event.slug === slug && event.competitorAnalysis) {
-        setCompetitorAnalysis(event.competitorAnalysis);
-        setLastSyncedAt(new Date());
+      const msg = JSON.parse(evt.data as string) as RoadmapEvent;
+      if (msg.type === 'roadmap_updated' && msg.slug === slug) {
+        fetchAll();
+      }
+      if (msg.type === 'competitors_updated' && msg.slug === slug) {
+        fetchAll();
       }
     } catch {
       // ignore malformed messages

--- a/apps/desktop/src/layouts/AppLayout.tsx
+++ b/apps/desktop/src/layouts/AppLayout.tsx
@@ -78,6 +78,11 @@ export const NAV_SECTIONS: NavSection[] = [
     path: "/board",
   },
   {
+    id: "roadmap",
+    label: "Roadmap",
+    path: "/roadmap",
+  },
+  {
     id: "memory",
     label: "Memory",
     path: "/memory",

--- a/apps/desktop/src/lib/board-api.ts
+++ b/apps/desktop/src/lib/board-api.ts
@@ -129,6 +129,7 @@ export interface Task {
   execution?: TaskExecution;
   default_harness?: string;
   default_model?: string;
+  linkedFeatureId?: string;
   created_at: string;
   updated_at: string;
   // enriched by list_tasks

--- a/apps/desktop/src/lib/roadmap-api.ts
+++ b/apps/desktop/src/lib/roadmap-api.ts
@@ -1,0 +1,83 @@
+import type {
+  Roadmap,
+  RoadmapFeature,
+  CompetitorAnalysis,
+  Competitor,
+} from './roadmap-types';
+
+const BASE = 'http://localhost:4800/api/v1';
+
+async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    headers: { 'Content-Type': 'application/json', ...(init?.headers ?? {}) },
+    ...init,
+  });
+  if (!res.ok) {
+    const err = await res.text().catch(() => res.statusText);
+    throw new Error(`API ${res.status}: ${err}`);
+  }
+  if (res.status === 204) {
+    return undefined as unknown as T;
+  }
+  const body = await res.json() as { data: T } | { error: string };
+  if ('error' in body) throw new Error((body as { error: string }).error);
+  return (body as { data: T }).data;
+}
+
+export const roadmapApi = {
+  roadmap: {
+    get: (slug: string) =>
+      apiFetch<Roadmap | null>(`/projects/${slug}/roadmap`),
+    save: (slug: string, roadmap: Roadmap) =>
+      apiFetch<Roadmap>(`/projects/${slug}/roadmap`, {
+        method: 'PUT',
+        body: JSON.stringify(roadmap),
+      }),
+  },
+  features: {
+    list: (slug: string, filters?: { status?: string; priority?: string }) => {
+      const q = new URLSearchParams();
+      if (filters?.status) q.set('status', filters.status);
+      if (filters?.priority) q.set('priority', filters.priority);
+      return apiFetch<RoadmapFeature[]>(
+        `/projects/${slug}/roadmap/features${q.size ? `?${q}` : ''}`
+      );
+    },
+    add: (slug: string, feature: Omit<RoadmapFeature, 'id'>) =>
+      apiFetch<RoadmapFeature>(`/projects/${slug}/roadmap/features`, {
+        method: 'POST',
+        body: JSON.stringify(feature),
+      }),
+    update: (slug: string, featureId: string, updates: Partial<RoadmapFeature>) =>
+      apiFetch<RoadmapFeature>(`/projects/${slug}/roadmap/features/${featureId}`, {
+        method: 'PATCH',
+        body: JSON.stringify(updates),
+      }),
+    remove: (slug: string, featureId: string) =>
+      apiFetch<void>(`/projects/${slug}/roadmap/features/${featureId}`, {
+        method: 'DELETE',
+      }),
+    convertToTask: (slug: string, featureId: string, epicId: number) =>
+      apiFetch<{ task: unknown; feature: RoadmapFeature }>(
+        `/projects/${slug}/roadmap/features/${featureId}/convert`,
+        {
+          method: 'POST',
+          body: JSON.stringify({ epic_id: epicId }),
+        }
+      ),
+  },
+  competitors: {
+    get: (slug: string) =>
+      apiFetch<CompetitorAnalysis | null>(`/projects/${slug}/competitors`),
+    save: (slug: string, analysis: CompetitorAnalysis) =>
+      apiFetch<CompetitorAnalysis>(`/projects/${slug}/competitors`, {
+        method: 'PUT',
+        body: JSON.stringify(analysis),
+      }),
+    add: (slug: string, competitor: Omit<Competitor, 'id'>) =>
+      apiFetch<CompetitorAnalysis>(`/projects/${slug}/competitors`, {
+        method: 'POST',
+        body: JSON.stringify(competitor),
+      }),
+  },
+};

--- a/apps/desktop/src/lib/roadmap-api.ts
+++ b/apps/desktop/src/lib/roadmap-api.ts
@@ -1,28 +1,10 @@
+import { apiFetch } from './board-api';
 import type {
   Roadmap,
   RoadmapFeature,
   CompetitorAnalysis,
   Competitor,
 } from './roadmap-types';
-
-const BASE = 'http://localhost:4800/api/v1';
-
-async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(`${BASE}${path}`, {
-    headers: { 'Content-Type': 'application/json', ...(init?.headers ?? {}) },
-    ...init,
-  });
-  if (!res.ok) {
-    const err = await res.text().catch(() => res.statusText);
-    throw new Error(`API ${res.status}: ${err}`);
-  }
-  if (res.status === 204) {
-    return undefined as unknown as T;
-  }
-  const body = await res.json() as { data: T } | { error: string };
-  if ('error' in body) throw new Error((body as { error: string }).error);
-  return (body as { data: T }).data;
-}
 
 export const roadmapApi = {
   roadmap: {

--- a/apps/desktop/src/lib/roadmap-constants.ts
+++ b/apps/desktop/src/lib/roadmap-constants.ts
@@ -1,0 +1,40 @@
+import type { RoadmapFeatureStatus, RoadmapFeaturePriority } from './roadmap-types';
+
+export interface RoadmapColumn {
+  id: RoadmapFeatureStatus;
+  label: string;
+  color: string;
+}
+
+export const ROADMAP_COLUMNS: RoadmapColumn[] = [
+  { id: 'backlog',     label: 'Backlog',      color: 'var(--status-backlog)' },
+  { id: 'planning',    label: 'Planning',     color: 'var(--status-planning)' },
+  { id: 'in_progress', label: 'In Progress',  color: 'var(--status-in-progress)' },
+  { id: 'done',        label: 'Done',         color: 'var(--status-done)' },
+];
+
+export const ROADMAP_PRIORITY_LABELS: Record<RoadmapFeaturePriority, string> = {
+  must:   'Must Have',
+  should: 'Should Have',
+  could:  'Could Have',
+  wont:   "Won't Have",
+};
+
+export const ROADMAP_PRIORITY_CONFIG: Record<RoadmapFeaturePriority, { label: string; color: string; bg: string; border: string }> = {
+  must:   { label: 'Must Have',    color: '#dc2626', bg: 'rgba(220,38,38,0.1)',   border: 'rgba(220,38,38,0.2)' },
+  should: { label: 'Should Have',  color: '#d97706', bg: 'rgba(217,119,6,0.1)',   border: 'rgba(217,119,6,0.2)' },
+  could:  { label: 'Could Have',   color: '#2563eb', bg: 'rgba(37,99,235,0.1)',   border: 'rgba(37,99,235,0.2)' },
+  wont:   { label: "Won't Have",   color: '#9a9892', bg: 'rgba(154,152,146,0.1)', border: 'rgba(154,152,146,0.2)' },
+};
+
+export const ROADMAP_COMPLEXITY_CONFIG: Record<'low' | 'medium' | 'high', { label: string; color: string }> = {
+  low:    { label: 'Low',    color: '#16a34a' },
+  medium: { label: 'Medium', color: '#d97706' },
+  high:   { label: 'High',   color: '#dc2626' },
+};
+
+export const ROADMAP_IMPACT_CONFIG: Record<'low' | 'medium' | 'high', { label: string; color: string }> = {
+  low:    { label: 'Low',    color: '#9a9892' },
+  medium: { label: 'Medium', color: '#2563eb' },
+  high:   { label: 'High',   color: '#16a34a' },
+};

--- a/apps/desktop/src/lib/roadmap-types.ts
+++ b/apps/desktop/src/lib/roadmap-types.ts
@@ -1,0 +1,129 @@
+export type CompetitorSource = 'manual' | 'ai';
+export type CompetitorRelevance = 'high' | 'medium' | 'low';
+export type PainPointSeverity = 'high' | 'medium' | 'low';
+export type OpportunitySize = 'high' | 'medium' | 'low';
+
+export interface CompetitorPainPoint {
+  id: string;
+  description: string;
+  source: string;
+  severity: PainPointSeverity;
+  frequency: string;
+  opportunity: string;
+}
+
+export interface Competitor {
+  id: string;
+  name: string;
+  url: string;
+  description: string;
+  relevance: CompetitorRelevance;
+  painPoints: CompetitorPainPoint[];
+  strengths: string[];
+  marketPosition: string;
+  source?: CompetitorSource;
+}
+
+export interface ManualCompetitorInput {
+  name: string;
+  url: string;
+  description: string;
+  relevance: CompetitorRelevance;
+}
+
+export interface CompetitorMarketGap {
+  id: string;
+  description: string;
+  affectedCompetitors: string[];
+  opportunitySize: OpportunitySize;
+  suggestedFeature: string;
+}
+
+export interface CompetitorInsightsSummary {
+  topPainPoints: string[];
+  differentiatorOpportunities: string[];
+  marketTrends: string[];
+}
+
+export interface CompetitorResearchMetadata {
+  searchQueriesUsed: string[];
+  sourcesConsulted: string[];
+  limitations: string[];
+}
+
+export interface CompetitorAnalysis {
+  projectContext: {
+    projectName: string;
+    projectType: string;
+    targetAudience: string;
+  };
+  competitors: Competitor[];
+  marketGaps: CompetitorMarketGap[];
+  insightsSummary: CompetitorInsightsSummary;
+  researchMetadata: CompetitorResearchMetadata;
+  created_at: string;
+}
+
+export type RoadmapFeaturePriority = 'must' | 'should' | 'could' | 'wont';
+export type RoadmapFeatureStatus = 'backlog' | 'planning' | 'in_progress' | 'done';
+export type RoadmapPhaseStatus = 'planned' | 'in_progress' | 'completed';
+export type RoadmapMilestoneStatus = 'planned' | 'achieved';
+export type RoadmapStatus = 'draft' | 'active' | 'archived';
+
+export interface TargetAudience {
+  primary: string;
+  secondary: string[];
+  painPoints?: string[];
+  goals?: string[];
+  usageContext?: string;
+}
+
+export interface RoadmapMilestone {
+  id: string;
+  title: string;
+  description: string;
+  features: string[];
+  status: RoadmapMilestoneStatus;
+  targetDate?: string;
+}
+
+export interface RoadmapPhase {
+  id: string;
+  name: string;
+  description: string;
+  order: number;
+  status: RoadmapPhaseStatus;
+  features: string[];
+  milestones: RoadmapMilestone[];
+}
+
+export interface RoadmapFeature {
+  id: string;
+  title: string;
+  description: string;
+  rationale: string;
+  priority: RoadmapFeaturePriority;
+  complexity: 'low' | 'medium' | 'high';
+  impact: 'low' | 'medium' | 'high';
+  phaseId: string;
+  dependencies: string[];
+  status: RoadmapFeatureStatus;
+  acceptanceCriteria: string[];
+  userStories: string[];
+  linkedTaskId?: number;
+  competitorInsightIds?: string[];
+}
+
+export interface Roadmap {
+  id: string;
+  projectSlug: string;
+  projectName: string;
+  version: string;
+  vision: string;
+  targetAudience: TargetAudience;
+  phases: RoadmapPhase[];
+  features: RoadmapFeature[];
+  status: RoadmapStatus;
+  created_at: string;
+  updated_at: string;
+}

--- a/apps/desktop/src/pages/roadmap/RoadmapPage.tsx
+++ b/apps/desktop/src/pages/roadmap/RoadmapPage.tsx
@@ -1,0 +1,487 @@
+import { useState, useMemo, useCallback } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useRoadmapData } from '../../hooks/useRoadmapData';
+import { useBoardServerReady } from '../../hooks/useBoardServerReady';
+import { BoardServerOffline } from '../../components/board/BoardServerOffline';
+import { RoadmapEmptyState } from '../../components/roadmap/RoadmapEmptyState';
+import { RoadmapHeader } from '../../components/roadmap/RoadmapHeader';
+import { RoadmapTabs } from '../../components/roadmap/RoadmapTabs';
+import { RoadmapKanbanView } from '../../components/roadmap/RoadmapKanbanView';
+import { FeatureCard } from '../../components/roadmap/FeatureCard';
+import { FeatureDetailPanel } from '../../components/roadmap/FeatureDetailPanel';
+import { PhaseCard } from '../../components/roadmap/PhaseCard';
+import { CompetitorAnalysisViewer } from '../../components/roadmap/CompetitorAnalysisViewer';
+import { AddFeatureDialog } from '../../components/roadmap/AddFeatureDialog';
+import { AddCompetitorDialog } from '../../components/roadmap/AddCompetitorDialog';
+import { roadmapApi } from '../../lib/roadmap-api';
+import { api } from '../../lib/board-api';
+import type { Epic } from '../../lib/board-api';
+import type { RoadmapFeature, Roadmap, CompetitorPainPoint, Competitor } from '../../lib/roadmap-types';
+import { ROADMAP_PRIORITY_CONFIG } from '../../lib/roadmap-constants';
+
+type TabId = 'kanban' | 'phases' | 'features' | 'priorities';
+
+// ─── EpicPickerModal ────────────────────────────────────────────────────────
+
+interface EpicPickerProps {
+  epics: Epic[];
+  onPick: (epicId: number) => void;
+  onCancel: () => void;
+}
+
+function EpicPickerModal({ epics, onPick, onCancel }: EpicPickerProps) {
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.55)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 200,
+      }}
+      onClick={onCancel}
+    >
+      <div
+        style={{
+          background: 'var(--bg-elevated)',
+          border: '1px solid var(--border)',
+          borderRadius: 10,
+          padding: 24,
+          width: 360,
+          maxWidth: '90vw',
+        }}
+        onClick={e => e.stopPropagation()}
+      >
+        <h3 style={{ margin: '0 0 6px', fontSize: 15, fontWeight: 600, color: 'var(--text-primary)' }}>
+          Add to Epic
+        </h3>
+        <p style={{ margin: '0 0 16px', fontSize: 12, color: 'var(--text-muted)' }}>
+          Choose which epic to place the new task in.
+        </p>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {epics.map(epic => (
+            <button
+              key={epic.id}
+              onClick={() => onPick(epic.id)}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                padding: '10px 12px',
+                background: 'var(--bg-surface)',
+                border: '1px solid var(--border-subtle)',
+                borderRadius: 7,
+                cursor: 'pointer',
+                textAlign: 'left',
+                transition: 'border-color 0.1s',
+              }}
+              onMouseEnter={e => { (e.currentTarget as HTMLElement).style.borderColor = 'var(--accent)'; }}
+              onMouseLeave={e => { (e.currentTarget as HTMLElement).style.borderColor = 'var(--border-subtle)'; }}
+            >
+              <span style={{ fontSize: 13, color: 'var(--text-primary)' }}>{epic.name}</span>
+              <span style={{ fontSize: 11, color: 'var(--text-muted)' }}>{epic.tasks.length} tasks</span>
+            </button>
+          ))}
+        </div>
+        <button
+          onClick={onCancel}
+          style={{
+            marginTop: 12,
+            width: '100%',
+            padding: '7px',
+            background: 'transparent',
+            border: '1px solid var(--border)',
+            borderRadius: 6,
+            fontSize: 12,
+            color: 'var(--text-muted)',
+            cursor: 'pointer',
+          }}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ─── AllFeaturesView ─────────────────────────────────────────────────────────
+
+interface AllFeaturesViewProps {
+  features: RoadmapFeature[];
+  onSelect: (f: RoadmapFeature) => void;
+}
+
+function AllFeaturesView({ features, onSelect }: AllFeaturesViewProps) {
+  if (features.length === 0) {
+    return (
+      <div style={{ padding: 40, textAlign: 'center', color: 'var(--text-muted)', fontSize: 13 }}>
+        No features yet.
+      </div>
+    );
+  }
+  return (
+    <div
+      style={{
+        flex: 1,
+        overflowY: 'auto',
+        padding: 20,
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))',
+        gap: 10,
+        alignContent: 'start',
+      }}
+    >
+      {features.map(f => (
+        <FeatureCard key={f.id} feature={f} onSelect={onSelect} />
+      ))}
+    </div>
+  );
+}
+
+// ─── PhasesView ──────────────────────────────────────────────────────────────
+
+interface PhasesViewProps {
+  roadmap: Roadmap;
+  onFeatureSelect: (f: RoadmapFeature) => void;
+  onBuild: (f: RoadmapFeature) => void;
+}
+
+function PhasesView({ roadmap, onFeatureSelect, onBuild }: PhasesViewProps) {
+  if (roadmap.phases.length === 0) {
+    return (
+      <div style={{ padding: 40, textAlign: 'center', color: 'var(--text-muted)', fontSize: 13 }}>
+        No phases defined yet.
+      </div>
+    );
+  }
+  return (
+    <div style={{ flex: 1, overflowY: 'auto', padding: 20, display: 'flex', flexDirection: 'column', gap: 12 }}>
+      {[...roadmap.phases].sort((a, b) => a.order - b.order).map(phase => {
+        const phaseFeatures = roadmap.features.filter(f => f.phaseId === phase.id);
+        return (
+          <PhaseCard
+            key={phase.id}
+            phase={phase}
+            features={phaseFeatures}
+            onFeatureSelect={onFeatureSelect}
+            onBuild={onBuild}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── PrioritiesView ───────────────────────────────────────────────────────────
+
+interface PrioritiesViewProps {
+  features: RoadmapFeature[];
+  onSelect: (f: RoadmapFeature) => void;
+}
+
+function PrioritiesView({ features, onSelect }: PrioritiesViewProps) {
+  const priorities = ['must', 'should', 'could', 'wont'] as const;
+
+  return (
+    <div
+      style={{
+        flex: 1,
+        overflowY: 'auto',
+        padding: 20,
+        display: 'grid',
+        gridTemplateColumns: '1fr 1fr',
+        gridTemplateRows: '1fr 1fr',
+        gap: 12,
+        minHeight: 0,
+      }}
+    >
+      {priorities.map(priority => {
+        const cfg = ROADMAP_PRIORITY_CONFIG[priority];
+        const priorityFeatures = features.filter(f => f.priority === priority);
+        return (
+          <div
+            key={priority}
+            style={{
+              background: 'var(--bg-surface)',
+              border: `1px solid ${cfg.border}`,
+              borderRadius: 10,
+              overflow: 'hidden',
+              display: 'flex',
+              flexDirection: 'column',
+            }}
+          >
+            {/* Section header */}
+            <div
+              style={{
+                padding: '10px 14px',
+                borderBottom: `1px solid ${cfg.border}`,
+                background: cfg.bg,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                flexShrink: 0,
+              }}
+            >
+              <span style={{ fontSize: 12, fontWeight: 700, color: cfg.color, textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+                {cfg.label}
+              </span>
+              <span style={{ fontSize: 11, color: cfg.color, opacity: 0.8 }}>
+                {priorityFeatures.length}
+              </span>
+            </div>
+
+            {/* Feature cards */}
+            <div style={{ flex: 1, overflowY: 'auto', padding: 10, display: 'flex', flexDirection: 'column', gap: 6 }}>
+              {priorityFeatures.length === 0 ? (
+                <div style={{ textAlign: 'center', padding: '20px 8px', color: 'var(--text-muted)', fontSize: 12 }}>
+                  No features
+                </div>
+              ) : (
+                priorityFeatures.map(f => (
+                  <FeatureCard key={f.id} feature={f} onSelect={onSelect} />
+                ))
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── RoadmapPage ─────────────────────────────────────────────────────────────
+
+export default function RoadmapPage() {
+  const { slug } = useParams<{ slug: string }>();
+  const navigate = useNavigate();
+  const serverState = useBoardServerReady();
+  const { ready, timedOut } = serverState;
+  const { roadmap, competitorAnalysis, loading, error, refetch } = useRoadmapData(slug!, ready);
+
+  const [activeTab, setActiveTab] = useState<TabId>('kanban');
+  const [selectedFeature, setSelectedFeature] = useState<RoadmapFeature | null>(null);
+  const [showAddFeature, setShowAddFeature] = useState(false);
+  const [showAddCompetitor, setShowAddCompetitor] = useState(false);
+  const [showCompetitorViewer, setShowCompetitorViewer] = useState(false);
+  const [pendingConvertFeature, setPendingConvertFeature] = useState<RoadmapFeature | null>(null);
+  const [epicPickerEpics, setEpicPickerEpics] = useState<Epic[] | null>(null);
+
+  // Collect all pain points from competitors indexed by ID
+  const painPointsById = useMemo(() => {
+    const map = new Map<string, CompetitorPainPoint>();
+    for (const c of competitorAnalysis?.competitors ?? []) {
+      for (const pp of c.painPoints) {
+        map.set(pp.id, pp);
+      }
+    }
+    return map;
+  }, [competitorAnalysis]);
+
+  const selectedInsights = useMemo(() => {
+    if (!selectedFeature) return [];
+    return (selectedFeature.competitorInsightIds ?? [])
+      .map(id => painPointsById.get(id))
+      .filter((pp): pp is CompetitorPainPoint => pp != null);
+  }, [selectedFeature, painPointsById]);
+
+  // ── Handlers ──
+
+  const handleSaveRoadmap = useCallback(async (updated: Roadmap) => {
+    await roadmapApi.roadmap.save(slug!, updated);
+    refetch();
+  }, [slug, refetch]);
+
+  const handleAddFeature = useCallback(async (data: Omit<RoadmapFeature, 'id'>) => {
+    await roadmapApi.features.add(slug!, data);
+    refetch();
+  }, [slug, refetch]);
+
+  const handleDeleteFeature = useCallback(async (featureId: string) => {
+    await roadmapApi.features.remove(slug!, featureId);
+    setSelectedFeature(null);
+    refetch();
+  }, [slug, refetch]);
+
+  const handleAddCompetitor = useCallback(async (competitor: Omit<Competitor, 'id'>) => {
+    await roadmapApi.competitors.add(slug!, competitor);
+    refetch();
+  }, [slug, refetch]);
+
+  const handleConvertToTask = useCallback(async (feature: RoadmapFeature) => {
+    const project = await api.projects.get(slug!);
+    if (project.epics.length === 0) {
+      alert('No epics found. Create an epic on the Board first.');
+      return;
+    }
+    if (project.epics.length === 1) {
+      const result = await roadmapApi.features.convertToTask(slug!, feature.id, project.epics[0].id);
+      setSelectedFeature(result.feature);
+      refetch();
+    } else {
+      setPendingConvertFeature(feature);
+      setEpicPickerEpics(project.epics);
+    }
+  }, [slug, refetch]);
+
+  const handleEpicPick = useCallback(async (epicId: number) => {
+    if (!pendingConvertFeature) return;
+    const result = await roadmapApi.features.convertToTask(slug!, pendingConvertFeature.id, epicId);
+    setSelectedFeature(result.feature);
+    setPendingConvertFeature(null);
+    setEpicPickerEpics(null);
+    refetch();
+  }, [slug, pendingConvertFeature, refetch]);
+
+  const handleGoToTask = useCallback((taskId: number) => {
+    navigate(`/board/${slug}`, { state: { highlightTaskId: taskId } });
+  }, [navigate, slug]);
+
+  // ── Render ──
+
+  if (timedOut) {
+    return <BoardServerOffline serverState={serverState} />;
+  }
+
+  if (!ready || loading) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+        <span style={{ color: 'var(--text-muted)', fontSize: 14 }}>
+          {!ready ? 'Connecting to board server...' : 'Loading roadmap...'}
+        </span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', flexDirection: 'column', gap: 12 }}>
+        <span style={{ color: 'var(--text-secondary)', fontSize: 14 }}>Failed to load roadmap</span>
+        <span style={{ color: 'var(--text-muted)', fontSize: 12 }}>{error}</span>
+        <button
+          onClick={refetch}
+          style={{
+            padding: '6px 14px',
+            background: 'var(--accent)',
+            border: 'none',
+            borderRadius: 6,
+            color: '#fff',
+            fontSize: 12,
+            cursor: 'pointer',
+          }}
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!roadmap) {
+    return (
+      <div style={{ height: '100%' }}>
+        <RoadmapEmptyState onGenerate={() => {
+          // The user should ask Claude via MCP to generate a roadmap
+          // We surface a hint for now
+          alert('Ask Claude to generate a roadmap:\n\nget_roadmap(project: "' + slug + '")');
+        }} />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        overflow: 'hidden',
+        position: 'relative',
+      }}
+    >
+      <RoadmapHeader
+        roadmap={roadmap}
+        competitorAnalysis={competitorAnalysis}
+        onAddFeature={() => setShowAddFeature(true)}
+        onRefresh={refetch}
+        onViewCompetitors={() => setShowCompetitorViewer(true)}
+      />
+
+      <RoadmapTabs activeTab={activeTab} onTabChange={tab => setActiveTab(tab as TabId)} />
+
+      {/* Tab content */}
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', minHeight: 0 }}>
+        {activeTab === 'kanban' && (
+          <RoadmapKanbanView
+            roadmap={roadmap}
+            onFeatureSelect={setSelectedFeature}
+            onSave={handleSaveRoadmap}
+          />
+        )}
+        {activeTab === 'phases' && (
+          <PhasesView
+            roadmap={roadmap}
+            onFeatureSelect={setSelectedFeature}
+            onBuild={handleConvertToTask}
+          />
+        )}
+        {activeTab === 'features' && (
+          <AllFeaturesView
+            features={roadmap.features}
+            onSelect={setSelectedFeature}
+          />
+        )}
+        {activeTab === 'priorities' && (
+          <PrioritiesView
+            features={roadmap.features}
+            onSelect={setSelectedFeature}
+          />
+        )}
+      </div>
+
+      {/* Feature detail panel */}
+      {selectedFeature && (
+        <FeatureDetailPanel
+          feature={selectedFeature}
+          competitorInsights={selectedInsights}
+          onClose={() => setSelectedFeature(null)}
+          onConvertToTask={handleConvertToTask}
+          onGoToTask={handleGoToTask}
+          onDelete={handleDeleteFeature}
+        />
+      )}
+
+      {/* Dialogs */}
+      <AddFeatureDialog
+        phases={roadmap.phases}
+        open={showAddFeature}
+        onOpenChange={setShowAddFeature}
+        onAdd={handleAddFeature}
+      />
+
+      <AddCompetitorDialog
+        open={showAddCompetitor}
+        onOpenChange={setShowAddCompetitor}
+        onAdd={handleAddCompetitor}
+      />
+
+      {competitorAnalysis && (
+        <CompetitorAnalysisViewer
+          analysis={competitorAnalysis}
+          open={showCompetitorViewer}
+          onOpenChange={setShowCompetitorViewer}
+          onAddCompetitor={() => { setShowCompetitorViewer(false); setShowAddCompetitor(true); }}
+        />
+      )}
+
+      {/* Epic picker */}
+      {epicPickerEpics && (
+        <EpicPickerModal
+          epics={epicPickerEpics}
+          onPick={handleEpicPick}
+          onCancel={() => { setEpicPickerEpics(null); setPendingConvertFeature(null); }}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/pages/roadmap/RoadmapPage.tsx
+++ b/apps/desktop/src/pages/roadmap/RoadmapPage.tsx
@@ -267,6 +267,7 @@ export default function RoadmapPage() {
   const [showCompetitorViewer, setShowCompetitorViewer] = useState(false);
   const [pendingConvertFeature, setPendingConvertFeature] = useState<RoadmapFeature | null>(null);
   const [epicPickerEpics, setEpicPickerEpics] = useState<Epic[] | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
 
   // Collect all pain points from competitors indexed by ID
   const painPointsById = useMemo(() => {
@@ -289,49 +290,73 @@ export default function RoadmapPage() {
   // ── Handlers ──
 
   const handleSaveRoadmap = useCallback(async (updated: Roadmap) => {
-    await roadmapApi.roadmap.save(slug!, updated);
-    refetch();
+    try {
+      await roadmapApi.roadmap.save(slug!, updated);
+      refetch();
+    } catch (err) {
+      setActionError(String(err));
+    }
   }, [slug, refetch]);
 
   const handleAddFeature = useCallback(async (data: Omit<RoadmapFeature, 'id'>) => {
-    await roadmapApi.features.add(slug!, data);
-    refetch();
+    try {
+      await roadmapApi.features.add(slug!, data);
+      refetch();
+    } catch (err) {
+      setActionError(String(err));
+    }
   }, [slug, refetch]);
 
   const handleDeleteFeature = useCallback(async (featureId: string) => {
-    await roadmapApi.features.remove(slug!, featureId);
-    setSelectedFeature(null);
-    refetch();
+    try {
+      await roadmapApi.features.remove(slug!, featureId);
+      setSelectedFeature(null);
+      refetch();
+    } catch (err) {
+      setActionError(String(err));
+    }
   }, [slug, refetch]);
 
   const handleAddCompetitor = useCallback(async (competitor: Omit<Competitor, 'id'>) => {
-    await roadmapApi.competitors.add(slug!, competitor);
-    refetch();
+    try {
+      await roadmapApi.competitors.add(slug!, competitor);
+      refetch();
+    } catch (err) {
+      setActionError(String(err));
+    }
   }, [slug, refetch]);
 
   const handleConvertToTask = useCallback(async (feature: RoadmapFeature) => {
-    const project = await api.projects.get(slug!);
-    if (project.epics.length === 0) {
-      alert('No epics found. Create an epic on the Board first.');
-      return;
-    }
-    if (project.epics.length === 1) {
-      const result = await roadmapApi.features.convertToTask(slug!, feature.id, project.epics[0].id);
-      setSelectedFeature(result.feature);
-      refetch();
-    } else {
-      setPendingConvertFeature(feature);
-      setEpicPickerEpics(project.epics);
+    try {
+      const project = await api.projects.get(slug!);
+      if (project.epics.length === 0) {
+        setActionError('No epics found. Create an epic on the Board first.');
+        return;
+      }
+      if (project.epics.length === 1) {
+        const result = await roadmapApi.features.convertToTask(slug!, feature.id, project.epics[0].id);
+        setSelectedFeature(result.feature);
+        refetch();
+      } else {
+        setPendingConvertFeature(feature);
+        setEpicPickerEpics(project.epics);
+      }
+    } catch (err) {
+      setActionError(String(err));
     }
   }, [slug, refetch]);
 
   const handleEpicPick = useCallback(async (epicId: number) => {
     if (!pendingConvertFeature) return;
-    const result = await roadmapApi.features.convertToTask(slug!, pendingConvertFeature.id, epicId);
-    setSelectedFeature(result.feature);
-    setPendingConvertFeature(null);
-    setEpicPickerEpics(null);
-    refetch();
+    try {
+      const result = await roadmapApi.features.convertToTask(slug!, pendingConvertFeature.id, epicId);
+      setSelectedFeature(result.feature);
+      setPendingConvertFeature(null);
+      setEpicPickerEpics(null);
+      refetch();
+    } catch (err) {
+      setActionError(String(err));
+    }
   }, [slug, pendingConvertFeature, refetch]);
 
   const handleGoToTask = useCallback((taskId: number) => {
@@ -408,6 +433,30 @@ export default function RoadmapPage() {
       />
 
       <RoadmapTabs activeTab={activeTab} onTabChange={tab => setActiveTab(tab as TabId)} />
+
+      {/* Action error banner */}
+      {actionError && (
+        <div
+          style={{
+            flexShrink: 0,
+            padding: '8px 16px',
+            background: 'rgba(220,38,38,0.1)',
+            borderBottom: '1px solid rgba(220,38,38,0.2)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 8,
+          }}
+        >
+          <span style={{ fontSize: 12, color: '#dc2626' }}>{actionError}</span>
+          <button
+            onClick={() => setActionError(null)}
+            style={{ background: 'none', border: 'none', color: '#dc2626', cursor: 'pointer', fontSize: 14, padding: 0 }}
+          >
+            {'✕'}
+          </button>
+        </div>
+      )}
 
       {/* Tab content */}
       <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', minHeight: 0 }}>

--- a/apps/desktop/src/pages/roadmap/RoadmapProjectsPage.tsx
+++ b/apps/desktop/src/pages/roadmap/RoadmapProjectsPage.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { api } from '../../lib/board-api';
+import type { Project } from '../../lib/board-api';
+import { useBoardServerReady } from '../../hooks/useBoardServerReady';
+import { BoardServerOffline } from '../../components/board/BoardServerOffline';
+
+export default function RoadmapProjectsPage() {
+  const navigate = useNavigate();
+  const serverState = useBoardServerReady();
+  const { ready, timedOut } = serverState;
+  const [loading, setLoading] = useState(true);
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!ready) return;
+    setLoading(true);
+    setError(null);
+    api.projects.list()
+      .then(list => {
+        if (list.length === 1) {
+          navigate(`/roadmap/${list[0].slug}`, { replace: true });
+        } else if (list.length > 1) {
+          setProjects(list);
+          setLoading(false);
+        } else {
+          setProjects([]);
+          setLoading(false);
+        }
+      })
+      .catch(err => {
+        setError(String(err));
+        setLoading(false);
+      });
+  }, [ready, navigate]);
+
+  if (timedOut) {
+    return <BoardServerOffline serverState={serverState} />;
+  }
+
+  if (!ready || loading) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+        <span style={{ color: 'var(--text-muted)', fontSize: 14 }}>
+          {!ready ? 'Connecting to board server...' : 'Loading projects...'}
+        </span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', flexDirection: 'column', gap: 12 }}>
+        <span style={{ fontSize: 32 }}>{'!'}</span>
+        <span style={{ color: 'var(--text-secondary)', fontSize: 14 }}>Could not load projects</span>
+        <span style={{ color: 'var(--text-muted)', fontSize: 12 }}>{error}</span>
+      </div>
+    );
+  }
+
+  // Multiple projects — show picker
+  if (projects.length > 1) {
+    return (
+      <div style={{ padding: 32, maxWidth: 600, margin: '0 auto' }}>
+        <h1 style={{ fontSize: 20, fontWeight: 600, color: 'var(--text-primary)', marginBottom: 20 }}>
+          Roadmap
+        </h1>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {projects.map(p => (
+            <button
+              key={p.slug}
+              onClick={() => navigate(`/roadmap/${p.slug}`)}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 12,
+                padding: '14px 16px',
+                background: 'var(--bg-surface)',
+                border: '1px solid var(--border-subtle)',
+                borderRadius: 8,
+                cursor: 'pointer',
+                textAlign: 'left',
+                transition: 'border-color 0.1s, background 0.1s',
+              }}
+              onMouseEnter={e => {
+                (e.currentTarget as HTMLElement).style.borderColor = 'var(--accent)';
+                (e.currentTarget as HTMLElement).style.background = 'var(--bg-elevated)';
+              }}
+              onMouseLeave={e => {
+                (e.currentTarget as HTMLElement).style.borderColor = 'var(--border-subtle)';
+                (e.currentTarget as HTMLElement).style.background = 'var(--bg-surface)';
+              }}
+            >
+              {p.color && (
+                <span style={{ width: 10, height: 10, borderRadius: '50%', background: p.color, flexShrink: 0 }} />
+              )}
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--text-primary)' }}>{p.name}</div>
+                {p.description && (
+                  <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 2 }}>{p.description}</div>
+                )}
+              </div>
+              <span style={{ fontSize: 11, color: 'var(--text-muted)' }}>
+                {p.epics.reduce((n, e) => n + e.tasks.length, 0)} tasks
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // No projects
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', flexDirection: 'column', gap: 16 }}>
+      <h1 style={{ color: 'var(--text-primary)', fontSize: 20, fontWeight: 600, margin: 0 }}>
+        No projects yet
+      </h1>
+      <p style={{ color: 'var(--text-muted)', fontSize: 14, margin: 0, textAlign: 'center', maxWidth: 320 }}>
+        Create a project with an MCP tool call to get started:
+      </p>
+      <code style={{
+        background: 'var(--bg-elevated)',
+        border: '1px solid var(--border)',
+        borderRadius: 6,
+        padding: '8px 16px',
+        fontSize: 13,
+        color: 'var(--text-secondary)',
+        fontFamily: 'monospace',
+      }}>
+        create_project(name: "My Project")
+      </code>
+    </div>
+  );
+}

--- a/packages/board-server/src/http/roadmap-routes.ts
+++ b/packages/board-server/src/http/roadmap-routes.ts
@@ -12,10 +12,10 @@ export function createRoadmapRouter(): Router {
   router.get('/projects/:slug/roadmap', (req, res) => {
     try {
       const roadmap = roadmapStore.readRoadmap(req.params.slug);
-      if (!roadmap) return res.status(404).json({ error: 'Not found' });
-      res.json({ data: roadmap });
+      if (!roadmap) return res.status(404).json({ message: 'Not found' });
+      res.json(roadmap);
     } catch (err) {
-      res.status(500).json({ error: String(err) });
+      res.status(500).json({ message: String(err) });
     }
   });
 
@@ -30,9 +30,9 @@ export function createRoadmapRouter(): Router {
         id: req.body.id ?? randomUUID(),
       };
       roadmapStore.writeRoadmap(req.params.slug, roadmap);
-      res.json({ data: roadmap });
+      res.json(roadmap);
     } catch (err) {
-      res.status(400).json({ error: String(err) });
+      res.status(400).json({ message: String(err) });
     }
   });
 
@@ -41,20 +41,20 @@ export function createRoadmapRouter(): Router {
   router.get('/projects/:slug/roadmap/features', (req, res) => {
     try {
       const roadmap = roadmapStore.readRoadmap(req.params.slug);
-      if (!roadmap) return res.status(404).json({ error: 'Not found' });
+      if (!roadmap) return res.status(404).json({ message: 'Not found' });
       let features = roadmap.features;
       if (req.query.status) features = features.filter(f => f.status === req.query.status);
       if (req.query.priority) features = features.filter(f => f.priority === req.query.priority);
-      res.json({ data: features });
+      res.json(features);
     } catch (err) {
-      res.status(500).json({ error: String(err) });
+      res.status(500).json({ message: String(err) });
     }
   });
 
   router.post('/projects/:slug/roadmap/features', (req, res) => {
     try {
       const roadmap = roadmapStore.readRoadmap(req.params.slug);
-      if (!roadmap) return res.status(404).json({ error: 'Not found' });
+      if (!roadmap) return res.status(404).json({ message: 'Not found' });
       const feature: RoadmapFeature = {
         dependencies: [],
         acceptanceCriteria: [],
@@ -66,52 +66,52 @@ export function createRoadmapRouter(): Router {
       roadmap.features.push(feature);
       roadmap.updated_at = new Date().toISOString();
       roadmapStore.writeRoadmap(req.params.slug, roadmap);
-      res.status(201).json({ data: feature });
+      res.status(201).json(feature);
     } catch (err) {
-      res.status(400).json({ error: String(err) });
+      res.status(400).json({ message: String(err) });
     }
   });
 
   router.patch('/projects/:slug/roadmap/features/:id', (req, res) => {
     try {
       const roadmap = roadmapStore.readRoadmap(req.params.slug);
-      if (!roadmap) return res.status(404).json({ error: 'Not found' });
+      if (!roadmap) return res.status(404).json({ message: 'Not found' });
       const idx = roadmap.features.findIndex(f => f.id === req.params.id);
-      if (idx === -1) return res.status(404).json({ error: 'Feature not found' });
+      if (idx === -1) return res.status(404).json({ message: 'Feature not found' });
       const { id: _id, ...safeUpdates } = req.body as Record<string, unknown> & { id?: unknown };
       Object.assign(roadmap.features[idx], safeUpdates);
       roadmap.updated_at = new Date().toISOString();
       roadmapStore.writeRoadmap(req.params.slug, roadmap);
-      res.json({ data: roadmap.features[idx] });
+      res.json(roadmap.features[idx]);
     } catch (err) {
-      res.status(400).json({ error: String(err) });
+      res.status(400).json({ message: String(err) });
     }
   });
 
   router.delete('/projects/:slug/roadmap/features/:id', (req, res) => {
     try {
       const roadmap = roadmapStore.readRoadmap(req.params.slug);
-      if (!roadmap) return res.status(404).json({ error: 'Not found' });
+      if (!roadmap) return res.status(404).json({ message: 'Not found' });
       const idx = roadmap.features.findIndex(f => f.id === req.params.id);
-      if (idx === -1) return res.status(404).json({ error: 'Feature not found' });
+      if (idx === -1) return res.status(404).json({ message: 'Feature not found' });
       roadmap.features.splice(idx, 1);
       roadmap.updated_at = new Date().toISOString();
       roadmapStore.writeRoadmap(req.params.slug, roadmap);
       res.status(204).send();
     } catch (err) {
-      res.status(400).json({ error: String(err) });
+      res.status(400).json({ message: String(err) });
     }
   });
 
   router.post('/projects/:slug/roadmap/features/:id/convert', (req, res) => {
     try {
       const { epic_id } = req.body as { epic_id?: number };
-      if (!epic_id) return res.status(400).json({ error: 'epic_id is required' });
+      if (!epic_id) return res.status(400).json({ message: 'epic_id is required' });
 
       const roadmap = roadmapStore.readRoadmap(req.params.slug);
-      if (!roadmap) return res.status(404).json({ error: 'Not found' });
+      if (!roadmap) return res.status(404).json({ message: 'Not found' });
       const featureIdx = roadmap.features.findIndex(f => f.id === req.params.id);
-      if (featureIdx === -1) return res.status(404).json({ error: 'Feature not found' });
+      if (featureIdx === -1) return res.status(404).json({ message: 'Feature not found' });
 
       const feature = roadmap.features[featureIdx];
       const descriptionParts: string[] = [];
@@ -133,9 +133,10 @@ export function createRoadmapRouter(): Router {
       roadmap.updated_at = new Date().toISOString();
       roadmapStore.writeRoadmap(req.params.slug, roadmap);
 
-      res.status(201).json({ data: task });
+      const updatedFeature = roadmap.features[featureIdx];
+      res.status(201).json({ task, feature: updatedFeature });
     } catch (err) {
-      res.status(400).json({ error: String(err) });
+      res.status(400).json({ message: String(err) });
     }
   });
 
@@ -144,10 +145,10 @@ export function createRoadmapRouter(): Router {
   router.get('/projects/:slug/competitors', (req, res) => {
     try {
       const analysis = roadmapStore.readCompetitorAnalysis(req.params.slug);
-      if (!analysis) return res.status(404).json({ error: 'Not found' });
-      res.json({ data: analysis });
+      if (!analysis) return res.status(404).json({ message: 'Not found' });
+      res.json(analysis);
     } catch (err) {
-      res.status(500).json({ error: String(err) });
+      res.status(500).json({ message: String(err) });
     }
   });
 
@@ -158,9 +159,9 @@ export function createRoadmapRouter(): Router {
         created_at: req.body.created_at ?? new Date().toISOString(),
       };
       roadmapStore.writeCompetitorAnalysis(req.params.slug, analysis);
-      res.json({ data: analysis });
+      res.json(analysis);
     } catch (err) {
-      res.status(400).json({ error: String(err) });
+      res.status(400).json({ message: String(err) });
     }
   });
 
@@ -180,9 +181,9 @@ export function createRoadmapRouter(): Router {
       }
       analysis.competitors.push(competitor);
       roadmapStore.writeCompetitorAnalysis(req.params.slug, analysis);
-      res.status(201).json({ data: competitor });
+      res.status(201).json(competitor);
     } catch (err) {
-      res.status(400).json({ error: String(err) });
+      res.status(400).json({ message: String(err) });
     }
   });
 

--- a/packages/board-server/src/http/roadmap-routes.ts
+++ b/packages/board-server/src/http/roadmap-routes.ts
@@ -1,0 +1,190 @@
+import { Router } from 'express';
+import { randomUUID } from 'node:crypto';
+import * as roadmapStore from '../store/roadmap-store.js';
+import * as store from '../store/yaml-store.js';
+import type { RoadmapFeature } from '../roadmap-types.js';
+
+export function createRoadmapRouter(): Router {
+  const router = Router();
+
+  // --- Roadmap ---
+
+  router.get('/projects/:slug/roadmap', (req, res) => {
+    try {
+      const roadmap = roadmapStore.readRoadmap(req.params.slug);
+      if (!roadmap) return res.status(404).json({ error: 'Not found' });
+      res.json({ data: roadmap });
+    } catch (err) {
+      res.status(500).json({ error: String(err) });
+    }
+  });
+
+  router.put('/projects/:slug/roadmap', (req, res) => {
+    try {
+      const now = new Date().toISOString();
+      const roadmap = {
+        ...req.body,
+        projectSlug: req.params.slug,
+        updated_at: now,
+        created_at: req.body.created_at ?? now,
+        id: req.body.id ?? randomUUID(),
+      };
+      roadmapStore.writeRoadmap(req.params.slug, roadmap);
+      res.json({ data: roadmap });
+    } catch (err) {
+      res.status(400).json({ error: String(err) });
+    }
+  });
+
+  // --- Features ---
+
+  router.get('/projects/:slug/roadmap/features', (req, res) => {
+    try {
+      const roadmap = roadmapStore.readRoadmap(req.params.slug);
+      if (!roadmap) return res.status(404).json({ error: 'Not found' });
+      let features = roadmap.features;
+      if (req.query.status) features = features.filter(f => f.status === req.query.status);
+      if (req.query.priority) features = features.filter(f => f.priority === req.query.priority);
+      res.json({ data: features });
+    } catch (err) {
+      res.status(500).json({ error: String(err) });
+    }
+  });
+
+  router.post('/projects/:slug/roadmap/features', (req, res) => {
+    try {
+      const roadmap = roadmapStore.readRoadmap(req.params.slug);
+      if (!roadmap) return res.status(404).json({ error: 'Not found' });
+      const feature: RoadmapFeature = {
+        dependencies: [],
+        acceptanceCriteria: [],
+        userStories: [],
+        competitorInsightIds: [],
+        ...(req.body as Partial<RoadmapFeature>),
+        id: randomUUID(),
+      } as RoadmapFeature;
+      roadmap.features.push(feature);
+      roadmap.updated_at = new Date().toISOString();
+      roadmapStore.writeRoadmap(req.params.slug, roadmap);
+      res.status(201).json({ data: feature });
+    } catch (err) {
+      res.status(400).json({ error: String(err) });
+    }
+  });
+
+  router.patch('/projects/:slug/roadmap/features/:id', (req, res) => {
+    try {
+      const roadmap = roadmapStore.readRoadmap(req.params.slug);
+      if (!roadmap) return res.status(404).json({ error: 'Not found' });
+      const idx = roadmap.features.findIndex(f => f.id === req.params.id);
+      if (idx === -1) return res.status(404).json({ error: 'Feature not found' });
+      const { id: _id, ...safeUpdates } = req.body as Record<string, unknown> & { id?: unknown };
+      Object.assign(roadmap.features[idx], safeUpdates);
+      roadmap.updated_at = new Date().toISOString();
+      roadmapStore.writeRoadmap(req.params.slug, roadmap);
+      res.json({ data: roadmap.features[idx] });
+    } catch (err) {
+      res.status(400).json({ error: String(err) });
+    }
+  });
+
+  router.delete('/projects/:slug/roadmap/features/:id', (req, res) => {
+    try {
+      const roadmap = roadmapStore.readRoadmap(req.params.slug);
+      if (!roadmap) return res.status(404).json({ error: 'Not found' });
+      const idx = roadmap.features.findIndex(f => f.id === req.params.id);
+      if (idx === -1) return res.status(404).json({ error: 'Feature not found' });
+      roadmap.features.splice(idx, 1);
+      roadmap.updated_at = new Date().toISOString();
+      roadmapStore.writeRoadmap(req.params.slug, roadmap);
+      res.status(204).send();
+    } catch (err) {
+      res.status(400).json({ error: String(err) });
+    }
+  });
+
+  router.post('/projects/:slug/roadmap/features/:id/convert', (req, res) => {
+    try {
+      const { epic_id } = req.body as { epic_id?: number };
+      if (!epic_id) return res.status(400).json({ error: 'epic_id is required' });
+
+      const roadmap = roadmapStore.readRoadmap(req.params.slug);
+      if (!roadmap) return res.status(404).json({ error: 'Not found' });
+      const featureIdx = roadmap.features.findIndex(f => f.id === req.params.id);
+      if (featureIdx === -1) return res.status(404).json({ error: 'Feature not found' });
+
+      const feature = roadmap.features[featureIdx];
+      const descriptionParts: string[] = [];
+      descriptionParts.push(`## ${feature.title}`);
+      if (feature.description) descriptionParts.push(`\n${feature.description}`);
+      if (feature.rationale) descriptionParts.push(`\n### Rationale\n${feature.rationale}`);
+      if (feature.userStories?.length) {
+        descriptionParts.push(`\n### User Stories\n${feature.userStories.map(s => `- ${s}`).join('\n')}`);
+      }
+      if (feature.acceptanceCriteria?.length) {
+        descriptionParts.push(`\n### Acceptance Criteria\n${feature.acceptanceCriteria.map(c => `- ${c}`).join('\n')}`);
+      }
+      const description = descriptionParts.join('\n');
+
+      const task = store.createTask(req.params.slug, epic_id, feature.title, description);
+      store.updateTask(req.params.slug, task.id, { linkedFeatureId: feature.id });
+
+      roadmap.features[featureIdx].linkedTaskId = task.id;
+      roadmap.updated_at = new Date().toISOString();
+      roadmapStore.writeRoadmap(req.params.slug, roadmap);
+
+      res.status(201).json({ data: task });
+    } catch (err) {
+      res.status(400).json({ error: String(err) });
+    }
+  });
+
+  // --- Competitor Analysis ---
+
+  router.get('/projects/:slug/competitors', (req, res) => {
+    try {
+      const analysis = roadmapStore.readCompetitorAnalysis(req.params.slug);
+      if (!analysis) return res.status(404).json({ error: 'Not found' });
+      res.json({ data: analysis });
+    } catch (err) {
+      res.status(500).json({ error: String(err) });
+    }
+  });
+
+  router.put('/projects/:slug/competitors', (req, res) => {
+    try {
+      const analysis = {
+        ...req.body,
+        created_at: req.body.created_at ?? new Date().toISOString(),
+      };
+      roadmapStore.writeCompetitorAnalysis(req.params.slug, analysis);
+      res.json({ data: analysis });
+    } catch (err) {
+      res.status(400).json({ error: String(err) });
+    }
+  });
+
+  router.post('/projects/:slug/competitors', (req, res) => {
+    try {
+      const competitor = { ...req.body, id: randomUUID() };
+      let analysis = roadmapStore.readCompetitorAnalysis(req.params.slug);
+      if (!analysis) {
+        analysis = {
+          projectContext: { projectName: req.params.slug, projectType: '', targetAudience: '' },
+          competitors: [],
+          marketGaps: [],
+          insightsSummary: { topPainPoints: [], differentiatorOpportunities: [], marketTrends: [] },
+          researchMetadata: { searchQueriesUsed: [], sourcesConsulted: [], limitations: [] },
+          created_at: new Date().toISOString(),
+        };
+      }
+      analysis.competitors.push(competitor);
+      roadmapStore.writeCompetitorAnalysis(req.params.slug, analysis);
+      res.status(201).json({ data: competitor });
+    } catch (err) {
+      res.status(400).json({ error: String(err) });
+    }
+  });
+
+  return router;
+}

--- a/packages/board-server/src/http/routes.ts
+++ b/packages/board-server/src/http/routes.ts
@@ -1,9 +1,12 @@
 import { Router } from 'express';
 import * as store from '../store/yaml-store.js';
 import type { TaskStatus, TaskPriority, TaskCategory, TaskComplexity, SubtaskStatus, EpicStatus, ExecutionStatus } from '../types.js';
+import { createRoadmapRouter } from './roadmap-routes.js';
 
 export function createRouter(): Router {
   const router = Router();
+
+  router.use('/', createRoadmapRouter());
 
   // --- Projects ---
 

--- a/packages/board-server/src/mcp/server.ts
+++ b/packages/board-server/src/mcp/server.ts
@@ -7,8 +7,9 @@ import {
 import { projectTools } from './tools/project.js';
 import { epicTools } from './tools/epic.js';
 import { taskTools } from './tools/task.js';
+import { roadmapTools } from './tools/roadmap.js';
 
-const allTools = [...projectTools, ...epicTools, ...taskTools];
+const allTools = [...projectTools, ...epicTools, ...taskTools, ...roadmapTools];
 
 type AnyTool = (typeof allTools)[number];
 type ToolName = AnyTool['name'];

--- a/packages/board-server/src/mcp/tools/roadmap.ts
+++ b/packages/board-server/src/mcp/tools/roadmap.ts
@@ -43,10 +43,6 @@ export const roadmapTools = [
     }),
     handler: async (args: { project: string; roadmap: Record<string, unknown> }) => {
       const { roadmap: raw } = args;
-      // Runtime validation: required fields
-      if (!raw.id && !raw.projectSlug && !raw.version && !Array.isArray(raw.phases) && !Array.isArray(raw.features)) {
-        // At least one of the key fields must be present; build a specific error if any are missing
-      }
       const missingFields: string[] = [];
       if (!raw.version) missingFields.push('version');
       if (!Array.isArray(raw.phases)) missingFields.push('phases (array)');

--- a/packages/board-server/src/mcp/tools/roadmap.ts
+++ b/packages/board-server/src/mcp/tools/roadmap.ts
@@ -1,0 +1,313 @@
+import { z } from 'zod';
+import { randomUUID } from 'node:crypto';
+import * as roadmapStore from '../../store/roadmap-store.js';
+import * as store from '../../store/yaml-store.js';
+import type { RoadmapFeature, RoadmapFeatureStatus, RoadmapFeaturePriority } from '../../roadmap-types.js';
+
+export const roadmapTools = [
+  {
+    name: 'get_roadmap',
+    description: 'Get the roadmap for a project',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        project: { type: 'string', description: 'Project slug' },
+      },
+      required: ['project'],
+    },
+    schema: z.object({
+      project: z.string(),
+    }),
+    handler: async (args: { project: string }) => {
+      const roadmap = roadmapStore.readRoadmap(args.project);
+      if (!roadmap) {
+        return { content: [{ type: 'text' as const, text: 'No roadmap found' }] };
+      }
+      return { content: [{ type: 'text' as const, text: JSON.stringify(roadmap, null, 2) }] };
+    },
+  },
+  {
+    name: 'save_roadmap',
+    description: 'Persist a roadmap for a project (Claude generates the roadmap object and calls this to save it)',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        project: { type: 'string', description: 'Project slug' },
+        roadmap: { type: 'object', description: 'Roadmap object conforming to the Roadmap type' },
+      },
+      required: ['project', 'roadmap'],
+    },
+    schema: z.object({
+      project: z.string(),
+      roadmap: z.record(z.unknown()),
+    }),
+    handler: async (args: { project: string; roadmap: Record<string, unknown> }) => {
+      const { roadmap: raw } = args;
+      // Runtime validation: required fields
+      if (!raw.id && !raw.projectSlug && !raw.version && !Array.isArray(raw.phases) && !Array.isArray(raw.features)) {
+        // At least one of the key fields must be present; build a specific error if any are missing
+      }
+      const missingFields: string[] = [];
+      if (!raw.version) missingFields.push('version');
+      if (!Array.isArray(raw.phases)) missingFields.push('phases (array)');
+      if (!Array.isArray(raw.features)) missingFields.push('features (array)');
+      if (missingFields.length > 0) {
+        return { content: [{ type: 'text' as const, text: `Invalid roadmap: missing required fields: ${missingFields.join(', ')}` }] };
+      }
+      const now = new Date().toISOString();
+      const roadmap = {
+        ...raw,
+        projectSlug: args.project,
+        updated_at: now,
+        created_at: (raw.created_at as string | undefined) ?? now,
+        id: (raw.id as string | undefined) ?? randomUUID(),
+      };
+      roadmapStore.writeRoadmap(args.project, roadmap as unknown as import('../../roadmap-types.js').Roadmap);
+      return { content: [{ type: 'text' as const, text: `Roadmap saved for project "${args.project}"` }] };
+    },
+  },
+  {
+    name: 'get_competitor_analysis',
+    description: 'Get the competitor analysis for a project',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        project: { type: 'string', description: 'Project slug' },
+      },
+      required: ['project'],
+    },
+    schema: z.object({
+      project: z.string(),
+    }),
+    handler: async (args: { project: string }) => {
+      const analysis = roadmapStore.readCompetitorAnalysis(args.project);
+      if (!analysis) {
+        return { content: [{ type: 'text' as const, text: 'No competitor analysis found' }] };
+      }
+      return { content: [{ type: 'text' as const, text: JSON.stringify(analysis, null, 2) }] };
+    },
+  },
+  {
+    name: 'save_competitor_analysis',
+    description: 'Persist competitor analysis for a project',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        project: { type: 'string', description: 'Project slug' },
+        analysis: { type: 'object', description: 'CompetitorAnalysis object' },
+      },
+      required: ['project', 'analysis'],
+    },
+    schema: z.object({
+      project: z.string(),
+      analysis: z.record(z.unknown()),
+    }),
+    handler: async (args: { project: string; analysis: Record<string, unknown> }) => {
+      const { analysis: raw } = args;
+      if (!Array.isArray(raw.competitors)) {
+        return { content: [{ type: 'text' as const, text: 'Invalid competitor analysis: missing required field: competitors (array)' }] };
+      }
+      const analysis = {
+        ...raw,
+        created_at: (raw.created_at as string | undefined) ?? new Date().toISOString(),
+      };
+      roadmapStore.writeCompetitorAnalysis(args.project, analysis as unknown as import('../../roadmap-types.js').CompetitorAnalysis);
+      return { content: [{ type: 'text' as const, text: `Competitor analysis saved for project "${args.project}"` }] };
+    },
+  },
+  {
+    name: 'list_roadmap_features',
+    description: 'List roadmap features, optionally filtered by status or priority',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        project: { type: 'string', description: 'Project slug' },
+        status: { type: 'string', enum: ['backlog', 'planning', 'in_progress', 'done'], description: 'Filter by status' },
+        priority: { type: 'string', enum: ['must', 'should', 'could', 'wont'], description: 'Filter by priority' },
+      },
+      required: ['project'],
+    },
+    schema: z.object({
+      project: z.string(),
+      status: z.enum(['backlog', 'planning', 'in_progress', 'done']).optional(),
+      priority: z.enum(['must', 'should', 'could', 'wont']).optional(),
+    }),
+    handler: async (args: { project: string; status?: RoadmapFeatureStatus; priority?: RoadmapFeaturePriority }) => {
+      const roadmap = roadmapStore.readRoadmap(args.project);
+      if (!roadmap) {
+        return { content: [{ type: 'text' as const, text: 'No roadmap found' }] };
+      }
+      let features = roadmap.features;
+      if (args.status) features = features.filter(f => f.status === args.status);
+      if (args.priority) features = features.filter(f => f.priority === args.priority);
+      if (features.length === 0) {
+        return { content: [{ type: 'text' as const, text: 'No features match the given filters' }] };
+      }
+      const lines = features.map(f =>
+        `[${f.id}] ${f.title} | status: ${f.status} | priority: ${f.priority} | complexity: ${f.complexity} | impact: ${f.impact}${f.linkedTaskId ? ` | task: #${f.linkedTaskId}` : ''}`,
+      );
+      return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
+    },
+  },
+  {
+    name: 'add_roadmap_feature',
+    description: 'Add a single feature to an existing roadmap',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        project: { type: 'string', description: 'Project slug' },
+        feature: { type: 'object', description: 'Feature object (title, description, rationale, priority, complexity, impact, phaseId, status, acceptanceCriteria, userStories are required)' },
+      },
+      required: ['project', 'feature'],
+    },
+    schema: z.object({
+      project: z.string(),
+      feature: z.record(z.unknown()),
+    }),
+    handler: async (args: { project: string; feature: Record<string, unknown> }) => {
+      const roadmap = roadmapStore.readRoadmap(args.project);
+      if (!roadmap) {
+        return { content: [{ type: 'text' as const, text: 'No roadmap found — create one first with save_roadmap' }] };
+      }
+      const feature = {
+        dependencies: [],
+        acceptanceCriteria: [],
+        userStories: [],
+        competitorInsightIds: [],
+        ...(args.feature as Partial<RoadmapFeature>),
+        id: randomUUID(),
+      } as RoadmapFeature;
+      roadmap.features.push(feature);
+      roadmap.updated_at = new Date().toISOString();
+      roadmapStore.writeRoadmap(args.project, roadmap);
+      return { content: [{ type: 'text' as const, text: JSON.stringify(feature, null, 2) }] };
+    },
+  },
+  {
+    name: 'update_roadmap_feature',
+    description: 'Patch fields on an existing roadmap feature',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        project: { type: 'string', description: 'Project slug' },
+        feature_id: { type: 'string', description: 'Feature ID' },
+        updates: { type: 'object', description: 'Fields to update on the feature' },
+      },
+      required: ['project', 'feature_id', 'updates'],
+    },
+    schema: z.object({
+      project: z.string(),
+      feature_id: z.string(),
+      updates: z.record(z.unknown()),
+    }),
+    handler: async (args: { project: string; feature_id: string; updates: Record<string, unknown> }) => {
+      const roadmap = roadmapStore.readRoadmap(args.project);
+      if (!roadmap) {
+        return { content: [{ type: 'text' as const, text: 'No roadmap found' }] };
+      }
+      const idx = roadmap.features.findIndex(f => f.id === args.feature_id);
+      if (idx === -1) {
+        return { content: [{ type: 'text' as const, text: `Feature "${args.feature_id}" not found` }] };
+      }
+      // Prevent overwriting the id
+      const { id: _id, ...safeUpdates } = args.updates as Record<string, unknown> & { id?: unknown };
+      Object.assign(roadmap.features[idx], safeUpdates);
+      roadmap.updated_at = new Date().toISOString();
+      roadmapStore.writeRoadmap(args.project, roadmap);
+      return { content: [{ type: 'text' as const, text: JSON.stringify(roadmap.features[idx], null, 2) }] };
+    },
+  },
+  {
+    name: 'delete_roadmap_feature',
+    description: 'Remove a feature from the roadmap',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        project: { type: 'string', description: 'Project slug' },
+        feature_id: { type: 'string', description: 'Feature ID' },
+      },
+      required: ['project', 'feature_id'],
+    },
+    schema: z.object({
+      project: z.string(),
+      feature_id: z.string(),
+    }),
+    handler: async (args: { project: string; feature_id: string }) => {
+      const roadmap = roadmapStore.readRoadmap(args.project);
+      if (!roadmap) {
+        return { content: [{ type: 'text' as const, text: 'No roadmap found' }] };
+      }
+      const idx = roadmap.features.findIndex(f => f.id === args.feature_id);
+      if (idx === -1) {
+        return { content: [{ type: 'text' as const, text: `Feature "${args.feature_id}" not found` }] };
+      }
+      roadmap.features.splice(idx, 1);
+      roadmap.updated_at = new Date().toISOString();
+      roadmapStore.writeRoadmap(args.project, roadmap);
+      return { content: [{ type: 'text' as const, text: `Feature "${args.feature_id}" deleted` }] };
+    },
+  },
+  {
+    name: 'convert_feature_to_task',
+    description: 'Create a board task from a roadmap feature and link them together',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        project: { type: 'string', description: 'Project slug' },
+        feature_id: { type: 'string', description: 'Roadmap feature ID' },
+        epic_id: { type: 'number', description: 'Epic ID to create the task under' },
+      },
+      required: ['project', 'feature_id', 'epic_id'],
+    },
+    schema: z.object({
+      project: z.string(),
+      feature_id: z.string(),
+      epic_id: z.number(),
+    }),
+    handler: async (args: { project: string; feature_id: string; epic_id: number }) => {
+      const roadmap = roadmapStore.readRoadmap(args.project);
+      if (!roadmap) {
+        return { content: [{ type: 'text' as const, text: 'No roadmap found' }] };
+      }
+      const featureIdx = roadmap.features.findIndex(f => f.id === args.feature_id);
+      if (featureIdx === -1) {
+        return { content: [{ type: 'text' as const, text: `Feature "${args.feature_id}" not found` }] };
+      }
+      const feature = roadmap.features[featureIdx];
+
+      const descriptionParts: string[] = [];
+      descriptionParts.push(`## ${feature.title}`);
+      if (feature.description) descriptionParts.push(`\n${feature.description}`);
+      if (feature.rationale) descriptionParts.push(`\n### Rationale\n${feature.rationale}`);
+      if (feature.userStories?.length) {
+        descriptionParts.push(`\n### User Stories\n${feature.userStories.map(s => `- ${s}`).join('\n')}`);
+      }
+      if (feature.acceptanceCriteria?.length) {
+        descriptionParts.push(`\n### Acceptance Criteria\n${feature.acceptanceCriteria.map(c => `- ${c}`).join('\n')}`);
+      }
+      const description = descriptionParts.join('\n');
+
+      const task = store.createTask(args.project, args.epic_id, feature.title, description);
+
+      // Link task → feature using updateTask (avoids a redundant read/write)
+      store.updateTask(args.project, task.id, { linkedFeatureId: feature.id });
+
+      // Link feature → task
+      roadmap.features[featureIdx].linkedTaskId = task.id;
+      roadmap.updated_at = new Date().toISOString();
+      roadmapStore.writeRoadmap(args.project, roadmap);
+
+      return {
+        content: [{
+          type: 'text' as const,
+          text: [
+            `Task #${task.id} created: "${task.title}"`,
+            `Feature "${args.feature_id}" linked to task #${task.id}`,
+            '',
+            JSON.stringify(task, null, 2),
+          ].join('\n'),
+        }],
+      };
+    },
+  },
+] as const;

--- a/packages/board-server/src/roadmap-types.ts
+++ b/packages/board-server/src/roadmap-types.ts
@@ -1,0 +1,130 @@
+export type CompetitorSource = 'manual' | 'ai';
+export type CompetitorRelevance = 'high' | 'medium' | 'low';
+export type PainPointSeverity = 'high' | 'medium' | 'low';
+export type OpportunitySize = 'high' | 'medium' | 'low';
+
+export interface CompetitorPainPoint {
+  id: string;
+  description: string;
+  source: string;
+  severity: PainPointSeverity;
+  frequency: string;
+  opportunity: string;
+}
+
+export interface Competitor {
+  id: string;
+  name: string;
+  url: string;
+  description: string;
+  relevance: CompetitorRelevance;
+  painPoints: CompetitorPainPoint[];
+  strengths: string[];
+  marketPosition: string;
+  source?: CompetitorSource;
+}
+
+export interface ManualCompetitorInput {
+  name: string;
+  url: string;
+  description: string;
+  relevance: CompetitorRelevance;
+}
+
+export interface CompetitorMarketGap {
+  id: string;
+  description: string;
+  affectedCompetitors: string[];
+  opportunitySize: OpportunitySize;
+  suggestedFeature: string;
+}
+
+export interface CompetitorInsightsSummary {
+  topPainPoints: string[];
+  differentiatorOpportunities: string[];
+  marketTrends: string[];
+}
+
+export interface CompetitorResearchMetadata {
+  searchQueriesUsed: string[];
+  sourcesConsulted: string[];
+  limitations: string[];
+}
+
+export interface CompetitorAnalysis {
+  projectContext: {
+    projectName: string;
+    projectType: string;
+    targetAudience: string;
+  };
+  competitors: Competitor[];
+  marketGaps: CompetitorMarketGap[];
+  insightsSummary: CompetitorInsightsSummary;
+  researchMetadata: CompetitorResearchMetadata;
+  created_at: string;
+}
+
+export type RoadmapFeaturePriority = 'must' | 'should' | 'could' | 'wont';
+export type RoadmapFeatureStatus = 'backlog' | 'planning' | 'in_progress' | 'done';
+export type RoadmapPhaseStatus = 'planned' | 'in_progress' | 'completed';
+export type RoadmapStatus = 'draft' | 'active' | 'archived';
+
+export interface TargetAudience {
+  primary: string;
+  secondary: string[];
+  painPoints?: string[];
+  goals?: string[];
+  usageContext?: string;
+}
+
+export type RoadmapMilestoneStatus = 'planned' | 'achieved';
+
+export interface RoadmapMilestone {
+  id: string;
+  title: string;
+  description: string;
+  features: string[];
+  status: RoadmapMilestoneStatus;
+  targetDate?: string;
+}
+
+export interface RoadmapPhase {
+  id: string;
+  name: string;
+  description: string;
+  order: number;
+  status: RoadmapPhaseStatus;
+  features: string[];
+  milestones: RoadmapMilestone[];
+}
+
+export interface RoadmapFeature {
+  id: string;
+  title: string;
+  description: string;
+  rationale: string;
+  priority: RoadmapFeaturePriority;
+  complexity: 'low' | 'medium' | 'high';
+  impact: 'low' | 'medium' | 'high';
+  phaseId: string;
+  dependencies: string[];
+  status: RoadmapFeatureStatus;
+  acceptanceCriteria: string[];
+  userStories: string[];
+  linkedTaskId?: number;
+  competitorInsightIds?: string[];
+}
+
+export interface Roadmap {
+  id: string;
+  projectSlug: string;
+  projectName: string;
+  version: string;
+  vision: string;
+  targetAudience: TargetAudience;
+  phases: RoadmapPhase[];
+  features: RoadmapFeature[];
+  status: RoadmapStatus;
+  created_at: string;
+  updated_at: string;
+}

--- a/packages/board-server/src/store/file-watcher.ts
+++ b/packages/board-server/src/store/file-watcher.ts
@@ -25,6 +25,13 @@ export class FileWatcher extends EventEmitter {
       const timer = setTimeout(() => {
         this.debounceTimers.delete(filename);
         this.emit('change', { type: eventType, filename } satisfies FileWatcherEvent);
+        if (filename.endsWith('.roadmap.yaml')) {
+          const slug = filename.replace(/\.roadmap\.yaml$/, '');
+          this.emit('roadmap_updated', { slug });
+        } else if (filename.endsWith('.competitors.yaml')) {
+          const slug = filename.replace(/\.competitors\.yaml$/, '');
+          this.emit('competitors_updated', { slug });
+        }
       }, this.debounceMs);
       this.debounceTimers.set(filename, timer);
     });

--- a/packages/board-server/src/store/roadmap-store.ts
+++ b/packages/board-server/src/store/roadmap-store.ts
@@ -1,0 +1,64 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import yaml from 'js-yaml';
+import type { Roadmap, CompetitorAnalysis } from '../roadmap-types.js';
+
+function getBoardDir(): string {
+  if (process.env.NODE_ENV === 'test' && process.env.BOARD_TEST_DIR) {
+    return process.env.BOARD_TEST_DIR;
+  }
+  return path.join(os.homedir(), '.harness', 'board', 'projects');
+}
+
+let roadmapDirEnsured = false;
+function ensureRoadmapDir(): void {
+  if (roadmapDirEnsured) return;
+  fs.mkdirSync(getBoardDir(), { recursive: true });
+  roadmapDirEnsured = true;
+}
+
+// For testing: reset the roadmapDirEnsured flag
+export function resetRoadmapDirCache(): void {
+  roadmapDirEnsured = false;
+}
+
+function roadmapPath(slug: string): string {
+  return path.join(getBoardDir(), `${slug}.roadmap.yaml`);
+}
+
+function competitorsPath(slug: string): string {
+  return path.join(getBoardDir(), `${slug}.competitors.yaml`);
+}
+
+export function readRoadmap(slug: string): Roadmap | null {
+  const filePath = roadmapPath(slug);
+  if (!fs.existsSync(filePath)) return null;
+  const raw = fs.readFileSync(filePath, 'utf-8');
+  return yaml.load(raw) as Roadmap;
+}
+
+export function writeRoadmap(slug: string, roadmap: Roadmap): void {
+  ensureRoadmapDir();
+  const filePath = roadmapPath(slug);
+  const raw = yaml.dump(roadmap, { lineWidth: 120 });
+  const tmpPath = `${filePath}.tmp`;
+  fs.writeFileSync(tmpPath, raw, 'utf-8');
+  fs.renameSync(tmpPath, filePath);
+}
+
+export function readCompetitorAnalysis(slug: string): CompetitorAnalysis | null {
+  const filePath = competitorsPath(slug);
+  if (!fs.existsSync(filePath)) return null;
+  const raw = fs.readFileSync(filePath, 'utf-8');
+  return yaml.load(raw) as CompetitorAnalysis;
+}
+
+export function writeCompetitorAnalysis(slug: string, analysis: CompetitorAnalysis): void {
+  ensureRoadmapDir();
+  const filePath = competitorsPath(slug);
+  const raw = yaml.dump(analysis, { lineWidth: 120 });
+  const tmpPath = `${filePath}.tmp`;
+  fs.writeFileSync(tmpPath, raw, 'utf-8');
+  fs.renameSync(tmpPath, filePath);
+}

--- a/packages/board-server/src/store/roadmap-store.ts
+++ b/packages/board-server/src/store/roadmap-store.ts
@@ -23,11 +23,20 @@ export function resetRoadmapDirCache(): void {
   roadmapDirEnsured = false;
 }
 
+/** Reject slugs that could escape the board directory via path traversal. */
+function assertSafeSlug(slug: string): void {
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(slug)) {
+    throw new Error(`Invalid project slug: "${slug}"`);
+  }
+}
+
 function roadmapPath(slug: string): string {
+  assertSafeSlug(slug);
   return path.join(getBoardDir(), `${slug}.roadmap.yaml`);
 }
 
 function competitorsPath(slug: string): string {
+  assertSafeSlug(slug);
   return path.join(getBoardDir(), `${slug}.competitors.yaml`);
 }
 

--- a/packages/board-server/src/store/yaml-store.ts
+++ b/packages/board-server/src/store/yaml-store.ts
@@ -73,7 +73,7 @@ export function writeProject(project: Project): void {
 export function listProjects(): Project[] {
   ensureBoardDir();
   const boardDir = getBoardDir();
-  const files = fs.readdirSync(boardDir).filter(f => f.endsWith('.yaml'));
+  const files = fs.readdirSync(boardDir).filter(f => f.endsWith('.yaml') && !f.includes('.roadmap') && !f.includes('.competitors'));
   return files.map(f => {
     const raw = fs.readFileSync(path.join(boardDir, f), 'utf-8');
     const project = yaml.load(raw) as Project;
@@ -221,7 +221,7 @@ function withTask(projectSlug: string, taskId: number, fn: (task: Task, epic: Ep
 export function updateTask(
   projectSlug: string,
   taskId: number,
-  updates: Partial<Pick<Task, 'title' | 'description' | 'status' | 'priority' | 'category' | 'complexity' | 'no_worktree' | 'default_harness' | 'default_model'>>,
+  updates: Partial<Pick<Task, 'title' | 'description' | 'status' | 'priority' | 'category' | 'complexity' | 'no_worktree' | 'default_harness' | 'default_model' | 'linkedFeatureId'>>,
 ): Task {
   // Strip undefined values so we don't wipe existing fields
   const cleanUpdates = Object.fromEntries(Object.entries(updates).filter(([, v]) => v !== undefined));

--- a/packages/board-server/src/types.ts
+++ b/packages/board-server/src/types.ts
@@ -37,6 +37,7 @@ export interface Task {
   status: TaskStatus;
   priority?: TaskPriority;
   branch?: string;
+  linkedFeatureId?: string;
   worktree_path?: string;
   linked_commits: string[];
   comments: Comment[];

--- a/packages/board-server/src/ws/hub.ts
+++ b/packages/board-server/src/ws/hub.ts
@@ -26,6 +26,7 @@ export class WsHub {
 
     // When a YAML file changes (externally or via MCP subprocess), push the updated project
     this.watcher.on('change', ({ filename }: { filename: string }) => {
+      if (filename.endsWith('.roadmap.yaml') || filename.endsWith('.competitors.yaml')) return;
       const slug = filename.replace(/\.yaml$/, '');
       const project = store.readProject(slug);
       if (!project) return;

--- a/packages/board-server/src/ws/hub.ts
+++ b/packages/board-server/src/ws/hub.ts
@@ -5,6 +5,8 @@ import { FileWatcher } from '../store/file-watcher.js';
 
 export type BoardEvent =
   | { type: 'project_updated'; slug: string; project: ReturnType<typeof store.readProject> }
+  | { type: 'roadmap_updated'; slug: string }
+  | { type: 'competitors_updated'; slug: string }
   | { type: 'connected'; message: string };
 
 export class WsHub {
@@ -29,6 +31,14 @@ export class WsHub {
       if (!project) return;
       const event: BoardEvent = { type: 'project_updated', slug, project };
       this.broadcast(event);
+    });
+
+    this.watcher.on('roadmap_updated', ({ slug }: { slug: string }) => {
+      this.broadcast({ type: 'roadmap_updated', slug });
+    });
+
+    this.watcher.on('competitors_updated', ({ slug }: { slug: string }) => {
+      this.broadcast({ type: 'competitors_updated', slug });
     });
 
     this.watcher.on('error', (err: unknown) => {


### PR DESCRIPTION
## Summary

Adds a full-featured Roadmap module to the desktop app — a strategic layer sitting above the Board for planning product vision, features, and competitor intelligence. Features flow from Roadmap → Board via a \"Convert to Task\" action with bidirectional linking.

This extends the existing board-server (no new server) with separate YAML storage files alongside each project's board data. Claude acts as the AI engine via MCP tools — it generates roadmaps and competitor research and calls storage tools to persist the results.

## Changes

**Backend (board-server):**
- New `roadmap-types.ts` — full type system: `Roadmap`, `RoadmapFeature` (MoSCoW priority, 4-column status), `RoadmapPhase`, `CompetitorAnalysis`, `Competitor`, `CompetitorPainPoint`, etc.
- New `store/roadmap-store.ts` — synchronous YAML read/write to `{slug}.roadmap.yaml` and `{slug}.competitors.yaml` alongside existing board data; atomic temp-file-rename writes
- New `mcp/tools/roadmap.ts` — 9 MCP tools: `get_roadmap`, `save_roadmap`, `add/update/delete_roadmap_feature`, `get/save_competitor_analysis`, `convert_feature_to_task`
- New `http/roadmap-routes.ts` — 10 REST endpoints returning bare JSON (no envelope), consistent with board routes
- Extended `file-watcher.ts` + `ws/hub.ts` — `roadmap_updated` and `competitors_updated` WebSocket events when YAML files change
- Fixed `listProjects` to exclude `.roadmap.yaml` / `.competitors.yaml` from project list
- Added `linkedFeatureId?` to Task type for bidirectional linking

**Frontend (desktop):**
- `lib/roadmap-types.ts`, `lib/roadmap-api.ts`, `lib/roadmap-constants.ts` — API client using shared `apiFetch`, 4-column/priority/complexity/impact configs
- `hooks/useRoadmapData.ts` — fetches roadmap + competitor data, subscribes to WebSocket events
- 11 components in `components/roadmap/`: `RoadmapEmptyState`, `RoadmapHeader`, `RoadmapTabs`, `RoadmapKanbanView` (dnd-kit DnD), `SortableFeatureCard`, `FeatureCard`, `FeatureDetailPanel` (slide-in right panel), `PhaseCard`, `CompetitorAnalysisViewer`, `AddFeatureDialog`, `AddCompetitorDialog`
- `pages/roadmap/RoadmapProjectsPage.tsx` + `RoadmapPage.tsx` — 4 tab views (Kanban, Phases, All Features, By Priority), epic picker for convert-to-task
- Routes added to `App.tsx`, "Roadmap" section added to sidebar nav in `AppLayout.tsx`
- "View on Roadmap" chip in task detail dialog when task has a `linkedFeatureId`

## Test Plan
- [x] All 130 board-server unit tests pass (`vitest run`)
- [x] Board-server TypeScript build clean (`tsc`)
- [x] Desktop TypeScript type check clean (`tsc --noEmit`)
- [ ] CI checks pass
- [ ] Manual: start board-server, ask Claude to call `save_roadmap` via MCP, verify roadmap appears in Roadmap sidebar
- [ ] Manual: convert a feature to a task, verify bidirectional link and "View on Roadmap" chip in task detail

## Notes

- Claude drives roadmap generation via MCP — the UI surfaces an empty state hint prompting the user to ask Claude to generate. No AI SDK dependency added.
- `convert_feature_to_task` is atomic: creates the board task and sets `linkedFeatureId` in a single `updateTask` call.
- All inline styles use CSS custom properties (`var(--bg-surface)`, `var(--accent)`, etc.) — no Tailwind. Consistent with board components.
- No Aperant/Auto-Claude naming anywhere in the output code or UI.