### PR TITLE
docs: propagate plugin renames and sync documentation with current features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **Desktop: AI Chat** — local LLM conversations via Ollama with multi-session support, model selection, session management (create/load/delete/rename), and `Cmd+N` to create a new session. Models can be downloaded inline.
+- **Desktop: Roadmap** — AI-driven product roadmap with kanban views, phase cards, feature cards, and competitor analysis. Roadmaps are generated via Claude using OAuth authentication. Features can be promoted to board epics and tasks.
+- **Desktop: Parity dashboard** — cross-platform feature parity tracking across AI coding tools. Covers config files, settings keys, CLI flags, CLI subcommands, MCP transports, MCP servers, and plugin types with drift detection and baseline comparison.
+- **Desktop: Security section** — three sub-pages: Permissions (visual editor for tool allow/deny/ask lists, path write restrictions, and network allowlists with security presets), Secrets (keychain secret management), and Audit Log (security event trail with timestamps).
+- **Desktop: Board** — kanban project board with projects, epics, and tasks backed by the board-server. Execution engine with harness-agnostic task runners.
+- **Desktop: Embedded marketplace browser** — browse and install plugins from the marketplace without leaving the desktop app.
 - **Desktop: Preferences page** — dedicated `/preferences` route replaces the old popover. Settings: font size (11–18px), density (comfortable/compact), default landing section, hidden sidebar sections, observatory auto-refresh interval, markdown font (sans/mono). All persisted in localStorage with `harness-kit-` prefix.
 - **Desktop: Keyboard shortcut** — `Cmd+,` navigates to preferences (standard macOS convention).
 - **Desktop: Docs link** — sidebar footer now includes a persistent link to harnesskit.ai/docs (opens in external browser).
@@ -14,14 +20,19 @@
 - **Desktop: Inline config file editor** — the Settings page now opens `~/.claude/` files in an inline split-pane editor instead of navigating away. File list is filterable by detail level (Essentials / Text Files / All), controlled from Preferences. Unsaved-changes are detected on file switch with an inline discard prompt. Files with a `.md` extension default to preview mode; toggle to editor is per-file. Draggable panel resize persists across sessions.
 - **Desktop: MCP Servers page** — dedicated page in the Harness menu for managing `~/.claude/mcp.json` entries. Add, edit, and remove stdio and network (HTTP/SSE) servers. Source toggle switches between editing `mcp.json` directly and the `harness.yaml` `mcp-servers` section. Servers present in both sources show an "in harness" indicator.
 - **Desktop: Comparator v4** — Rebuilt from terminal multiplexer to structured evaluation workbench with 4-phase workflow (Setup → Execution → Results → Judge), session history rail, SQLite persistence, and shared Comparator types
+- **Marketplace: Ratings and reviews** — install counts, trust tiers, and user ratings on plugin detail pages.
+- **CLI: `detect` and `init` commands** — `harness-kit detect` shows which AI coding platforms are active in the current directory; `harness-kit init` scaffolds a new `harness.yaml` interactively.
 
 ### Changed
 
+- **Plugin renamed: `capture-session` → `capture`** — the slash command is now `/capture`. Staging file (`session-staging.md`) unchanged.
+- **Plugin renamed: `data-lineage` → `lineage`** — the slash command is now `/lineage`. SVG output filename pattern unchanged.
+- **Plugin renamed: `pull-request-sweep` → `pr-sweep`** — the slash command is now `/pr-sweep`.
+- **Plugin versions** — research bumped to 0.4.0, lineage to 0.3.0, capture to 0.4.0, review to 0.3.0, harness-share to 0.3.0, pr-sweep to 0.2.0.
 - **Desktop: MCP Servers, Hooks, and CLAUDE.md pages** — all three pages are now full-page Monaco editors that load their respective config files (`~/.claude/mcp.json`, `~/.claude/settings.json`, `~/.claude/CLAUDE.md`) directly. The previous card-based MCP UI (add/edit/remove servers, source toggle) and the read-only Hooks list are replaced by inline editing. CLAUDE.md gains an Editor/Preview toggle with Preview as the default.
 - **Desktop: Comparator terminals** — each output panel is now a real xterm.js terminal instance, replacing the previous ansi-to-html + `dangerouslySetInnerHTML` approach. Output writes incrementally, auto-resizes with the panel, and renders ANSI color codes natively. Spawned harness processes now receive `FORCE_COLOR=1` and `CLICOLOR_FORCE=1` so CLIs emit color output over pipes. OSC hyperlink handling is disabled (`linkHandler: null`) to eliminate the terminal escape injection surface.
 - **Desktop: Observatory typography** — stat and chart card headers use `font-variant-caps: all-small-caps` instead of `text-transform: uppercase`, matching the sidebar and other labels. Area chart fill gradients are subtler (top stop halved); grid lines use `--separator` instead of `--border-base` so data pops more.
 - **Desktop: Permissions layout** — Tools, Paths, and Network sections merged into a single unified card with inset section dividers. Allow/Deny/Ask tool rows are stacked vertically with color-coded labels. Preset cards display a colored left border (green for Strict, blue for Standard, amber for Permissive) for at-a-glance identity.
-- Renamed `stage` plugin to `capture-session` for clarity — the slash command is now `/capture-session`. The staging file (`session-staging.md`) keeps its name.
 
 ### Security
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,8 @@ harness-kit/
 │   ├── board/                    ← web board client
 │   ├── cli/                      ← harness CLI
 │   └── marketplace/              ← Next.js marketplace web app
+├── profiles/                     ← pre-configured harness.yaml bundles for different roles
+├── evals/                        ← automated skill evaluation framework (Python + golden responses)
 ├── harness.yaml                  ← dogfooding config (plugins used to develop this repo)
 ├── install.sh                    ← script fallback for users without plugin marketplace
 ├── CLAUDE.md                     ← this file

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -371,6 +371,6 @@ Before opening a PR:
 - [ ] `SKILL.md` has YAML frontmatter with `name:` and `description:`
 - [ ] `description:` starts with "Use when" and names the invocation trigger
 - [ ] `README.md` exists in `plugins/<name>/skills/<name>/`
-- [ ] Plugin section added to `README.md` at repo root
+- [ ] Plugin count updated in `README.md` badge and "Browse all N plugins" link if adding a new plugin
 - [ ] PR includes a test plan with at least one test per argument type
 - [ ] If plugin includes agents: `agents/<name>.md` has YAML frontmatter with `name:` and `description:`

--- a/README.md
+++ b/README.md
@@ -118,9 +118,14 @@ A Tauri desktop companion that brings the harness concept to a native UI.
 
 - **Sync engine** — compiles `harness.yaml` to platform configs
 - **Plugin explorer** — browse and manage installed plugins
+- **Marketplace** — embedded plugin browser for discovering and installing from the marketplace
 - **Observatory** — live session dashboard with stats and transcripts
 - **Comparator** -- structured evaluation workbench: configure harnesses, run side-by-side comparisons, review file diffs, and judge results across a 4-phase workflow
 - **Harness editor** — inline editing with custom profiles
+- **Board** — kanban project board with real-time Claude-to-web sync
+- **Roadmap** — AI-driven product roadmap with competitor analysis, generated via Claude
+- **Parity** — cross-platform feature parity tracking across AI coding tools
+- **Security** — permissions editor, secrets management, and audit logging
 - **Memory** — knowledge graph viewer via [membrain](https://github.com/siracusa5/membrain) integration
 - **Team chat** — IRC-style chat backed by a self-hosted WebSocket relay
 - **AI Chat** — streaming conversations with local LLMs via Ollama, with session persistence and inline model downloads

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -26,7 +26,13 @@ A prompt tells Claude what to do. A SKILL.md specifies how: step ordering, input
 
 ## Does this only work with Claude Code?
 
-The install system targets Claude Code's plugin marketplace. But SKILL.md files are plain markdown — any tool that reads prompt files can use them. VS Code Copilot reads `CLAUDE.md` natively via `chat.useClaudeMdFile`. See the [Cross-Harness setup guide](https://harnesskit.ai/docs/cross-harness/setup-guide) for Cursor, Windsurf, and others.
+The primary install path targets Claude Code's plugin marketplace. But harness-kit has a few other interfaces:
+
+- **Desktop app** (`apps/desktop/`) — a Tauri native app with a full GUI for managing harness configs, browsing plugins, running the observatory, comparator, board, roadmap, and more
+- **CLI** (`harness-kit` command) — `validate`, `compile`, `detect`, and `init` commands for working with `harness.yaml` from any terminal
+- **SKILL.md files** are plain markdown — any tool that reads prompt files can use them. VS Code Copilot reads `CLAUDE.md` natively via `chat.useClaudeMdFile`
+
+See the [Cross-Harness setup guide](https://harnesskit.ai/docs/cross-harness/setup-guide) for Cursor, Windsurf, and others.
 
 ## Is this safe? What does installing a plugin actually do?
 

--- a/docs/plugins-vs-skills.md
+++ b/docs/plugins-vs-skills.md
@@ -26,7 +26,7 @@ Marketplace
 
 ## Why everything here is a plugin
 
-Some plugins in this repo are "just" a skill — `explain`, `data-lineage`, and `orient` each contain a single `SKILL.md` with no scripts or hooks. We package them as plugins anyway:
+Some plugins in this repo are "just" a skill — `explain`, `lineage`, and `orient` each contain a single `SKILL.md` with no scripts or hooks. We package them as plugins anyway:
 
 - **Room to grow** — Adding scripts or hooks later is a file addition, not a restructuring. `research` started as a bare skill and grew a prompt-injection scanner and an index rebuild script.
 - **Uniform install** — One mental model: add the marketplace, install by name. Users don't need to know what's inside.

--- a/profiles/data-engineer.yaml
+++ b/profiles/data-engineer.yaml
@@ -15,20 +15,20 @@ author:
   name: harnessprotocol
 
 components:
-  - name: data-lineage
-    version: "0.2.0"
+  - name: lineage
+    version: "0.3.0"
   - name: research
-    version: "0.2.0"
+    version: "0.4.0"
   - name: orient
     version: "0.2.0"
-  - name: capture-session
-    version: "0.2.0"
+  - name: capture
+    version: "0.4.0"
   - name: explain
     version: "0.2.0"
   - name: docgen
     version: "0.2.0"
   - name: review
-    version: "0.2.0"
+    version: "0.3.0"
 
 knowledge:
   backend: memory-md

--- a/profiles/full-stack-engineer.yaml
+++ b/profiles/full-stack-engineer.yaml
@@ -15,13 +15,13 @@ author:
 
 components:
   - name: review
-    version: "0.2.0"
+    version: "0.3.0"
   - name: open-pr
     version: "0.1.0"
   - name: merge-pr
     version: "0.1.0"
   - name: pr-sweep
-    version: "0.1.0"
+    version: "0.2.0"
   - name: explain
     version: "0.2.0"
   - name: docgen

--- a/profiles/research-knowledge.yaml
+++ b/profiles/research-knowledge.yaml
@@ -15,11 +15,11 @@ author:
 
 components:
   - name: research
-    version: "0.2.0"
+    version: "0.4.0"
   - name: orient
     version: "0.2.0"
-  - name: capture-session
-    version: "0.2.0"
+  - name: capture
+    version: "0.4.0"
   - name: explain
     version: "0.2.0"
   - name: docgen

--- a/website/content/docs/concepts/cross-harness-portability.md
+++ b/website/content/docs/concepts/cross-harness-portability.md
@@ -41,7 +41,7 @@ Some parts of the plugin system are tied to Claude Code's infrastructure:
 | SKILL.md prompts | Portable now | Plain markdown, works anywhere |
 | Distribution (marketplace install) | Claude Code + Copilot CLI | Both use compatible plugin formats; Copilot CLI reads `.claude-plugin/` natively |
 | Stop hooks | Claude Code only | Hook system is Claude Code-specific |
-| MCP server references (orient, capture-session) | Partially portable | MCP is an open protocol, but wiring varies by tool |
+| MCP server references (orient, capture) | Partially portable | MCP is an open protocol, but wiring varies by tool |
 | Bundled scripts | Portable | Shell scripts, but auto-execution depends on the harness |
 
 ## The vision

--- a/website/content/docs/concepts/plugins-vs-skills.md
+++ b/website/content/docs/concepts/plugins-vs-skills.md
@@ -56,7 +56,7 @@ The Agent Skills specification that underlies this format is published as an ope
 
 ## Why Everything Here is a Plugin
 
-Some plugins in this repo are "just" a skill — `explain`, `data-lineage`, and `orient` each contain a single `SKILL.md` with no scripts or hooks. We package them as plugins anyway:
+Some plugins in this repo are "just" a skill — `explain`, `lineage`, and `orient` each contain a single `SKILL.md` with no scripts or hooks. We package them as plugins anyway:
 
 - **Room to grow** — Adding scripts or hooks later is a file addition, not a restructuring. `research` started as a bare skill and grew a prompt-injection scanner and an index rebuild script.
 - **Uniform install** — One mental model: add the marketplace, install by name. Users don't need to know what's inside.

--- a/website/content/docs/cross-harness/ide-support.md
+++ b/website/content/docs/cross-harness/ide-support.md
@@ -31,16 +31,25 @@ Quick reference for feature support by editor — useful when deciding where to 
 | review | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
 | docgen | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
 | research | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
-| data-lineage | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
+| lineage | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
 | orient | ✅ native | ✅ native | 🔄 MCP required | 🔄 MCP required | ❌ no MCP |
-| capture-session | ✅ native | ✅ native | 🔄 MCP required | 🔄 MCP required | ❌ no MCP |
+| capture | ✅ native | ✅ native | 🔄 MCP required | 🔄 MCP required | ❌ no MCP |
+| membrain | ✅ native | ✅ native | 🔄 MCP required | 🔄 MCP required | ❌ no MCP |
+| open-pr | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
+| merge-pr | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
+| pr-sweep | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
+| harness-share | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
+| stats | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
+| board | ✅ native | 🔄 MCP required | 🔄 MCP required | 🔄 MCP required | ❌ no MCP |
+| iterm-notify | ✅ native | ❌ hooks only | ❌ hooks only | ❌ hooks only | ❌ hooks only |
+| frontend-design | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
 
 > MCP-required plugins work in tools that support MCP servers.
 
 ## MCP as Universal Fallback
 
-MCP has the broadest cross-tool support of any harness-kit feature. The `orient` and `capture-session` plugins depend on MCP Memory Server — any tool supporting MCP (via `.vscode/mcp.json`, `.cursor/mcp.json`, etc.) can run these plugins. MCP is the forward-compatible path for bringing harness-kit capabilities to new editors as support expands.
+MCP has the broadest cross-tool support of any harness-kit feature. The `orient`, `capture`, and `membrain` plugins depend on MCP — any tool supporting MCP (via `.vscode/mcp.json`, `.cursor/mcp.json`, etc.) can run these plugins. MCP is the forward-compatible path for bringing harness-kit capabilities to new editors as support expands.
 
 ## Last Updated
 
-Last updated: 2026-03-09
+Last updated: 2026-04-06

--- a/website/content/docs/cross-harness/setup-guide.mdx
+++ b/website/content/docs/cross-harness/setup-guide.mdx
@@ -77,7 +77,7 @@ MCP has 100% cross-platform support — it's the only harness-kit feature that w
 | Copilot (VS Code) | `.vscode/mcp.json` |
 | Cursor | `.cursor/mcp.json` |
 
-Plugins that depend on MCP (like `orient` and `capture-session`) work in any of these tools as long as the server is wired up.
+Plugins that depend on MCP (like `orient` and `capture`) work in any of these tools as long as the server is wired up.
 
 ## What You Lose
 

--- a/website/content/docs/getting-started/architecture.mdx
+++ b/website/content/docs/getting-started/architecture.mdx
@@ -88,7 +88,7 @@ Your harness setup is fully reproducible. Config files live in version control; 
   <rect x="86" y="142" width="74" height="22" rx="5" fill="#12121a" stroke="#555" strokeWidth="1.5" />
   <text x="123" y="157" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="11" fill="#888">research</text>
   <rect x="18" y="170" width="94" height="22" rx="5" fill="#12121a" stroke="#555" strokeWidth="1.5" />
-  <text x="65" y="185" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="11" fill="#888">data-lineage</text>
+  <text x="65" y="185" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="11" fill="#888">lineage</text>
   <rect x="120" y="170" width="60" height="22" rx="5" fill="#12121a" stroke="#555" strokeWidth="1.5" />
   <text x="150" y="185" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="11" fill="#888">review ...</text>
   <line x1="202" y1="78" x2="354" y2="78" markerEnd="url(#arr)" stroke="#8b7aff" strokeWidth="1.5" />
@@ -111,7 +111,7 @@ Your harness setup is fully reproducible. Config files live in version control; 
   <rect x="440" y="142" width="74" height="22" rx="5" fill="#12121a" stroke="#555" strokeWidth="1.5" />
   <text x="477" y="157" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="11" fill="#888">research</text>
   <rect x="372" y="170" width="94" height="22" rx="5" fill="#12121a" stroke="#555" strokeWidth="1.5" />
-  <text x="419" y="185" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="11" fill="#888">data-lineage</text>
+  <text x="419" y="185" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="11" fill="#888">lineage</text>
   <rect x="474" y="170" width="60" height="22" rx="5" fill="#12121a" stroke="#555" strokeWidth="1.5" />
   <text x="504" y="185" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="11" fill="#888">review ...</text>
 </svg>
@@ -146,7 +146,7 @@ Your entire harness — plugins, versions, sources — serializes into a single 
   <rect x="84" y="100" width="52" height="20" rx="4" fill="#12121a" stroke="#555" strokeWidth="1.2" />
   <text x="110" y="114" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="10" fill="#888">explain</text>
   <rect x="18" y="126" width="74" height="20" rx="4" fill="#12121a" stroke="#555" strokeWidth="1.2" />
-  <text x="55" y="140" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="10" fill="#888">data-lineage</text>
+  <text x="55" y="140" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="10" fill="#888">lineage</text>
   <rect x="98" y="126" width="52" height="20" rx="4" fill="#12121a" stroke="#555" strokeWidth="1.2" />
   <text x="124" y="140" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="10" fill="#888">review</text>
 
@@ -170,7 +170,7 @@ Your entire harness — plugins, versions, sources — serializes into a single 
   <text x="258" y="132" fontFamily="monospace, Menlo, Consolas" fontSize="10" fill="#888">plugins:</text>
   <text x="268" y="148" fontFamily="monospace, Menlo, Consolas" fontSize="10" fill="#666">- research@0.2.0</text>
   <text x="268" y="162" fontFamily="monospace, Menlo, Consolas" fontSize="10" fill="#666">- explain@0.2.0</text>
-  <text x="268" y="176" fontFamily="monospace, Menlo, Consolas" fontSize="10" fill="#666">- data-lineage@0.2.0</text>
+  <text x="268" y="176" fontFamily="monospace, Menlo, Consolas" fontSize="10" fill="#666">- lineage@0.3.0</text>
   <text x="268" y="190" fontFamily="monospace, Menlo, Consolas" fontSize="10" fill="#666">- review@0.2.0</text>
   <text x="258" y="210" fontFamily="monospace, Menlo, Consolas" fontSize="10" fill="#888">mcp-servers:</text>
   <text x="268" y="226" fontFamily="monospace, Menlo, Consolas" fontSize="10" fill="#666">- memory, filesystem</text>
@@ -207,7 +207,7 @@ Your entire harness — plugins, versions, sources — serializes into a single 
 
   {/* Checkboxes — skipped */}
   <rect x="522" y="98" width="14" height="14" rx="3" fill="none" stroke="#555" strokeWidth="1.2" />
-  <text x="544" y="110" fontFamily="system-ui, sans-serif" fontSize="11" fill="#666">data-lineage@0.2.0</text>
+  <text x="544" y="110" fontFamily="system-ui, sans-serif" fontSize="11" fill="#666">lineage@0.3.0</text>
 
   <rect x="522" y="120" width="14" height="14" rx="3" fill="#8b7aff" stroke="#8b7aff" strokeWidth="1" />
   <text x="520" y="132" fontFamily="system-ui, sans-serif" fontSize="11" fill="#fff" dx="3" dy="-1">✓</text>

--- a/website/content/docs/getting-started/installation.mdx
+++ b/website/content/docs/getting-started/installation.mdx
@@ -20,9 +20,9 @@ Repeat for any plugin you want:
 
 ```
 /plugin install explain@harness-kit
-/plugin install data-lineage@harness-kit
+/plugin install lineage@harness-kit
 /plugin install orient@harness-kit
-/plugin install capture-session@harness-kit
+/plugin install capture@harness-kit
 /plugin install review@harness-kit
 /plugin install docgen@harness-kit
 ```
@@ -64,11 +64,20 @@ For per-tool setup instructions (Copilot, Cursor, Windsurf, MCP wiring), see [Us
 |--------|-------------|
 | research | `gh` CLI (GitHub sources only), Python 3.10+ (index rebuild) |
 | explain | None |
-| data-lineage | None |
+| lineage | None |
 | orient | None (optional: [MCP Memory Server](https://github.com/anthropics/claude-code-memory)) |
-| capture-session | None |
+| capture | None |
 | review | `gh` CLI (PR review only) |
 | docgen | None |
+| open-pr | `gh` CLI |
+| merge-pr | `gh` CLI |
+| pr-sweep | `gh` CLI, review plugin |
+| harness-share | None |
+| stats | Python 3.10+ |
+| board | Node.js (board server) |
+| iterm-notify | macOS, iTerm2, terminal-notifier, jq |
+| membrain | Go 1.25+, membrain MCP server |
+| frontend-design | None |
 
 <Callout type="warn" title="Environment variables">
   Some plugins require environment variables for optional features. See the [Secrets Management guide](/docs/guides/secrets-management) for how to configure them.

--- a/website/content/docs/getting-started/quick-start.mdx
+++ b/website/content/docs/getting-started/quick-start.mdx
@@ -57,8 +57,8 @@ Fetches the repo, saves raw content, and creates a synthesis document.
 ### Trace data lineage
 
 ```
-/plugin install data-lineage@harness-kit
-/data-lineage orders.total_amount
+/plugin install lineage@harness-kit
+/lineage orders.total_amount
 ```
 
 Traces a column through SQL, Kafka, Spark, and JDBC code. Generates an SVG diagram.
@@ -75,8 +75,8 @@ Searches your knowledge graph, docs, and journal for everything related to a top
 ### Capture session facts
 
 ```
-/plugin install capture-session@harness-kit
-/capture-session SQLite chosen over Postgres for local-first storage
+/plugin install capture@harness-kit
+/capture SQLite chosen over Postgres for local-first storage
 ```
 
 Stages important decisions and facts for later reflection.

--- a/website/content/docs/plugins/data-engineering/lineage.mdx
+++ b/website/content/docs/plugins/data-engineering/lineage.mdx
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 4
-title: data-lineage
+title: lineage
 ---
 
-> **[View in Marketplace →](https://marketplace.harnessprotocol.io/plugins/data-lineage)** for install tracking, related plugins, and profiles.
+> **[View in Marketplace →](https://marketplace.harnessprotocol.io/plugins/lineage)** for install tracking, related plugins, and profiles.
 
-# data-lineage
+# lineage
 
 Column-level lineage tracing through SQL, Kafka, Spark, and JDBC codebases.
 
@@ -15,7 +15,7 @@ None — uses only codebase search, file reads, and inline SVG generation. No da
 
 ## What It Does
 
-When you invoke `/data-lineage` with a column name:
+When you invoke `/lineage` with a column name:
 
 1. Searches for SQL definitions (tables, views, migrations) containing the column
 2. Traces view chains recursively to find source tables
@@ -38,25 +38,25 @@ Each trace produces two outputs:
 ### Trace a qualified column
 
 ```
-/data-lineage orders.total_amount
+/lineage orders.total_amount
 ```
 
 ### Trace with full qualification
 
 ```
-/data-lineage reporting.daily_summary.total_amount
+/lineage reporting.daily_summary.total_amount
 ```
 
 ### Trace with context
 
 ```
-/data-lineage customer_id in reporting.daily_summary
+/lineage customer_id in reporting.daily_summary
 ```
 
 ### Trace an unqualified column
 
 ```
-/data-lineage revenue
+/lineage revenue
 ```
 
 If the column exists in multiple tables, you'll be asked which one to trace.
@@ -108,12 +108,12 @@ Self-contained, opens in any browser, requires no dependencies. Can be shared, e
 <Accordions>
 <Accordion title="SKILL.md — Runtime Configuration">
 
-{/* @embed plugins/data-lineage/skills/data-lineage/SKILL.md */}
+{/* @embed plugins/lineage/skills/lineage/SKILL.md */}
 
 </Accordion>
 <Accordion title="README.md — Plugin Documentation">
 
-{/* @embed plugins/data-lineage/skills/data-lineage/README.md */}
+{/* @embed plugins/lineage/skills/lineage/README.md */}
 
 </Accordion>
 </Accordions>

--- a/website/content/docs/plugins/data-engineering/meta.json
+++ b/website/content/docs/plugins/data-engineering/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Data Engineering",
-  "pages": ["data-lineage"]
+  "pages": ["lineage"]
 }

--- a/website/content/docs/plugins/devops/meta.json
+++ b/website/content/docs/plugins/devops/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "DevOps",
-  "pages": ["open-pr", "merge-pr", "pull-request-sweep"]
+  "pages": ["open-pr", "merge-pr", "pr-sweep"]
 }

--- a/website/content/docs/plugins/devops/pr-sweep.mdx
+++ b/website/content/docs/plugins/devops/pr-sweep.mdx
@@ -1,10 +1,10 @@
 ---
-title: pull-request-sweep
+title: pr-sweep
 ---
 
-> **[View in Marketplace →](https://marketplace.harnessprotocol.io/plugins/pull-request-sweep)** for install tracking, related plugins, and profiles.
+> **[View in Marketplace →](https://marketplace.harnessprotocol.io/plugins/pr-sweep)** for install tracking, related plugins, and profiles.
 
-# pull-request-sweep
+# pr-sweep
 
 Cross-repo PR sweep — discover, triage, review, merge, and report on all your open PRs.
 
@@ -18,12 +18,12 @@ Cross-repo PR sweep — discover, triage, review, merge, and report on all your 
 
 ```
 /plugin marketplace add harnessprotocol/harness-kit
-/plugin install pull-request-sweep@harness-kit
+/plugin install pr-sweep@harness-kit
 ```
 
 ## What It Does
 
-When you invoke `/pull-request-sweep`:
+When you invoke `/pr-sweep`:
 
 1. Discovers all open (non-draft) PRs authored by you across all repos
 2. Enriches each PR with CI status and merge state
@@ -35,7 +35,7 @@ When you invoke `/pull-request-sweep`:
 ## Usage
 
 ```
-/pull-request-sweep
+/pr-sweep
 ```
 
 Or use natural language:
@@ -51,7 +51,7 @@ Sweep my PRs.
 - Never acts on draft PRs
 - Never auto-resolves CHANGES_REQUESTED — flags for human follow-up
 - Safe to run repeatedly — idempotent, already-merged PRs won't reappear
-- Pairs with `/loop 30m /pull-request-sweep` for ongoing PR babysitting
+- Pairs with `/loop 30m /pr-sweep` for ongoing PR babysitting
 
 ## Source Files
 

--- a/website/content/docs/plugins/overview.md
+++ b/website/content/docs/plugins/overview.md
@@ -13,14 +13,14 @@ harness-kit ships 16 plugins across 7 categories. Each packages a proven workflo
 |--------|-------------|-------------|
 | [research](research-knowledge/research) | Process any source into a structured, compounding knowledge base | `gh` CLI (GitHub only), Python 3.10+ |
 | [orient](research-knowledge/orient) | Topic-focused session orientation across graph, knowledge, and research | None (optional: MCP Memory Server) |
-| [capture-session](research-knowledge/capture-session) | Capture session information into a staging file for later reflection | None |
+| [capture](research-knowledge/capture) | Capture session information into a staging file for later reflection | None |
 | [review](code-quality/review) | Structured code review for branches, PRs, or paths with severity labels | `gh` CLI (PR review only) |
 | [explain](code-quality/explain) | Layered explanations of files, functions, directories, or concepts | None |
-| [data-lineage](data-engineering/data-lineage) | Column-level lineage tracing through SQL, Kafka, Spark, JDBC | None |
+| [lineage](data-engineering/lineage) | Column-level lineage tracing through SQL, Kafka, Spark, JDBC | None |
 | [docgen](documentation/docgen) | Generate or update README, API docs, architecture overview, or changelog | None |
 | [open-pr](devops/open-pr) | Pre-flight checks and PR creation: tests, PR, review, CI | `gh` CLI |
 | [merge-pr](devops/merge-pr) | Merge a ready PR: verify CI, sync base, squash merge, clean up | `gh` CLI |
-| [pull-request-sweep](devops/pull-request-sweep) | Cross-repo PR sweep: triage, review, merge, fix CI | `gh` CLI |
+| [pr-sweep](devops/pr-sweep) | Cross-repo PR sweep: triage, review, merge, fix CI | `gh` CLI |
 | [harness-share](productivity/harness-share) | Compile, export, import, and sync harness configs across AI tools | None |
 | [stats](productivity/stats) | Interactive HTML dashboard for Claude Code token and session usage | Python 3.10+ |
 | [iterm-notify](productivity/iterm-notify) | macOS desktop notifications and iTerm2 badge management for Claude Code events | macOS, iTerm2, terminal-notifier, jq |
@@ -64,8 +64,8 @@ Profiles are pre-configured collections of plugins for specific roles. Each prof
 
 | Profile | Who it's for | Plugins included |
 |---------|-------------|-----------------|
-| [research-knowledge](/profiles/research-knowledge) | Research-focused roles | research, orient, capture-session, explain, docgen |
-| [data-engineer](/profiles/data-engineer) | Data engineers with SQL pipelines | data-lineage, research, orient, capture-session, explain, docgen, review |
-| [full-stack-engineer](/profiles/full-stack-engineer) | Full-stack feature shipping | review, open-pr, merge-pr, pull-request-sweep, explain, docgen, harness-share |
+| [research-knowledge](/profiles/research-knowledge) | Research-focused roles | research, orient, capture, explain, docgen |
+| [data-engineer](/profiles/data-engineer) | Data engineers with SQL pipelines | lineage, research, orient, capture, explain, docgen, review |
+| [full-stack-engineer](/profiles/full-stack-engineer) | Full-stack feature shipping | review, open-pr, merge-pr, pr-sweep, explain, docgen, harness-share |
 
 Install a profile's plugins individually, or use `/harness-import` with the profile's YAML to install them all at once.

--- a/website/content/docs/plugins/research-knowledge/capture.mdx
+++ b/website/content/docs/plugins/research-knowledge/capture.mdx
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 6
-title: capture-session
+title: capture
 ---
 
-> **[View in Marketplace →](https://marketplace.harnessprotocol.io/plugins/capture-session)** for install tracking, related plugins, and profiles.
+> **[View in Marketplace →](https://marketplace.harnessprotocol.io/plugins/capture)** for install tracking, related plugins, and profiles.
 
-# capture-session
+# capture
 
 Capture session information into a staging file for later reflection and knowledge graph processing.
 
@@ -17,12 +17,12 @@ None.
 
 | Component | Purpose |
 |-----------|---------|
-| `/capture-session` skill | Manual, on-demand staging from within a conversation |
-| `session-capture.sh` | Automated Stop hook that summarizes sessions at exit |
+| `/capture` skill | Manual, on-demand staging from within a conversation |
+| `session-end.sh` | Automated Stop hook that summarizes sessions at exit |
 
 ## What It Does
 
-When you invoke `/capture-session`:
+When you invoke `/capture`:
 
 1. Parses your argument to determine what to capture
 2. Resolves the staging file (`scripts/session-staging.md` or `~/.claude/session-staging.md`)
@@ -34,7 +34,7 @@ When you invoke `/capture-session`:
 ### Auto-extract (no argument)
 
 ```
-/capture-session
+/capture
 ```
 
 Scans the conversation and extracts 3-8 most important facts — decisions, technical details, status changes, new entities.
@@ -42,14 +42,14 @@ Scans the conversation and extracts 3-8 most important facts — decisions, tech
 ### Stage specific facts
 
 ```
-/capture-session SQLite chosen over Postgres for local-first storage
-/capture-session harness-kit domain purchased at harnesskit.ai, 3-year registration
+/capture SQLite chosen over Postgres for local-first storage
+/capture harness-kit domain purchased at harnesskit.ai, 3-year registration
 ```
 
 ### Filter to decisions only
 
 ```
-/capture-session decisions
+/capture decisions
 ```
 
 Extracts only explicit decisions — architectural choices, plans confirmed, approaches selected.
@@ -57,7 +57,7 @@ Extracts only explicit decisions — architectural choices, plans confirmed, app
 ### Filter to technical facts only
 
 ```
-/capture-session technical
+/capture technical
 ```
 
 Extracts only implementation details, file paths, APIs, schemas, commands.
@@ -75,7 +75,7 @@ The Stop hook automatically summarizes sessions at exit. Add to `~/.claude/hooks
         "hooks": [
           {
             "type": "command",
-            "command": "/path/to/plugins/capture-session/scripts/session-capture.sh"
+            "command": "/path/to/plugins/capture/scripts/session-end.sh"
           }
         ]
       }
@@ -86,14 +86,14 @@ The Stop hook automatically summarizes sessions at exit. Add to `~/.claude/hooks
 
 The `"matcher": ""` field is an empty string, which means the hook fires on every Stop event regardless of context. To restrict it to specific projects, set `matcher` to a glob pattern matching the project path.
 
-After `plugin install capture-session@harness-kit`, the script is at `~/.claude/plugins/capture-session/scripts/session-capture.sh`. For a local clone, use the absolute path to `plugins/capture-session/scripts/session-capture.sh`.
+After `plugin install capture@harness-kit`, the script is at `~/.claude/plugins/capture/scripts/session-end.sh`. For a local clone, use the absolute path to `plugins/capture/scripts/session-end.sh`.
 
 The hook reads the Stop event payload, finds the session transcript, summarizes it, and appends to the staging file. It deduplicates against `<!-- source: manual -->` entries from the same day.
 
 ## Pipeline
 
 ```
-Manual /capture-session  ──┐
+Manual /capture  ──┐
                   ├──▶  session-staging.md  ──▶  daily reflection  ──▶  knowledge graph
 Auto Stop hook ──┘
 ```
@@ -112,7 +112,7 @@ Facts staged here are consumed by the daily reflection.
 
 ## 2026-03-08 23:59
 <!-- source: hook -->
-- Implemented capture-session plugin with 4 argument types
+- Implemented capture plugin with 4 argument types
 - Updated marketplace.json and install.sh
 ```
 
@@ -120,7 +120,7 @@ Facts staged here are consumed by the daily reflection.
 
 ### Why manual staging?
 
-The Stop hook auto-summarizes at session end — useful, but it misses nuance. `/capture-session decisions` lets you control what gets remembered while context is fresh.
+The Stop hook auto-summarizes at session end — useful, but it misses nuance. `/capture decisions` lets you control what gets remembered while context is fresh.
 
 ### Why the same pipeline?
 
@@ -135,12 +135,12 @@ The staging file is a write-ahead log. Modifying existing entries would corrupt 
 <Accordions>
 <Accordion title="SKILL.md — Runtime Configuration">
 
-{/* @embed plugins/capture-session/skills/capture-session/SKILL.md */}
+{/* @embed plugins/capture/skills/capture/SKILL.md */}
 
 </Accordion>
 <Accordion title="README.md — Plugin Documentation">
 
-{/* @embed plugins/capture-session/skills/capture-session/README.md */}
+{/* @embed plugins/capture/skills/capture/README.md */}
 
 </Accordion>
 </Accordions>

--- a/website/content/docs/plugins/research-knowledge/meta.json
+++ b/website/content/docs/plugins/research-knowledge/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Research & Knowledge",
-  "pages": ["research", "orient", "capture-session", "membrain"]
+  "pages": ["research", "orient", "capture", "membrain"]
 }


### PR DESCRIPTION
## Summary

Comprehensive documentation audit and update. Three plugin renames (`data-lineage` → `lineage`, `capture-session` → `capture`, `pull-request-sweep` → `pr-sweep`) were applied to plugin manifests but never propagated to the website docs, profiles, or architecture diagrams. Additionally, the desktop app has gained major features since the docs were last updated, profile YAMLs have stale versions, and the installation/portability tables were incomplete.

## Changes

**Plugin renames propagated across all docs:**
- Renamed `data-lineage.mdx` → `lineage.mdx`, `capture-session.mdx` → `capture.mdx`, `pull-request-sweep.mdx` → `pr-sweep.mdx` (with all internal command references, marketplace URLs, and `@embed` paths updated)
- Updated 3 `meta.json` routing files, `overview.md`, `installation.mdx`, `quick-start.mdx`, `architecture.mdx` SVGs, and 4 cross-cutting concept/guide pages

**Profile YAMLs synced to current versions:**
- `data-engineer.yaml`: lineage 0.3.0, research 0.4.0, capture 0.4.0, review 0.3.0
- `research-knowledge.yaml`: research 0.4.0, capture 0.4.0
- `full-stack-engineer.yaml`: review 0.3.0, pr-sweep 0.2.0

**Tables expanded:**
- `installation.mdx` requirements table: 7 → 16 plugins
- `ide-support.md` portability matrix: 7 → 16 plugins (date updated to 2026-04-06)

**Root-level docs updated:**
- `README.md`: Added Roadmap, Parity, Security, and Marketplace to desktop app feature list
- `CHANGELOG.md`: Added missing 0.2.1 entries (AI Chat, Roadmap, Parity, Security section, Board, CLI commands, Marketplace ratings, plugin renames/version bumps)
- `CLAUDE.md`: Added `profiles/` and `evals/` to repo structure tree
- `CONTRIBUTING.md`: Fixed pre-submit checklist item for plugin count
- `docs/FAQ.md`: Expanded cross-tool answer to mention desktop app and CLI

## Test Plan

- [x] Local tests pass (`pnpm test:core` — 68/68)
- [x] Plugin manifest validation: all 16 plugins valid, versions aligned
- [ ] CI checks pass
- [ ] `grep -r "data-lineage" website/ profiles/ docs/` returns 0 hits ✓ (verified locally)
- [ ] `grep -r "capture-session" website/content/docs/ profiles/` returns 0 hits ✓ (verified locally)

## Notes

Blog posts under `website/blog/` intentionally keep old plugin names — they were accurate at time of writing and serve as historical record. CHANGELOG 0.1.0/0.2.0 sections likewise preserved as-is.