### PR TITLE
feat(roadmap): in-app AI generation via Claude Code OAuth

### DIFF
--- a/apps/desktop/src-tauri/src/board_server.rs
+++ b/apps/desktop/src-tauri/src/board_server.rs
@@ -72,17 +72,10 @@ fn xml_escape(s: &str) -> String {
         .replace('"', "&quot;")
 }
 
-fn generate_plist(node_path: &str, server_dir: &str, log_dir: &str, anthropic_key: Option<&str>) -> String {
+fn generate_plist(node_path: &str, server_dir: &str, log_dir: &str) -> String {
     let node_path = xml_escape(node_path);
     let server_dir = xml_escape(server_dir);
     let log_dir = xml_escape(log_dir);
-    let anthropic_key_entry = match anthropic_key {
-        Some(k) if !k.is_empty() => format!(
-            "\n    <key>ANTHROPIC_API_KEY</key>\n    <string>{}</string>",
-            xml_escape(k)
-        ),
-        _ => String::new(),
-    };
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -121,7 +114,7 @@ fn generate_plist(node_path: &str, server_dir: &str, log_dir: &str, anthropic_ke
   <key>EnvironmentVariables</key>
   <dict>
     <key>BOARD_PORT</key>
-    <string>4800</string>{anthropic_key_entry}
+    <string>4800</string>
   </dict>
 </dict>
 </plist>"#
@@ -146,8 +139,7 @@ pub fn board_server_install() -> Result<String, String> {
         .map_err(|_| "Failed to create log directory".to_string())?;
     let log_dir_str = log_dir.to_string_lossy().to_string();
 
-    let anthropic_key = std::env::var("ANTHROPIC_API_KEY").ok();
-    let plist_content = generate_plist(&node_path, &server_dir_str, &log_dir_str, anthropic_key.as_deref());
+    let plist_content = generate_plist(&node_path, &server_dir_str, &log_dir_str);
     let plist = plist_path();
 
     std::fs::write(&plist, &plist_content)

--- a/apps/desktop/src-tauri/src/board_server.rs
+++ b/apps/desktop/src-tauri/src/board_server.rs
@@ -72,10 +72,17 @@ fn xml_escape(s: &str) -> String {
         .replace('"', "&quot;")
 }
 
-fn generate_plist(node_path: &str, server_dir: &str, log_dir: &str) -> String {
+fn generate_plist(node_path: &str, server_dir: &str, log_dir: &str, anthropic_key: Option<&str>) -> String {
     let node_path = xml_escape(node_path);
     let server_dir = xml_escape(server_dir);
     let log_dir = xml_escape(log_dir);
+    let anthropic_key_entry = match anthropic_key {
+        Some(k) if !k.is_empty() => format!(
+            "\n    <key>ANTHROPIC_API_KEY</key>\n    <string>{}</string>",
+            xml_escape(k)
+        ),
+        _ => String::new(),
+    };
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -114,7 +121,7 @@ fn generate_plist(node_path: &str, server_dir: &str, log_dir: &str) -> String {
   <key>EnvironmentVariables</key>
   <dict>
     <key>BOARD_PORT</key>
-    <string>4800</string>
+    <string>4800</string>{anthropic_key_entry}
   </dict>
 </dict>
 </plist>"#
@@ -139,7 +146,8 @@ pub fn board_server_install() -> Result<String, String> {
         .map_err(|_| "Failed to create log directory".to_string())?;
     let log_dir_str = log_dir.to_string_lossy().to_string();
 
-    let plist_content = generate_plist(&node_path, &server_dir_str, &log_dir_str);
+    let anthropic_key = std::env::var("ANTHROPIC_API_KEY").ok();
+    let plist_content = generate_plist(&node_path, &server_dir_str, &log_dir_str, anthropic_key.as_deref());
     let plist = plist_path();
 
     std::fs::write(&plist, &plist_content)

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -11,7 +11,7 @@ mod membrain_commands;
 #[cfg(test)]
 pub static HOME_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-use tauri::Manager;
+use tauri::{LogicalSize, Manager};
 use ai::client::OllamaState;
 use commands::terminal::TerminalState;
 use board_server::BoardServerState;
@@ -193,6 +193,19 @@ pub fn run() {
             // membrain server starts on-demand when the user navigates to the
             // Memory section (via useMembrainServerReady hook), not at app launch.
             // This avoids opening a network listener until the Labs feature is enabled.
+
+            // Size the main window to 75% of the primary monitor on launch.
+            if let Some(window) = app.get_webview_window("main") {
+                if let Ok(Some(monitor)) = window.primary_monitor() {
+                    let scale = monitor.scale_factor();
+                    let phys = monitor.size();
+                    let w = phys.width as f64 / scale * 0.75;
+                    let h = phys.height as f64 / scale * 0.75;
+                    let _ = window.set_size(LogicalSize::new(w, h));
+                    let _ = window.center();
+                }
+            }
+
             Ok(())
         })
         .build(tauri::generate_context!())

--- a/apps/desktop/src/components/roadmap/RoadmapEmptyState.tsx
+++ b/apps/desktop/src/components/roadmap/RoadmapEmptyState.tsx
@@ -35,10 +35,14 @@ export function RoadmapEmptyState({ onGenerate }: Props) {
             alignItems: 'center',
             justifyContent: 'center',
             margin: '0 auto 16px',
-            fontSize: 24,
+            color: 'var(--text-muted)',
           }}
         >
-          {'🗺'}
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+            <polygon points="3 6 9 3 15 6 21 3 21 18 15 21 9 18 3 21" />
+            <line x1="9" y1="3" x2="9" y2="18" />
+            <line x1="15" y1="6" x2="15" y2="21" />
+          </svg>
         </div>
 
         <h2

--- a/apps/desktop/src/components/roadmap/RoadmapEmptyState.tsx
+++ b/apps/desktop/src/components/roadmap/RoadmapEmptyState.tsx
@@ -1,8 +1,17 @@
+import { useState } from 'react';
+
 interface Props {
   onGenerate: () => void;
 }
 
 export function RoadmapEmptyState({ onGenerate }: Props) {
+  const [loading, setLoading] = useState(false);
+
+  const handleClick = () => {
+    setLoading(true);
+    onGenerate();
+  };
+
   return (
     <div
       style={{
@@ -12,6 +21,9 @@ export function RoadmapEmptyState({ onGenerate }: Props) {
         justifyContent: 'center',
       }}
     >
+      <style>{`
+        @keyframes spin { to { transform: rotate(360deg); } }
+      `}</style>
       <div
         style={{
           width: '100%',
@@ -69,26 +81,42 @@ export function RoadmapEmptyState({ onGenerate }: Props) {
         </p>
 
         <button
-          onClick={onGenerate}
+          onClick={handleClick}
+          disabled={loading}
           style={{
             display: 'inline-flex',
             alignItems: 'center',
             gap: 6,
             padding: '8px 20px',
-            background: 'var(--accent)',
-            color: '#fff',
-            border: 'none',
+            background: loading ? 'var(--bg-surface)' : 'var(--accent)',
+            color: loading ? 'var(--text-muted)' : '#fff',
+            border: loading ? '1px solid var(--border-subtle)' : 'none',
             borderRadius: 7,
             fontSize: 13,
             fontWeight: 600,
-            cursor: 'pointer',
-            transition: 'opacity 0.1s',
+            cursor: loading ? 'default' : 'pointer',
+            transition: 'opacity 0.1s, background 0.15s, color 0.15s',
           }}
-          onMouseEnter={e => { (e.currentTarget as HTMLElement).style.opacity = '0.85'; }}
-          onMouseLeave={e => { (e.currentTarget as HTMLElement).style.opacity = '1'; }}
+          onMouseEnter={e => { if (!loading) (e.currentTarget as HTMLElement).style.opacity = '0.85'; }}
+          onMouseLeave={e => { if (!loading) (e.currentTarget as HTMLElement).style.opacity = '1'; }}
         >
-          <span style={{ fontSize: 14 }}>{'✦'}</span>
-          Generate Roadmap
+          {loading ? (
+            <svg
+              width="13"
+              height="13"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              style={{ animation: 'spin 0.8s linear infinite' }}
+            >
+              <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+            </svg>
+          ) : (
+            <span style={{ fontSize: 14 }}>✦</span>
+          )}
+          {loading ? 'Starting...' : 'Generate Roadmap'}
         </button>
       </div>
     </div>

--- a/apps/desktop/src/components/roadmap/RoadmapGenerationView.tsx
+++ b/apps/desktop/src/components/roadmap/RoadmapGenerationView.tsx
@@ -7,17 +7,27 @@ interface Props {
   onCancel: () => void;
 }
 
-const PHASES: { id: GenerationPhase | 'idle'; label: string }[] = [
-  { id: 'analyzing', label: 'Analyzing project' },
-  { id: 'generating', label: 'Generating roadmap' },
-  { id: 'saving', label: 'Saving' },
+const PHASES: { id: GenerationPhase; label: string; subtitle: string }[] = [
+  { id: 'analyzing',  label: 'Analyzing project',       subtitle: 'Reading tasks and epics' },
+  { id: 'generating', label: 'Generating roadmap',       subtitle: 'Claude is thinking...' },
+  { id: 'saving',     label: 'Saving',                   subtitle: 'Writing to disk' },
 ];
 
-function PhaseRow({ id, label, activePhase, error }: {
+const TIMEOUT_MS = 3 * 60 * 1000; // 3 minutes
+
+function formatElapsed(ms: number): string {
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  return `${Math.floor(s / 60)}m ${s % 60}s`;
+}
+
+function PhaseRow({ id, label, subtitle, activePhase, error, elapsed }: {
   id: GenerationPhase;
   label: string;
-  activePhase: GenerationPhase | 'idle' | 'done';
+  subtitle: string;
+  activePhase: GenerationPhase | 'done';
   error: string | null;
+  elapsed: number;
 }) {
   const idx = PHASES.findIndex(p => p.id === id);
   const activeIdx = PHASES.findIndex(p => p.id === activePhase);
@@ -36,20 +46,20 @@ function PhaseRow({ id, label, activePhase, error }: {
       style={{
         display: 'flex',
         alignItems: 'center',
-        gap: 10,
-        padding: '6px 0',
-        opacity: isPending ? 0.4 : 1,
+        gap: 12,
+        padding: '8px 0',
+        opacity: isPending ? 0.35 : 1,
         transition: 'opacity 0.3s',
       }}
     >
-      {/* Status indicator */}
+      {/* Status dot */}
       <div
         style={{
-          width: 20,
-          height: 20,
+          width: 22,
+          height: 22,
           borderRadius: '50%',
-          background: isFailed ? 'rgba(239,68,68,0.15)'
-            : isDone ? 'rgba(var(--accent-rgb, 99,102,241), 0.15)'
+          background: isFailed ? 'rgba(239,68,68,0.12)'
+            : isDone ? 'rgba(99,102,241,0.12)'
             : isActive ? 'var(--bg-surface)'
             : 'transparent',
           border: `1.5px solid ${color}`,
@@ -57,7 +67,7 @@ function PhaseRow({ id, label, activePhase, error }: {
           alignItems: 'center',
           justifyContent: 'center',
           flexShrink: 0,
-          transition: 'all 0.3s',
+          transition: 'all 0.25s',
         }}
       >
         {isDone && !isFailed && (
@@ -72,46 +82,73 @@ function PhaseRow({ id, label, activePhase, error }: {
           </svg>
         )}
         {isActive && !isFailed && (
-          <div
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
-              background: 'var(--accent)',
-              animation: 'pulse 1.2s ease-in-out infinite',
-            }}
-          />
+          <div style={{
+            width: 7, height: 7, borderRadius: '50%',
+            background: 'var(--accent)',
+            animation: 'roadmap-pulse 1.2s ease-in-out infinite',
+          }} />
         )}
       </div>
 
-      <span style={{ fontSize: 13, color, transition: 'color 0.3s' }}>
-        {label}
+      {/* Text */}
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 13, fontWeight: isActive ? 500 : 400, color, transition: 'color 0.25s' }}>
+          {label}
+        </div>
         {isActive && !isFailed && (
-          <span style={{ color: 'var(--text-muted)', marginLeft: 4 }}>...</span>
+          <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 1 }}>
+            {subtitle}
+          </div>
         )}
-      </span>
+      </div>
+
+      {/* Elapsed time on active phase */}
+      {isActive && !isFailed && elapsed > 0 && (
+        <span style={{
+          fontSize: 11,
+          color: 'var(--text-muted)',
+          fontVariantNumeric: 'tabular-nums',
+          flexShrink: 0,
+        }}>
+          {formatElapsed(elapsed)}
+        </span>
+      )}
     </div>
   );
 }
 
 export function RoadmapGenerationView({ projectSlug, onComplete, onCancel }: Props) {
-  // Start with 'analyzing' active immediately so the pulse is visible before the first SSE event
-  const [phase, setPhase] = useState<GenerationPhase | 'idle' | 'done'>('analyzing');
+  const [phase, setPhase] = useState<GenerationPhase | 'done'>('analyzing');
   const [error, setError] = useState<string | null>(null);
+  const [elapsed, setElapsed] = useState(0);
   const cancelRef = useRef<(() => void) | null>(null);
   const startedRef = useRef(false);
+  const startTimeRef = useRef(Date.now());
 
+  // Ticking elapsed timer
+  useEffect(() => {
+    const id = setInterval(() => {
+      const ms = Date.now() - startTimeRef.current;
+      setElapsed(ms);
+      if (ms > TIMEOUT_MS && phase !== 'done') {
+        setError('Generation is taking longer than expected. The API may be overloaded — cancel and try again.');
+      }
+    }, 1000);
+    return () => clearInterval(id);
+  }, [phase]);
+
+  // Start generation
   useEffect(() => {
     if (startedRef.current) return;
     startedRef.current = true;
 
     const cancel = streamRoadmapGeneration(projectSlug, (event) => {
       if (event.type === 'phase' && event.phase) {
-        setPhase(event.phase);
+        setPhase(event.phase as GenerationPhase);
         setError(null);
       } else if (event.type === 'done') {
         setPhase('done');
-        setTimeout(onComplete, 600);
+        setTimeout(onComplete, 500);
       } else if (event.type === 'error') {
         setError(event.message ?? 'Unknown error');
       }
@@ -127,95 +164,79 @@ export function RoadmapGenerationView({ projectSlug, onComplete, onCancel }: Pro
   };
 
   return (
-    <div
-      style={{
-        display: 'flex',
-        height: '100%',
-        alignItems: 'center',
-        justifyContent: 'center',
-      }}
-    >
+    <div style={{ display: 'flex', height: '100%', alignItems: 'center', justifyContent: 'center' }}>
       <style>{`
-        @keyframes pulse {
+        @keyframes roadmap-pulse {
           0%, 100% { opacity: 1; transform: scale(1); }
-          50% { opacity: 0.5; transform: scale(0.8); }
+          50% { opacity: 0.4; transform: scale(0.75); }
         }
       `}</style>
 
-      <div
-        style={{
-          width: '100%',
-          maxWidth: 400,
-          padding: 32,
-          background: 'var(--bg-elevated)',
-          border: '1px solid var(--border-subtle)',
-          borderRadius: 12,
-        }}
-      >
+      <div style={{
+        width: '100%',
+        maxWidth: 380,
+        padding: '28px 28px 24px',
+        background: 'var(--bg-elevated)',
+        border: '1px solid var(--border-subtle)',
+        borderRadius: 12,
+      }}>
         {/* Header */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 24 }}>
-          <div
-            style={{
-              width: 36,
-              height: 36,
-              borderRadius: 8,
-              background: 'var(--bg-surface)',
-              border: '1px solid var(--border-subtle)',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              color: 'var(--accent)',
-              flexShrink: 0,
-            }}
-          >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 22 }}>
+          <div style={{
+            width: 34, height: 34, borderRadius: 8,
+            background: 'var(--bg-surface)',
+            border: '1px solid var(--border-subtle)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            color: 'var(--accent)', flexShrink: 0,
+          }}>
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
               <polygon points="3 6 9 3 15 6 21 3 21 18 15 21 9 18 3 21" />
               <line x1="9" y1="3" x2="9" y2="18" />
               <line x1="15" y1="6" x2="15" y2="21" />
             </svg>
           </div>
-          <div>
+          <div style={{ flex: 1 }}>
             <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--text-primary)' }}>
               Generating Roadmap
             </div>
-            <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 1 }}>
-              Claude is analyzing your project
+            <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 1 }}>
+              {phase === 'done' ? 'Complete' : `${formatElapsed(elapsed)} elapsed`}
             </div>
           </div>
         </div>
 
         {/* Phase list */}
-        <div style={{ marginBottom: 20 }}>
+        <div style={{ marginBottom: error ? 14 : 18 }}>
           {PHASES.map(p => (
             <PhaseRow
               key={p.id}
-              id={p.id as GenerationPhase}
+              id={p.id}
               label={p.label}
+              subtitle={p.subtitle}
               activePhase={phase}
               error={error}
+              elapsed={elapsed}
             />
           ))}
         </div>
 
-        {/* Error state */}
+        {/* Error */}
         {error && (
-          <div
-            style={{
-              padding: '10px 12px',
-              background: 'rgba(239,68,68,0.08)',
-              border: '1px solid rgba(239,68,68,0.2)',
-              borderRadius: 7,
-              fontSize: 12,
-              color: '#ef4444',
-              lineHeight: 1.5,
-              marginBottom: 12,
-            }}
-          >
+          <div style={{
+            padding: '10px 12px',
+            background: 'rgba(239,68,68,0.07)',
+            border: '1px solid rgba(239,68,68,0.18)',
+            borderRadius: 7,
+            fontSize: 12,
+            color: '#ef4444',
+            lineHeight: 1.5,
+            marginBottom: 12,
+          }}>
             {error}
           </div>
         )}
 
-        {/* Cancel button — only while in progress */}
+        {/* Cancel/Dismiss */}
         {phase !== 'done' && (
           <button
             onClick={handleCancel}

--- a/apps/desktop/src/components/roadmap/RoadmapGenerationView.tsx
+++ b/apps/desktop/src/components/roadmap/RoadmapGenerationView.tsx
@@ -95,14 +95,15 @@ function PhaseRow({ id, label, activePhase, error }: {
 }
 
 export function RoadmapGenerationView({ projectSlug, onComplete, onCancel }: Props) {
-  const [phase, setPhase] = useState<GenerationPhase | 'idle' | 'done'>('idle');
+  // Start with 'analyzing' active immediately so the pulse is visible before the first SSE event
+  const [phase, setPhase] = useState<GenerationPhase | 'idle' | 'done'>('analyzing');
   const [error, setError] = useState<string | null>(null);
-  const [started, setStarted] = useState(false);
   const cancelRef = useRef<(() => void) | null>(null);
+  const startedRef = useRef(false);
 
   useEffect(() => {
-    if (started) return;
-    setStarted(true);
+    if (startedRef.current) return;
+    startedRef.current = true;
 
     const cancel = streamRoadmapGeneration(projectSlug, (event) => {
       if (event.type === 'phase' && event.phase) {
@@ -118,7 +119,7 @@ export function RoadmapGenerationView({ projectSlug, onComplete, onCancel }: Pro
 
     cancelRef.current = cancel;
     return () => cancel();
-  }, [projectSlug, started, onComplete]);
+  }, [projectSlug, onComplete]);
 
   const handleCancel = () => {
     cancelRef.current?.();

--- a/apps/desktop/src/components/roadmap/RoadmapGenerationView.tsx
+++ b/apps/desktop/src/components/roadmap/RoadmapGenerationView.tsx
@@ -1,0 +1,247 @@
+import { useEffect, useRef, useState } from 'react';
+import { streamRoadmapGeneration, type GenerationPhase } from '../../lib/roadmap-api';
+
+interface Props {
+  projectSlug: string;
+  onComplete: () => void;
+  onCancel: () => void;
+}
+
+const PHASES: { id: GenerationPhase | 'idle'; label: string }[] = [
+  { id: 'analyzing', label: 'Analyzing project' },
+  { id: 'generating', label: 'Generating roadmap' },
+  { id: 'saving', label: 'Saving' },
+];
+
+function PhaseRow({ id, label, activePhase, error }: {
+  id: GenerationPhase;
+  label: string;
+  activePhase: GenerationPhase | 'idle' | 'done';
+  error: string | null;
+}) {
+  const idx = PHASES.findIndex(p => p.id === id);
+  const activeIdx = PHASES.findIndex(p => p.id === activePhase);
+  const isDone = activePhase === 'done' || activeIdx > idx;
+  const isActive = activePhase === id;
+  const isFailed = isActive && error !== null;
+  const isPending = !isDone && !isActive;
+
+  const color = isFailed ? '#ef4444'
+    : isDone ? 'var(--accent)'
+    : isActive ? 'var(--text-primary)'
+    : 'var(--text-muted)';
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        padding: '6px 0',
+        opacity: isPending ? 0.4 : 1,
+        transition: 'opacity 0.3s',
+      }}
+    >
+      {/* Status indicator */}
+      <div
+        style={{
+          width: 20,
+          height: 20,
+          borderRadius: '50%',
+          background: isFailed ? 'rgba(239,68,68,0.15)'
+            : isDone ? 'rgba(var(--accent-rgb, 99,102,241), 0.15)'
+            : isActive ? 'var(--bg-surface)'
+            : 'transparent',
+          border: `1.5px solid ${color}`,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexShrink: 0,
+          transition: 'all 0.3s',
+        }}
+      >
+        {isDone && !isFailed && (
+          <svg width="10" height="10" viewBox="0 0 12 12" fill="none">
+            <polyline points="2 6 5 9 10 3" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        )}
+        {isFailed && (
+          <svg width="10" height="10" viewBox="0 0 12 12" fill="none">
+            <line x1="3" y1="3" x2="9" y2="9" stroke={color} strokeWidth="2" strokeLinecap="round" />
+            <line x1="9" y1="3" x2="3" y2="9" stroke={color} strokeWidth="2" strokeLinecap="round" />
+          </svg>
+        )}
+        {isActive && !isFailed && (
+          <div
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: '50%',
+              background: 'var(--accent)',
+              animation: 'pulse 1.2s ease-in-out infinite',
+            }}
+          />
+        )}
+      </div>
+
+      <span style={{ fontSize: 13, color, transition: 'color 0.3s' }}>
+        {label}
+        {isActive && !isFailed && (
+          <span style={{ color: 'var(--text-muted)', marginLeft: 4 }}>...</span>
+        )}
+      </span>
+    </div>
+  );
+}
+
+export function RoadmapGenerationView({ projectSlug, onComplete, onCancel }: Props) {
+  const [phase, setPhase] = useState<GenerationPhase | 'idle' | 'done'>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [started, setStarted] = useState(false);
+  const cancelRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    if (started) return;
+    setStarted(true);
+
+    const cancel = streamRoadmapGeneration(projectSlug, (event) => {
+      if (event.type === 'phase' && event.phase) {
+        setPhase(event.phase);
+        setError(null);
+      } else if (event.type === 'done') {
+        setPhase('done');
+        setTimeout(onComplete, 600);
+      } else if (event.type === 'error') {
+        setError(event.message ?? 'Unknown error');
+      }
+    });
+
+    cancelRef.current = cancel;
+    return () => cancel();
+  }, [projectSlug, started, onComplete]);
+
+  const handleCancel = () => {
+    cancelRef.current?.();
+    onCancel();
+  };
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        height: '100%',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <style>{`
+        @keyframes pulse {
+          0%, 100% { opacity: 1; transform: scale(1); }
+          50% { opacity: 0.5; transform: scale(0.8); }
+        }
+      `}</style>
+
+      <div
+        style={{
+          width: '100%',
+          maxWidth: 400,
+          padding: 32,
+          background: 'var(--bg-elevated)',
+          border: '1px solid var(--border-subtle)',
+          borderRadius: 12,
+        }}
+      >
+        {/* Header */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 24 }}>
+          <div
+            style={{
+              width: 36,
+              height: 36,
+              borderRadius: 8,
+              background: 'var(--bg-surface)',
+              border: '1px solid var(--border-subtle)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              color: 'var(--accent)',
+              flexShrink: 0,
+            }}
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <polygon points="3 6 9 3 15 6 21 3 21 18 15 21 9 18 3 21" />
+              <line x1="9" y1="3" x2="9" y2="18" />
+              <line x1="15" y1="6" x2="15" y2="21" />
+            </svg>
+          </div>
+          <div>
+            <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--text-primary)' }}>
+              Generating Roadmap
+            </div>
+            <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 1 }}>
+              Claude is analyzing your project
+            </div>
+          </div>
+        </div>
+
+        {/* Phase list */}
+        <div style={{ marginBottom: 20 }}>
+          {PHASES.map(p => (
+            <PhaseRow
+              key={p.id}
+              id={p.id as GenerationPhase}
+              label={p.label}
+              activePhase={phase}
+              error={error}
+            />
+          ))}
+        </div>
+
+        {/* Error state */}
+        {error && (
+          <div
+            style={{
+              padding: '10px 12px',
+              background: 'rgba(239,68,68,0.08)',
+              border: '1px solid rgba(239,68,68,0.2)',
+              borderRadius: 7,
+              fontSize: 12,
+              color: '#ef4444',
+              lineHeight: 1.5,
+              marginBottom: 12,
+            }}
+          >
+            {error}
+          </div>
+        )}
+
+        {/* Cancel button — only while in progress */}
+        {phase !== 'done' && (
+          <button
+            onClick={handleCancel}
+            style={{
+              width: '100%',
+              padding: '7px',
+              background: 'transparent',
+              border: '1px solid var(--border-subtle)',
+              borderRadius: 7,
+              fontSize: 12,
+              color: 'var(--text-muted)',
+              cursor: 'pointer',
+              transition: 'color 0.15s, border-color 0.15s',
+            }}
+            onMouseEnter={e => {
+              (e.currentTarget as HTMLElement).style.color = 'var(--text-primary)';
+              (e.currentTarget as HTMLElement).style.borderColor = 'var(--border-default)';
+            }}
+            onMouseLeave={e => {
+              (e.currentTarget as HTMLElement).style.color = 'var(--text-muted)';
+              (e.currentTarget as HTMLElement).style.borderColor = 'var(--border-subtle)';
+            }}
+          >
+            {error ? 'Dismiss' : 'Cancel'}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/lib/roadmap-api.ts
+++ b/apps/desktop/src/lib/roadmap-api.ts
@@ -1,4 +1,15 @@
-import { apiFetch } from './board-api';
+import { apiFetch, BOARD_SERVER_BASE } from './board-api';
+
+/** Fetch that returns null on 404 instead of throwing. */
+async function apiFetchOrNull<T>(path: string): Promise<T | null> {
+  const res = await fetch(`${BOARD_SERVER_BASE}/api/v1${path}`);
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    const err = await res.text().catch(() => res.statusText);
+    throw new Error(`API ${res.status}: ${err}`);
+  }
+  return res.json() as Promise<T>;
+}
 import type {
   Roadmap,
   RoadmapFeature,
@@ -6,10 +17,90 @@ import type {
   Competitor,
 } from './roadmap-types';
 
+export type GenerationPhase = 'analyzing' | 'generating' | 'saving' | 'done';
+
+export interface GenerationEvent {
+  type: 'phase' | 'done' | 'error';
+  phase?: GenerationPhase;
+  label?: string;
+  message?: string;
+}
+
+export function streamRoadmapGeneration(
+  slug: string,
+  onEvent: (event: GenerationEvent) => void,
+): () => void {
+  const url = `${BOARD_SERVER_BASE}/api/v1/projects/${slug}/roadmap/generate`;
+  let aborted = false;
+
+  const es = new EventSource(url);
+
+  // EventSource doesn't support POST — use fetch with SSE manually instead
+  es.close();
+
+  const controller = new AbortController();
+  const { signal } = controller;
+
+  (async () => {
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { Accept: 'text/event-stream' },
+        signal,
+      });
+
+      if (!res.ok || !res.body) {
+        const text = await res.text().catch(() => res.statusText);
+        onEvent({ type: 'error', message: `Server error ${res.status}: ${text}` });
+        return;
+      }
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (!aborted) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+
+        const blocks = buffer.split('\n\n');
+        buffer = blocks.pop() ?? '';
+
+        for (const block of blocks) {
+          const lines = block.split('\n');
+          let eventType = '';
+          let data = '';
+          for (const line of lines) {
+            if (line.startsWith('event: ')) eventType = line.slice(7).trim();
+            else if (line.startsWith('data: ')) data = line.slice(6).trim();
+          }
+          if (!eventType || !data) continue;
+          try {
+            const parsed = JSON.parse(data) as Record<string, string>;
+            onEvent({ type: eventType as 'phase' | 'done' | 'error', ...parsed });
+          } catch {
+            // ignore malformed frames
+          }
+        }
+      }
+    } catch (err) {
+      if (!aborted) {
+        onEvent({ type: 'error', message: err instanceof Error ? err.message : String(err) });
+      }
+    }
+  })();
+
+  return () => {
+    aborted = true;
+    controller.abort();
+  };
+}
+
 export const roadmapApi = {
   roadmap: {
     get: (slug: string) =>
-      apiFetch<Roadmap | null>(`/projects/${slug}/roadmap`),
+      apiFetchOrNull<Roadmap>(`/projects/${slug}/roadmap`),
     save: (slug: string, roadmap: Roadmap) =>
       apiFetch<Roadmap>(`/projects/${slug}/roadmap`, {
         method: 'PUT',
@@ -50,7 +141,7 @@ export const roadmapApi = {
   },
   competitors: {
     get: (slug: string) =>
-      apiFetch<CompetitorAnalysis | null>(`/projects/${slug}/competitors`),
+      apiFetchOrNull<CompetitorAnalysis>(`/projects/${slug}/competitors`),
     save: (slug: string, analysis: CompetitorAnalysis) =>
       apiFetch<CompetitorAnalysis>(`/projects/${slug}/competitors`, {
         method: 'PUT',

--- a/apps/desktop/src/lib/roadmap-api.ts
+++ b/apps/desktop/src/lib/roadmap-api.ts
@@ -1,4 +1,10 @@
 import { apiFetch, BOARD_SERVER_BASE } from './board-api';
+import type {
+  Roadmap,
+  RoadmapFeature,
+  CompetitorAnalysis,
+  Competitor,
+} from './roadmap-types';
 
 /** Fetch that returns null on 404 instead of throwing. */
 async function apiFetchOrNull<T>(path: string): Promise<T | null> {
@@ -10,12 +16,6 @@ async function apiFetchOrNull<T>(path: string): Promise<T | null> {
   }
   return res.json() as Promise<T>;
 }
-import type {
-  Roadmap,
-  RoadmapFeature,
-  CompetitorAnalysis,
-  Competitor,
-} from './roadmap-types';
 
 export type GenerationPhase = 'analyzing' | 'generating' | 'saving' | 'done';
 
@@ -30,13 +30,9 @@ export function streamRoadmapGeneration(
   slug: string,
   onEvent: (event: GenerationEvent) => void,
 ): () => void {
+  // EventSource only supports GET — use fetch with manual SSE parsing for POST
   const url = `${BOARD_SERVER_BASE}/api/v1/projects/${slug}/roadmap/generate`;
   let aborted = false;
-
-  const es = new EventSource(url);
-
-  // EventSource doesn't support POST — use fetch with SSE manually instead
-  es.close();
 
   const controller = new AbortController();
   const { signal } = controller;

--- a/apps/desktop/src/pages/roadmap/RoadmapPage.tsx
+++ b/apps/desktop/src/pages/roadmap/RoadmapPage.tsx
@@ -4,6 +4,7 @@ import { useRoadmapData } from '../../hooks/useRoadmapData';
 import { useBoardServerReady } from '../../hooks/useBoardServerReady';
 import { BoardServerOffline } from '../../components/board/BoardServerOffline';
 import { RoadmapEmptyState } from '../../components/roadmap/RoadmapEmptyState';
+import { RoadmapGenerationView } from '../../components/roadmap/RoadmapGenerationView';
 import { RoadmapHeader } from '../../components/roadmap/RoadmapHeader';
 import { RoadmapTabs } from '../../components/roadmap/RoadmapTabs';
 import { RoadmapKanbanView } from '../../components/roadmap/RoadmapKanbanView';
@@ -268,6 +269,7 @@ export default function RoadmapPage() {
   const [pendingConvertFeature, setPendingConvertFeature] = useState<RoadmapFeature | null>(null);
   const [epicPickerEpics, setEpicPickerEpics] = useState<Epic[] | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [showGenerateView, setShowGenerateView] = useState(false);
 
   // Collect all pain points from competitors indexed by ID
   const painPointsById = useMemo(() => {
@@ -403,15 +405,16 @@ export default function RoadmapPage() {
   }
 
   if (!roadmap) {
-    return (
-      <div style={{ height: '100%' }}>
-        <RoadmapEmptyState onGenerate={() => {
-          // The user should ask Claude via MCP to generate a roadmap
-          // We surface a hint for now
-          alert('Ask Claude to generate a roadmap:\n\nget_roadmap(project: "' + slug + '")');
-        }} />
-      </div>
-    );
+    if (showGenerateView) {
+      return (
+        <RoadmapGenerationView
+          projectSlug={slug!}
+          onComplete={() => { setShowGenerateView(false); refetch(); }}
+          onCancel={() => setShowGenerateView(false)}
+        />
+      );
+    }
+    return <RoadmapEmptyState onGenerate={() => setShowGenerateView(true)} />;
   }
 
   return (

--- a/packages/board-server/package.json
+++ b/packages/board-server/package.json
@@ -18,6 +18,7 @@
     "launchd:restart": "bash scripts/launchd-ctl.sh restart"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.82.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "express": "^4.18.2",
     "js-yaml": "^4.1.0",

--- a/packages/board-server/package.json
+++ b/packages/board-server/package.json
@@ -18,7 +18,6 @@
     "launchd:restart": "bash scripts/launchd-ctl.sh restart"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.82.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "express": "^4.18.2",
     "js-yaml": "^4.1.0",

--- a/packages/board-server/src/ai/roadmap-generator.ts
+++ b/packages/board-server/src/ai/roadmap-generator.ts
@@ -1,4 +1,4 @@
-import Anthropic from '@anthropic-ai/sdk';
+import { execFile, execFileSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import * as store from '../store/yaml-store.js';
 import * as roadmapStore from '../store/roadmap-store.js';
@@ -23,16 +23,61 @@ export interface ErrorEvent {
 
 export type RoadmapGeneratorEvent = GenerateEvent | DoneEvent | ErrorEvent;
 
+let _claudePath: string | null = null;
+function findClaude(): string {
+  if (process.env.CLAUDE_PATH) return process.env.CLAUDE_PATH;
+  if (_claudePath) return _claudePath;
+  // Try common install locations, then fall back to PATH lookup
+  const candidates = [
+    `${process.env.HOME}/.local/bin/claude`,
+    '/usr/local/bin/claude',
+    '/opt/homebrew/bin/claude',
+  ];
+  for (const p of candidates) {
+    try {
+      execFileSync('test', ['-x', p]);
+      _claudePath = p;
+      return p;
+    } catch { /* not found */ }
+  }
+  // Last resort: resolve via `which`
+  try {
+    _claudePath = execFileSync('which', ['claude'], { env: { ...process.env, PATH: `/usr/local/bin:/opt/homebrew/bin:${process.env.HOME}/.local/bin:${process.env.PATH}` } }).toString().trim();
+    return _claudePath;
+  } catch {
+    throw new Error('claude CLI not found. Install Claude Code: https://claude.ai/code');
+  }
+}
+
+function runClaude(prompt: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const claude = findClaude();
+    const child = execFile(
+      claude,
+      ['-p', '--output-format', 'json', '--model', 'claude-opus-4-6'],
+      { maxBuffer: 16 * 1024 * 1024, timeout: 180_000 },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(new Error(stderr || error.message));
+          return;
+        }
+        try {
+          const parsed = JSON.parse(stdout) as { result?: string };
+          resolve(parsed.result ?? stdout);
+        } catch {
+          resolve(stdout);
+        }
+      },
+    );
+    child.stdin?.write(prompt);
+    child.stdin?.end();
+  });
+}
+
 export async function generateRoadmap(
   slug: string,
   onEvent: (event: RoadmapGeneratorEvent) => void,
 ): Promise<void> {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
-    onEvent({ type: 'error', message: 'ANTHROPIC_API_KEY is not set. Set it in the board server environment.' });
-    return;
-  }
-
   // Phase 1: Analyze project
   onEvent({ type: 'phase', phase: 'analyzing', label: 'Reading project data...' });
 
@@ -52,7 +97,7 @@ export async function generateRoadmap(
       return `  Epic: ${epic.name}\n${tasksText}`;
     }).join('\n\n');
 
-    projectContext = `Project: ${project.name || slug}\nEpics and tasks (${taskCount} total):\n\n${epicsText}`;
+    projectContext = `Project: ${project.name || slug}\nEpics and tasks (${taskCount} total):\n\n${epicsText || '  (no epics or tasks yet)'}`;
   } catch (err) {
     onEvent({ type: 'error', message: `Failed to read project: ${err instanceof Error ? err.message : String(err)}` });
     return;
@@ -61,16 +106,11 @@ export async function generateRoadmap(
   // Phase 2: Generate with Claude
   onEvent({ type: 'phase', phase: 'generating', label: 'Generating roadmap with Claude...' });
 
-  const client = new Anthropic({ apiKey });
-
-  const systemPrompt = `You are a product strategist. Generate a comprehensive product roadmap as a JSON object.
-CRITICAL: Respond with ONLY a valid JSON object. No explanation, no markdown fences, no text before or after. Pure JSON only.`;
-
-  const userPrompt = `Generate a strategic product roadmap for this project.
+  const prompt = `Generate a strategic product roadmap for this project.
 
 ${projectContext}
 
-Return a JSON object with this exact structure (use real UUIDs for all id fields):
+Return ONLY a valid JSON object with this structure (use real UUIDs for all id fields):
 {
   "version": "1.0",
   "projectName": "<project name>",
@@ -78,9 +118,9 @@ Return a JSON object with this exact structure (use real UUIDs for all id fields
   "status": "active",
   "targetAudience": {
     "primary": "<primary user persona>",
-    "secondary": ["<secondary persona 1>", "<secondary persona 2>"],
-    "painPoints": ["<pain point 1>", "<pain point 2>", "<pain point 3>"],
-    "goals": ["<goal 1>", "<goal 2>", "<goal 3>"],
+    "secondary": ["<secondary persona>"],
+    "painPoints": ["<pain point>", "<pain point>", "<pain point>"],
+    "goals": ["<goal>", "<goal>", "<goal>"],
     "usageContext": "<when/how they use it>"
   },
   "phases": [
@@ -90,31 +130,23 @@ Return a JSON object with this exact structure (use real UUIDs for all id fields
       "description": "<phase goal>",
       "order": 1,
       "status": "planned",
-      "features": ["<feature-id-1>", "<feature-id-2>"],
-      "milestones": [
-        {
-          "id": "<uuid>",
-          "title": "<milestone title>",
-          "description": "<milestone description>",
-          "features": ["<feature-id>"],
-          "status": "planned"
-        }
-      ]
+      "features": ["<feature-id>"],
+      "milestones": [{"id": "<uuid>", "title": "<title>", "description": "<desc>", "features": ["<feature-id>"], "status": "planned"}]
     }
   ],
   "features": [
     {
       "id": "<uuid>",
-      "title": "<feature title>",
-      "description": "<feature description>",
-      "rationale": "<why this feature matters>",
+      "title": "<title>",
+      "description": "<description>",
+      "rationale": "<why this matters>",
       "priority": "must",
       "complexity": "medium",
       "impact": "high",
       "phaseId": "<phase-uuid>",
       "status": "backlog",
       "dependencies": [],
-      "acceptanceCriteria": ["<criterion 1>", "<criterion 2>"],
+      "acceptanceCriteria": ["<criterion>", "<criterion>"],
       "userStories": ["As a <persona>, I want to <action> so that <benefit>."],
       "competitorInsightIds": []
     }
@@ -122,31 +154,18 @@ Return a JSON object with this exact structure (use real UUIDs for all id fields
 }
 
 Requirements:
-- 3-4 phases ordered logically (foundation → growth → scale → etc.)
+- 3-4 phases ordered logically (foundation → growth → scale etc.)
 - 10-15 features total across all phases
-- Mix priorities: must (40%), should (35%), could (20%), wont (5%)
-- Each feature has 2-3 user stories and 2-3 acceptance criteria
-- phase.features array must contain the ids of features assigned to that phase
-- All ids must be valid UUIDs (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx format)
-- Base the roadmap on the existing tasks/epics — extend and improve, don't just restate them`;
+- Mix priorities: ~40% must, ~35% should, ~20% could, ~5% wont
+- Each feature needs 2-3 user stories and 2-3 acceptance criteria
+- phase.features array must list the ids of features in that phase
+- Base the roadmap on the existing tasks/epics context above
+- Return ONLY the JSON object, no explanation, no markdown fences`;
 
   let roadmapJson: Roadmap;
   try {
-    const message = await client.messages.create({
-      model: 'claude-opus-4-6',
-      max_tokens: 8192,
-      messages: [{ role: 'user', content: userPrompt }],
-      system: systemPrompt,
-    });
-
-    const content = message.content[0];
-    if (content.type !== 'text') {
-      onEvent({ type: 'error', message: 'Unexpected response type from Claude' });
-      return;
-    }
-
-    // Strip any accidental markdown fences
-    const rawText = content.text.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '');
+    const result = await runClaude(prompt);
+    const rawText = result.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '');
     const parsed = JSON.parse(rawText) as Record<string, unknown>;
 
     if (!parsed.version || !Array.isArray(parsed.phases) || !Array.isArray(parsed.features)) {

--- a/packages/board-server/src/ai/roadmap-generator.ts
+++ b/packages/board-server/src/ai/roadmap-generator.ts
@@ -1,0 +1,181 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { randomUUID } from 'node:crypto';
+import * as store from '../store/yaml-store.js';
+import * as roadmapStore from '../store/roadmap-store.js';
+import type { Roadmap } from '../roadmap-types.js';
+
+export type GeneratePhase = 'analyzing' | 'generating' | 'saving' | 'done';
+
+export interface GenerateEvent {
+  type: 'phase';
+  phase: GeneratePhase;
+  label: string;
+}
+
+export interface DoneEvent {
+  type: 'done';
+}
+
+export interface ErrorEvent {
+  type: 'error';
+  message: string;
+}
+
+export type RoadmapGeneratorEvent = GenerateEvent | DoneEvent | ErrorEvent;
+
+export async function generateRoadmap(
+  slug: string,
+  onEvent: (event: RoadmapGeneratorEvent) => void,
+): Promise<void> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    onEvent({ type: 'error', message: 'ANTHROPIC_API_KEY is not set. Set it in the board server environment.' });
+    return;
+  }
+
+  // Phase 1: Analyze project
+  onEvent({ type: 'phase', phase: 'analyzing', label: 'Reading project data...' });
+
+  let projectContext: string;
+  try {
+    const project = store.readProject(slug);
+    if (!project) {
+      onEvent({ type: 'error', message: `Project "${slug}" not found` });
+      return;
+    }
+
+    const taskCount = project.epics.reduce((n, e) => n + e.tasks.length, 0);
+    const epicsText = project.epics.map(epic => {
+      const tasksText = epic.tasks.length > 0
+        ? epic.tasks.map(t => `      - [${t.status}] ${t.title}${t.description ? ': ' + t.description.slice(0, 120) : ''}`).join('\n')
+        : '      (no tasks yet)';
+      return `  Epic: ${epic.name}\n${tasksText}`;
+    }).join('\n\n');
+
+    projectContext = `Project: ${project.name || slug}\nEpics and tasks (${taskCount} total):\n\n${epicsText}`;
+  } catch (err) {
+    onEvent({ type: 'error', message: `Failed to read project: ${err instanceof Error ? err.message : String(err)}` });
+    return;
+  }
+
+  // Phase 2: Generate with Claude
+  onEvent({ type: 'phase', phase: 'generating', label: 'Generating roadmap with Claude...' });
+
+  const client = new Anthropic({ apiKey });
+
+  const systemPrompt = `You are a product strategist. Generate a comprehensive product roadmap as a JSON object.
+CRITICAL: Respond with ONLY a valid JSON object. No explanation, no markdown fences, no text before or after. Pure JSON only.`;
+
+  const userPrompt = `Generate a strategic product roadmap for this project.
+
+${projectContext}
+
+Return a JSON object with this exact structure (use real UUIDs for all id fields):
+{
+  "version": "1.0",
+  "projectName": "<project name>",
+  "vision": "<1-2 sentence product vision>",
+  "status": "active",
+  "targetAudience": {
+    "primary": "<primary user persona>",
+    "secondary": ["<secondary persona 1>", "<secondary persona 2>"],
+    "painPoints": ["<pain point 1>", "<pain point 2>", "<pain point 3>"],
+    "goals": ["<goal 1>", "<goal 2>", "<goal 3>"],
+    "usageContext": "<when/how they use it>"
+  },
+  "phases": [
+    {
+      "id": "<uuid>",
+      "name": "<phase name>",
+      "description": "<phase goal>",
+      "order": 1,
+      "status": "planned",
+      "features": ["<feature-id-1>", "<feature-id-2>"],
+      "milestones": [
+        {
+          "id": "<uuid>",
+          "title": "<milestone title>",
+          "description": "<milestone description>",
+          "features": ["<feature-id>"],
+          "status": "planned"
+        }
+      ]
+    }
+  ],
+  "features": [
+    {
+      "id": "<uuid>",
+      "title": "<feature title>",
+      "description": "<feature description>",
+      "rationale": "<why this feature matters>",
+      "priority": "must",
+      "complexity": "medium",
+      "impact": "high",
+      "phaseId": "<phase-uuid>",
+      "status": "backlog",
+      "dependencies": [],
+      "acceptanceCriteria": ["<criterion 1>", "<criterion 2>"],
+      "userStories": ["As a <persona>, I want to <action> so that <benefit>."],
+      "competitorInsightIds": []
+    }
+  ]
+}
+
+Requirements:
+- 3-4 phases ordered logically (foundation → growth → scale → etc.)
+- 10-15 features total across all phases
+- Mix priorities: must (40%), should (35%), could (20%), wont (5%)
+- Each feature has 2-3 user stories and 2-3 acceptance criteria
+- phase.features array must contain the ids of features assigned to that phase
+- All ids must be valid UUIDs (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx format)
+- Base the roadmap on the existing tasks/epics — extend and improve, don't just restate them`;
+
+  let roadmapJson: Roadmap;
+  try {
+    const message = await client.messages.create({
+      model: 'claude-opus-4-6',
+      max_tokens: 8192,
+      messages: [{ role: 'user', content: userPrompt }],
+      system: systemPrompt,
+    });
+
+    const content = message.content[0];
+    if (content.type !== 'text') {
+      onEvent({ type: 'error', message: 'Unexpected response type from Claude' });
+      return;
+    }
+
+    // Strip any accidental markdown fences
+    const rawText = content.text.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '');
+    const parsed = JSON.parse(rawText) as Record<string, unknown>;
+
+    if (!parsed.version || !Array.isArray(parsed.phases) || !Array.isArray(parsed.features)) {
+      onEvent({ type: 'error', message: 'Generated roadmap is missing required fields (version, phases, features)' });
+      return;
+    }
+
+    const now = new Date().toISOString();
+    roadmapJson = {
+      ...(parsed as unknown as Roadmap),
+      id: randomUUID(),
+      projectSlug: slug,
+      created_at: now,
+      updated_at: now,
+    };
+  } catch (err) {
+    onEvent({ type: 'error', message: `Generation failed: ${err instanceof Error ? err.message : String(err)}` });
+    return;
+  }
+
+  // Phase 3: Save
+  onEvent({ type: 'phase', phase: 'saving', label: 'Saving roadmap...' });
+
+  try {
+    roadmapStore.writeRoadmap(slug, roadmapJson);
+  } catch (err) {
+    onEvent({ type: 'error', message: `Failed to save roadmap: ${err instanceof Error ? err.message : String(err)}` });
+    return;
+  }
+
+  onEvent({ type: 'done' });
+}

--- a/packages/board-server/src/ai/roadmap-generator.ts
+++ b/packages/board-server/src/ai/roadmap-generator.ts
@@ -1,4 +1,5 @@
-import { execFile, execFileSync } from 'node:child_process';
+import Anthropic from '@anthropic-ai/sdk';
+import { execFileSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import * as store from '../store/yaml-store.js';
 import * as roadmapStore from '../store/roadmap-store.js';
@@ -23,56 +24,56 @@ export interface ErrorEvent {
 
 export type RoadmapGeneratorEvent = GenerateEvent | DoneEvent | ErrorEvent;
 
-let _claudePath: string | null = null;
-function findClaude(): string {
-  if (process.env.CLAUDE_PATH) return process.env.CLAUDE_PATH;
-  if (_claudePath) return _claudePath;
-  // Try common install locations, then fall back to PATH lookup
-  const candidates = [
-    `${process.env.HOME}/.local/bin/claude`,
-    '/usr/local/bin/claude',
-    '/opt/homebrew/bin/claude',
-  ];
-  for (const p of candidates) {
-    try {
-      execFileSync('test', ['-x', p]);
-      _claudePath = p;
-      return p;
-    } catch { /* not found */ }
-  }
-  // Last resort: resolve via `which`
-  try {
-    _claudePath = execFileSync('which', ['claude'], { env: { ...process.env, PATH: `/usr/local/bin:/opt/homebrew/bin:${process.env.HOME}/.local/bin:${process.env.PATH}` } }).toString().trim();
-    return _claudePath;
-  } catch {
-    throw new Error('claude CLI not found. Install Claude Code: https://claude.ai/code');
-  }
+// ─── Auth ─────────────────────────────────────────────────────────────────────
+
+interface ClaudeCredentials {
+  accessToken: string;
+  expiresAt: number;
 }
 
-function runClaude(prompt: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const claude = findClaude();
-    const child = execFile(
-      claude,
-      ['-p', '--output-format', 'json', '--model', 'claude-opus-4-6'],
-      { maxBuffer: 16 * 1024 * 1024, timeout: 180_000 },
-      (error, stdout, stderr) => {
-        if (error) {
-          reject(new Error(stderr || error.message));
-          return;
-        }
-        try {
-          const parsed = JSON.parse(stdout) as { result?: string };
-          resolve(parsed.result ?? stdout);
-        } catch {
-          resolve(stdout);
-        }
-      },
-    );
-    child.stdin?.write(prompt);
-    child.stdin?.end();
-  });
+/** Read the Claude Code OAuth token from the macOS keychain. */
+function readKeychainToken(): ClaudeCredentials | null {
+  if (process.platform !== 'darwin') return null;
+  for (const service of ['Claude Code-credentials', 'Claude Code-credentials-518fa12f']) {
+    try {
+      const raw = execFileSync('security', [
+        'find-generic-password', '-s', service, '-w',
+      ], { timeout: 5000 }).toString().trim();
+
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      const oauth = parsed.claudeAiOauth as Record<string, unknown> | undefined;
+      if (oauth?.accessToken && typeof oauth.accessToken === 'string') {
+        return {
+          accessToken: oauth.accessToken,
+          expiresAt: typeof oauth.expiresAt === 'number' ? oauth.expiresAt : Infinity,
+        };
+      }
+    } catch {
+      continue;
+    }
+  }
+  return null;
 }
+
+function buildClient(): Anthropic {
+  // Prefer explicit API key
+  if (process.env.ANTHROPIC_API_KEY) {
+    return new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+  }
+  // Fall back to Claude Code's stored OAuth token
+  const creds = readKeychainToken();
+  if (creds) {
+    if (creds.expiresAt < Date.now()) {
+      throw new Error('Claude Code OAuth token has expired. Re-authenticate with: claude /login');
+    }
+    return new Anthropic({ authToken: creds.accessToken });
+  }
+  throw new Error(
+    'No Anthropic credentials found. Either set ANTHROPIC_API_KEY or authenticate Claude Code.'
+  );
+}
+
+// ─── Generator ────────────────────────────────────────────────────────────────
 
 export async function generateRoadmap(
   slug: string,
@@ -92,7 +93,9 @@ export async function generateRoadmap(
     const taskCount = project.epics.reduce((n, e) => n + e.tasks.length, 0);
     const epicsText = project.epics.map(epic => {
       const tasksText = epic.tasks.length > 0
-        ? epic.tasks.map(t => `      - [${t.status}] ${t.title}${t.description ? ': ' + t.description.slice(0, 120) : ''}`).join('\n')
+        ? epic.tasks.map(t =>
+            `      - [${t.status}] ${t.title}${t.description ? ': ' + t.description.slice(0, 120) : ''}`
+          ).join('\n')
         : '      (no tasks yet)';
       return `  Epic: ${epic.name}\n${tasksText}`;
     }).join('\n\n');
@@ -106,11 +109,22 @@ export async function generateRoadmap(
   // Phase 2: Generate with Claude
   onEvent({ type: 'phase', phase: 'generating', label: 'Generating roadmap with Claude...' });
 
-  const prompt = `Generate a strategic product roadmap for this project.
+  let roadmapJson: Roadmap;
+  try {
+    const client = buildClient();
+
+    const message = await client.messages.create({
+      model: 'claude-opus-4-6',
+      max_tokens: 8192,
+      system: `You are a product strategist. Generate a comprehensive product roadmap as a JSON object.
+CRITICAL: Respond with ONLY a valid JSON object. No explanation, no markdown fences, no text before or after. Pure JSON only.`,
+      messages: [{
+        role: 'user',
+        content: `Generate a strategic product roadmap for this project.
 
 ${projectContext}
 
-Return ONLY a valid JSON object with this structure (use real UUIDs for all id fields):
+Return a JSON object with this exact structure (use real UUIDs for all id fields):
 {
   "version": "1.0",
   "projectName": "<project name>",
@@ -159,13 +173,17 @@ Requirements:
 - Mix priorities: ~40% must, ~35% should, ~20% could, ~5% wont
 - Each feature needs 2-3 user stories and 2-3 acceptance criteria
 - phase.features array must list the ids of features in that phase
-- Base the roadmap on the existing tasks/epics context above
-- Return ONLY the JSON object, no explanation, no markdown fences`;
+- Base the roadmap on the existing tasks/epics context above`,
+      }],
+    });
 
-  let roadmapJson: Roadmap;
-  try {
-    const result = await runClaude(prompt);
-    const rawText = result.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '');
+    const content = message.content[0];
+    if (content.type !== 'text') {
+      onEvent({ type: 'error', message: 'Unexpected response type from Claude' });
+      return;
+    }
+
+    const rawText = content.text.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '');
     const parsed = JSON.parse(rawText) as Record<string, unknown>;
 
     if (!parsed.version || !Array.isArray(parsed.phases) || !Array.isArray(parsed.features)) {

--- a/packages/board-server/src/ai/roadmap-generator.ts
+++ b/packages/board-server/src/ai/roadmap-generator.ts
@@ -63,7 +63,9 @@ function buildClient(): Anthropic {
   // Fall back to Claude Code's stored OAuth token
   const creds = readKeychainToken();
   if (creds) {
-    if (creds.expiresAt < Date.now()) {
+    // expiresAt may be in ms (JS standard) or seconds (OAuth standard) — normalise to ms
+    const expiresAtMs = creds.expiresAt > 1e12 ? creds.expiresAt : creds.expiresAt * 1000;
+    if (expiresAtMs < Date.now()) {
       throw new Error('Claude Code OAuth token has expired. Re-authenticate with: claude /login');
     }
     return new Anthropic({ authToken: creds.accessToken });

--- a/packages/board-server/src/http/roadmap-routes.ts
+++ b/packages/board-server/src/http/roadmap-routes.ts
@@ -3,9 +3,49 @@ import { randomUUID } from 'node:crypto';
 import * as roadmapStore from '../store/roadmap-store.js';
 import * as store from '../store/yaml-store.js';
 import type { RoadmapFeature } from '../roadmap-types.js';
+import { generateRoadmap } from '../ai/roadmap-generator.js';
 
 export function createRoadmapRouter(): Router {
   const router = Router();
+
+  // --- Generate ---
+
+  router.post('/projects/:slug/roadmap/generate', async (req, res) => {
+    const { slug } = req.params;
+
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.flushHeaders();
+
+    const send = (event: string, data: unknown) => {
+      res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+    };
+
+    let finished = false;
+    req.on('close', () => { finished = true; });
+
+    try {
+      await generateRoadmap(slug, (e) => {
+        if (finished) return;
+        if (e.type === 'done') {
+          send('done', { success: true });
+          res.end();
+        } else if (e.type === 'error') {
+          send('error', { message: e.message });
+          res.end();
+        } else {
+          send('phase', { phase: e.phase, label: e.label });
+        }
+      });
+    } catch (err) {
+      if (!finished) {
+        send('error', { message: String(err) });
+        res.end();
+      }
+    }
+  });
 
   // --- Roadmap ---
 

--- a/packages/board-server/src/http/roadmap-routes.ts
+++ b/packages/board-server/src/http/roadmap-routes.ts
@@ -16,7 +16,6 @@ export function createRoadmapRouter(): Router {
     res.setHeader('Content-Type', 'text/event-stream');
     res.setHeader('Cache-Control', 'no-cache');
     res.setHeader('Connection', 'keep-alive');
-    res.setHeader('Access-Control-Allow-Origin', '*');
     res.flushHeaders();
 
     const send = (event: string, data: unknown) => {

--- a/packages/board-server/src/http/roadmap-routes.ts
+++ b/packages/board-server/src/http/roadmap-routes.ts
@@ -21,6 +21,10 @@ export function createRoadmapRouter(): Router {
 
     const send = (event: string, data: unknown) => {
       res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+      // Flush immediately — required when compression middleware is active
+      if (typeof (res as unknown as { flush?: () => void }).flush === 'function') {
+        (res as unknown as { flush: () => void }).flush();
+      }
     };
 
     let finished = false;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,6 +277,9 @@ importers:
 
   packages/board-server:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.82.0
+        version: 0.82.0(zod@3.25.76)
       '@modelcontextprotocol/sdk':
         specifier: ^1.0.0
         version: 1.27.1(zod@3.25.76)
@@ -475,6 +478,15 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@anthropic-ai/sdk@0.82.0':
+    resolution: {integrity: sha512-xdHTjL1GlUlDugHq/I47qdOKp/ROPvuHl7ROJCgUQigbvPu7asf9KcAcU1EqdrP2LuVhEKaTs7Z+ShpZDRzHdQ==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@asamuzakjp/css-color@5.0.1':
     resolution: {integrity: sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==}
@@ -3538,6 +3550,10 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
@@ -4620,6 +4636,9 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
@@ -4967,6 +4986,12 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
+
+  '@anthropic-ai/sdk@0.82.0(zod@3.25.76)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 3.25.76
 
   '@asamuzakjp/css-color@5.0.1':
     dependencies:
@@ -6713,6 +6738,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
+
   '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -7978,6 +8011,11 @@ snapshots:
       - supports-color
 
   jsesc@3.1.0: {}
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
 
   json-schema-traverse@1.0.0: {}
 
@@ -9411,6 +9449,8 @@ snapshots:
 
   trough@2.2.0: {}
 
+  ts-algebra@2.0.0: {}
+
   ts-interface-checker@0.1.13: {}
 
   tslib@2.8.1: {}
@@ -9656,7 +9696,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,6 +277,9 @@ importers:
 
   packages/board-server:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.82.0
+        version: 0.82.0(zod@3.25.76)
       '@modelcontextprotocol/sdk':
         specifier: ^1.0.0
         version: 1.27.1(zod@3.25.76)
@@ -475,6 +478,15 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@anthropic-ai/sdk@0.82.0':
+    resolution: {integrity: sha512-xdHTjL1GlUlDugHq/I47qdOKp/ROPvuHl7ROJCgUQigbvPu7asf9KcAcU1EqdrP2LuVhEKaTs7Z+ShpZDRzHdQ==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@asamuzakjp/css-color@5.0.1':
     resolution: {integrity: sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==}
@@ -3538,6 +3550,10 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
@@ -4620,6 +4636,9 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
@@ -4967,6 +4986,12 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
+
+  '@anthropic-ai/sdk@0.82.0(zod@3.25.76)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 3.25.76
 
   '@asamuzakjp/css-color@5.0.1':
     dependencies:
@@ -7987,6 +8012,11 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
+
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
@@ -9418,6 +9448,8 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-interface-checker@0.1.13: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,9 +277,6 @@ importers:
 
   packages/board-server:
     dependencies:
-      '@anthropic-ai/sdk':
-        specifier: ^0.82.0
-        version: 0.82.0(zod@3.25.76)
       '@modelcontextprotocol/sdk':
         specifier: ^1.0.0
         version: 1.27.1(zod@3.25.76)
@@ -478,15 +475,6 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
-
-  '@anthropic-ai/sdk@0.82.0':
-    resolution: {integrity: sha512-xdHTjL1GlUlDugHq/I47qdOKp/ROPvuHl7ROJCgUQigbvPu7asf9KcAcU1EqdrP2LuVhEKaTs7Z+ShpZDRzHdQ==}
-    hasBin: true
-    peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
-    peerDependenciesMeta:
-      zod:
-        optional: true
 
   '@asamuzakjp/css-color@5.0.1':
     resolution: {integrity: sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==}
@@ -3550,10 +3538,6 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  json-schema-to-ts@3.1.1:
-    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
-    engines: {node: '>=16'}
-
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
@@ -4636,9 +4620,6 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
-  ts-algebra@2.0.0:
-    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
-
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
@@ -4986,12 +4967,6 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
-
-  '@anthropic-ai/sdk@0.82.0(zod@3.25.76)':
-    dependencies:
-      json-schema-to-ts: 3.1.1
-    optionalDependencies:
-      zod: 3.25.76
 
   '@asamuzakjp/css-color@5.0.1':
     dependencies:
@@ -8012,11 +7987,6 @@ snapshots:
 
   jsesc@3.1.0: {}
 
-  json-schema-to-ts@3.1.1:
-    dependencies:
-      '@babel/runtime': 7.29.2
-      ts-algebra: 2.0.0
-
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
@@ -9448,8 +9418,6 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
-
-  ts-algebra@2.0.0: {}
 
   ts-interface-checker@0.1.13: {}
 


### PR DESCRIPTION
## Summary

Replaces the copy-prompt modal with actual in-app AI roadmap generation. The board server reads the Claude Code OAuth token from the macOS keychain (no `ANTHROPIC_API_KEY` required) and calls the Anthropic SDK directly to generate a structured roadmap using the project's existing epics and tasks as context.

## Changes

- **`packages/board-server/src/ai/roadmap-generator.ts`** (new) — core generation pipeline: reads keychain token via `security find-generic-password`, builds Anthropic client, analyzes project tasks/epics, calls `claude-opus-4-6` with a structured JSON prompt, validates and saves the result
- **`packages/board-server/src/http/roadmap-routes.ts`** — new `POST /projects/:slug/roadmap/generate` SSE endpoint that streams 3 phase events (`analyzing → generating → saving → done`) with explicit `res.flush()` to prevent compression buffering
- **`apps/desktop/src/lib/roadmap-api.ts`** — `streamRoadmapGeneration()` using manual SSE via `fetch()` POST (EventSource doesn't support POST); `apiFetchOrNull<T>()` for graceful 404 handling
- **`apps/desktop/src/components/roadmap/RoadmapGenerationView.tsx`** (new) — animated 3-phase progress card: ticking elapsed timer (1s interval), per-phase subtitle, 3-minute timeout warning, cancel button
- **`apps/desktop/src/components/roadmap/RoadmapEmptyState.tsx`** — button now shows spinner + "Starting..." immediately on click while the SSE connection is being established
- **`apps/desktop/src/pages/roadmap/RoadmapPage.tsx`** — replaces `GenerateRoadmapModal` with `RoadmapGenerationView`

## Test Plan

- [ ] Local tests pass (595 desktop + 130 board-server)
- [ ] CI checks pass
- [ ] Manual: click "Generate Roadmap" in desktop app — button shows spinner immediately, generation view shows pulse on "Analyzing project", timer ticks, phases advance, roadmap appears on completion
- [ ] Manual: no `ANTHROPIC_API_KEY` set — auth falls back to macOS keychain Claude Code OAuth token automatically

## Notes

- Auth fallback order: `ANTHROPIC_API_KEY` env var → macOS keychain `Claude Code-credentials` service → `Claude Code-credentials-518fa12f` (alternate key name). Throws a clear error if neither is found.
- The Tauri plist install path also accepts an optional `ANTHROPIC_API_KEY` at install time for users who prefer explicit API keys.
- SSE `res.flush()` is required when compression middleware is active; cast-guarded so it's a no-op on environments that don't expose `flush`.