### PR TITLE
feat(board): switch Claude harness to --permission-mode auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Changed
 
+- **Board: task execution permission mode** — Claude Code harness now uses `--permission-mode auto` instead of `--allowedTools Read,Grep,Glob,Agent,Skill`. Auto mode applies AI classifiers to approve non-destructive actions without blocking for human confirmation, eliminating friction on standard coding operations (writes, edits, shell commands) while preserving safety guardrails.
 - **Plugin renamed: `capture-session` → `capture`** — the slash command is now `/capture`. Staging file (`session-staging.md`) unchanged.
 - **Plugin renamed: `data-lineage` → `lineage`** — the slash command is now `/lineage`. SVG output filename pattern unchanged.
 - **Plugin renamed: `pull-request-sweep` → `pr-sweep`** — the slash command is now `/pr-sweep`.

--- a/apps/desktop/src/hooks/__tests__/useTaskExecution.test.ts
+++ b/apps/desktop/src/hooks/__tests__/useTaskExecution.test.ts
@@ -1,0 +1,425 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { useTaskExecution } from "../useTaskExecution";
+import type { Task, Project } from "../../lib/board-api";
+
+// ── Tauri mocks ────────────────────────────────────────────────
+
+const mockInvoke = vi.fn();
+const mockUnlisten = vi.fn();
+type ListenerFn = (event: { payload: unknown }) => void;
+const listeners: Record<string, ListenerFn> = {};
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: (...a: unknown[]) => mockInvoke(...a) }));
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn((eventName: string, callback: ListenerFn) => {
+    listeners[eventName] = callback;
+    return Promise.resolve(mockUnlisten);
+  }),
+}));
+
+// ── board-api mock ─────────────────────────────────────────────
+
+const mockUpdateExecution = vi.fn().mockResolvedValue({});
+const mockUpdateTask = vi.fn().mockResolvedValue({});
+
+vi.mock("../../lib/board-api", () => ({
+  api: {
+    tasks: {
+      updateExecution: (...a: unknown[]) => mockUpdateExecution(...a),
+      update: (...a: unknown[]) => mockUpdateTask(...a),
+    },
+  },
+}));
+
+// ── Wire-format helpers ────────────────────────────────────────
+
+function emitOutput(terminalId: string, data: string) {
+  listeners["terminal://output"]?.({ payload: { terminalId, data } });
+}
+
+function emitExit(terminalId: string, exitCode: number) {
+  listeners["terminal://exit"]?.({ payload: { terminalId, exitCode } });
+}
+
+// ── Fixtures ───────────────────────────────────────────────────
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 1,
+    title: "Fix the login bug",
+    status: "in-progress",
+    linked_commits: [],
+    comments: [],
+    subtasks: [],
+    next_subtask_id: 1,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeProject(overrides: Partial<Project> = {}): Project {
+  return {
+    name: "My Project",
+    slug: "my-project",
+    next_id: 2,
+    version: 1,
+    epics: [],
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+// ── Setup ──────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockInvoke.mockImplementation((cmd: string) => {
+    if (cmd === "create_terminal") return Promise.resolve("term-1");
+    if (cmd === "write_terminal") return Promise.resolve();
+    if (cmd === "destroy_terminal") return Promise.resolve();
+    return Promise.resolve();
+  });
+});
+
+// ── Tests ──────────────────────────────────────────────────────
+
+describe("useTaskExecution — prompt construction", () => {
+  it("builds prompt with task id and title", async () => {
+    const { result } = renderHook(() => useTaskExecution());
+    const task = makeTask({ id: 42, title: "Refactor auth module" });
+
+    await act(async () => {
+      await result.current.startTask("proj", task, makeProject());
+    });
+
+    expect(mockInvoke).toHaveBeenCalledWith("write_terminal", expect.objectContaining({
+      data: expect.stringContaining("Work on board task #42: Refactor auth module"),
+    }));
+  });
+
+  it("appends task description when present", async () => {
+    const { result } = renderHook(() => useTaskExecution());
+    const task = makeTask({ description: "Use JWT tokens instead of sessions." });
+
+    await act(async () => {
+      await result.current.startTask("proj", task, makeProject());
+    });
+
+    expect(mockInvoke).toHaveBeenCalledWith("write_terminal", expect.objectContaining({
+      data: expect.stringContaining("Use JWT tokens instead of sessions."),
+    }));
+  });
+
+  it("omits description section when task has no description", async () => {
+    const { result } = renderHook(() => useTaskExecution());
+    const task = makeTask({ description: undefined });
+
+    await act(async () => {
+      await result.current.startTask("proj", task, makeProject());
+    });
+
+    const call = (mockInvoke as Mock).mock.calls.find(
+      ([cmd]) => cmd === "write_terminal",
+    );
+    const data: string = call![1].data;
+    // Should be title line only, no blank-line-then-description
+    expect(data.trim()).toBe("claude 'Work on board task #1: Fix the login bug' --permission-mode auto\n".trim());
+  });
+
+  it("appends pending subtasks to prompt", async () => {
+    const { result } = renderHook(() => useTaskExecution());
+    const task = makeTask({
+      subtasks: [
+        { id: 1, title: "Write unit tests", status: "pending", files: [] },
+        { id: 2, title: "Update README", status: "in_progress", files: [] },
+        { id: 3, title: "Deploy to staging", status: "completed", files: [] },
+      ],
+    });
+
+    await act(async () => {
+      await result.current.startTask("proj", task, makeProject());
+    });
+
+    expect(mockInvoke).toHaveBeenCalledWith("write_terminal", expect.objectContaining({
+      data: expect.stringContaining("Write unit tests"),
+    }));
+    expect(mockInvoke).toHaveBeenCalledWith("write_terminal", expect.objectContaining({
+      data: expect.stringContaining("Update README"),
+    }));
+  });
+
+  it("excludes completed and failed subtasks from prompt", async () => {
+    const { result } = renderHook(() => useTaskExecution());
+    const task = makeTask({
+      subtasks: [
+        { id: 1, title: "Done subtask", status: "completed", files: [] },
+        { id: 2, title: "Failed subtask", status: "failed", files: [] },
+        { id: 3, title: "Pending subtask", status: "pending", files: [] },
+      ],
+    });
+
+    await act(async () => {
+      await result.current.startTask("proj", task, makeProject());
+    });
+
+    const call = (mockInvoke as Mock).mock.calls.find(
+      ([cmd]) => cmd === "write_terminal",
+    );
+    const data: string = call![1].data;
+    expect(data).not.toContain("Done subtask");
+    expect(data).not.toContain("Failed subtask");
+    expect(data).toContain("Pending subtask");
+  });
+
+  it("omits subtask section when all subtasks are completed", async () => {
+    const { result } = renderHook(() => useTaskExecution());
+    const task = makeTask({
+      subtasks: [
+        { id: 1, title: "Done", status: "completed", files: [] },
+      ],
+    });
+
+    await act(async () => {
+      await result.current.startTask("proj", task, makeProject());
+    });
+
+    const call = (mockInvoke as Mock).mock.calls.find(
+      ([cmd]) => cmd === "write_terminal",
+    );
+    const data: string = call![1].data;
+    expect(data).not.toContain("Pending subtasks");
+  });
+});
+
+describe("useTaskExecution — harness resolution", () => {
+  it("uses task.default_harness when set", async () => {
+    const { result } = renderHook(() => useTaskExecution());
+    const task = makeTask({ default_harness: "codex" });
+    const project = makeProject({ default_harness: "claude" });
+
+    await act(async () => {
+      await result.current.startTask("proj", task, project);
+    });
+
+    // codex uses positional prompt, no --permission-mode flag
+    const call = (mockInvoke as Mock).mock.calls.find(([cmd]) => cmd === "write_terminal");
+    expect(call![1].data).toMatch(/^opencode|^codex|^agent/);
+  });
+
+  it("falls back to project.default_harness when task has none", async () => {
+    const { result } = renderHook(() => useTaskExecution());
+    const task = makeTask({ default_harness: undefined });
+    const project = makeProject({ default_harness: "cursor-agent" });
+
+    await act(async () => {
+      await result.current.startTask("proj", task, project);
+    });
+
+    const call = (mockInvoke as Mock).mock.calls.find(([cmd]) => cmd === "write_terminal");
+    expect(call![1].data).toMatch(/^agent /);
+  });
+
+  it("falls back to claude when neither task nor project specifies a harness", async () => {
+    const { result } = renderHook(() => useTaskExecution());
+    const task = makeTask({ default_harness: undefined });
+    const project = makeProject({ default_harness: undefined });
+
+    await act(async () => {
+      await result.current.startTask("proj", task, project);
+    });
+
+    const call = (mockInvoke as Mock).mock.calls.find(([cmd]) => cmd === "write_terminal");
+    expect(call![1].data).toMatch(/^claude /);
+    expect(call![1].data).toContain("--permission-mode auto");
+  });
+});
+
+describe("useTaskExecution — model resolution", () => {
+  it("uses task.default_model when set", async () => {
+    const { result } = renderHook(() => useTaskExecution());
+    const task = makeTask({ default_model: "claude-opus-4-6" });
+    const project = makeProject({ default_model: "claude-haiku-4-5" });
+
+    await act(async () => {
+      await result.current.startTask("proj", task, project);
+    });
+
+    const call = (mockInvoke as Mock).mock.calls.find(([cmd]) => cmd === "write_terminal");
+    expect(call![1].data).toContain("--model claude-opus-4-6");
+    expect(call![1].data).not.toContain("claude-haiku-4-5");
+  });
+
+  it("falls back to project.default_model when task has none", async () => {
+    const { result } = renderHook(() => useTaskExecution());
+    const task = makeTask({ default_model: undefined });
+    const project = makeProject({ default_model: "claude-sonnet-4-6" });
+
+    await act(async () => {
+      await result.current.startTask("proj", task, project);
+    });
+
+    const call = (mockInvoke as Mock).mock.calls.find(([cmd]) => cmd === "write_terminal");
+    expect(call![1].data).toContain("--model claude-sonnet-4-6");
+  });
+
+  it("omits --model flag when no model is configured", async () => {
+    const { result } = renderHook(() => useTaskExecution());
+    const task = makeTask({ default_model: undefined });
+    const project = makeProject({ default_model: undefined });
+
+    await act(async () => {
+      await result.current.startTask("proj", task, project);
+    });
+
+    const call = (mockInvoke as Mock).mock.calls.find(([cmd]) => cmd === "write_terminal");
+    expect(call![1].data).not.toContain("--model");
+  });
+});
+
+describe("useTaskExecution — execution state", () => {
+  it("marks task as running after startTask", async () => {
+    const { result } = renderHook(() => useTaskExecution());
+
+    await act(async () => {
+      await result.current.startTask("proj", makeTask(), makeProject());
+    });
+
+    expect(mockUpdateExecution).toHaveBeenCalledWith("proj", 1, expect.objectContaining({
+      status: "running",
+      harness_id: "claude",
+    }));
+    expect(mockUpdateTask).toHaveBeenCalledWith("proj", 1, { status: "in-progress" });
+  });
+
+  it("isRunning returns true for active tasks", async () => {
+    const { result } = renderHook(() => useTaskExecution());
+
+    await act(async () => {
+      await result.current.startTask("proj", makeTask(), makeProject());
+    });
+
+    expect(result.current.isRunning(1)).toBe(true);
+  });
+
+  it("isRunning returns false for tasks that haven't started", () => {
+    const { result } = renderHook(() => useTaskExecution());
+    expect(result.current.isRunning(999)).toBe(false);
+  });
+
+  it("marks task as completed on exit code 0", async () => {
+    const { result } = renderHook(() => useTaskExecution());
+
+    await act(async () => {
+      await result.current.startTask("proj", makeTask(), makeProject());
+    });
+
+    await act(async () => {
+      emitExit("term-1", 0);
+    });
+
+    await waitFor(() => {
+      expect(mockUpdateExecution).toHaveBeenCalledWith("proj", 1, expect.objectContaining({
+        status: "completed",
+        exit_code: 0,
+      }));
+    });
+    expect(result.current.isRunning(1)).toBe(false);
+  });
+
+  it("marks task as failed on non-zero exit code", async () => {
+    const { result } = renderHook(() => useTaskExecution());
+
+    await act(async () => {
+      await result.current.startTask("proj", makeTask(), makeProject());
+    });
+
+    await act(async () => {
+      emitExit("term-1", 1);
+    });
+
+    await waitFor(() => {
+      expect(mockUpdateExecution).toHaveBeenCalledWith("proj", 1, expect.objectContaining({
+        status: "failed",
+        exit_code: 1,
+      }));
+    });
+  });
+
+  it("marks task as stopped after stopTask", async () => {
+    const { result } = renderHook(() => useTaskExecution());
+
+    await act(async () => {
+      await result.current.startTask("proj", makeTask(), makeProject());
+    });
+
+    await act(async () => {
+      await result.current.stopTask("proj", 1);
+    });
+
+    expect(mockUpdateExecution).toHaveBeenCalledWith("proj", 1, expect.objectContaining({
+      status: "stopped",
+    }));
+    expect(result.current.isRunning(1)).toBe(false);
+  });
+
+  it("accumulates terminal output chunks", async () => {
+    const { result } = renderHook(() => useTaskExecution());
+
+    await act(async () => {
+      await result.current.startTask("proj", makeTask(), makeProject());
+    });
+
+    act(() => { emitOutput("term-1", "line 1\n"); });
+    act(() => { emitOutput("term-1", "line 2\n"); });
+
+    await waitFor(() => {
+      expect(result.current.getOutput(1)).toContain("line 1\n");
+      expect(result.current.getOutput(1)).toContain("line 2\n");
+    });
+  });
+
+  it("canStartMore returns false when at max_concurrent limit", async () => {
+    const { result } = renderHook(() => useTaskExecution());
+    const project = makeProject({ max_concurrent: 1 });
+
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "create_terminal") return Promise.resolve(`term-${Date.now()}`);
+      return Promise.resolve();
+    });
+
+    await act(async () => {
+      await result.current.startTask("proj", makeTask({ id: 1 }), project);
+    });
+
+    expect(result.current.canStartMore(project)).toBe(false);
+  });
+
+  it("canStartMore returns true when below max_concurrent limit", async () => {
+    const { result } = renderHook(() => useTaskExecution());
+    const project = makeProject({ max_concurrent: 3 });
+    expect(result.current.canStartMore(project)).toBe(true);
+  });
+
+  it("throws when max_concurrent limit is reached", async () => {
+    const { result } = renderHook(() => useTaskExecution());
+    const project = makeProject({ max_concurrent: 1 });
+
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "create_terminal") return Promise.resolve(`term-${Math.random()}`);
+      return Promise.resolve();
+    });
+
+    await act(async () => {
+      await result.current.startTask("proj", makeTask({ id: 1 }), project);
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.startTask("proj", makeTask({ id: 2 }), project);
+      }),
+    ).rejects.toThrow(/Concurrent task limit/);
+  });
+});

--- a/apps/desktop/src/hooks/__tests__/useTerminals.test.ts
+++ b/apps/desktop/src/hooks/__tests__/useTerminals.test.ts
@@ -163,7 +163,7 @@ describe("useTerminals", () => {
     // Interactive mode (no -p) for full TUI with live streaming
     expect(mockInvoke).toHaveBeenCalledWith("write_terminal", {
       terminalId: "term-1",
-      data: "claude 'fix bug' --allowedTools Read,Grep,Glob,Agent,Skill --model claude-opus-4-6\n",
+      data: "claude 'fix bug' --permission-mode auto --model claude-opus-4-6\n",
     });
     expect(result.current.sessions[0].status).toBe("running");
     expect(result.current.sessions[0].harnessId).toBe("claude");

--- a/apps/desktop/src/lib/__tests__/harness-definitions.test.ts
+++ b/apps/desktop/src/lib/__tests__/harness-definitions.test.ts
@@ -48,6 +48,36 @@ describe("shellQuote", () => {
   it("quotes strings with pipes", () => {
     expect(shellQuote("a | b")).toBe("'a | b'");
   });
+
+  it("strips null bytes before quoting", () => {
+    // Null bytes can truncate shell arguments and enable injection
+    expect(shellQuote("hello\0world")).toBe("helloworld");
+    expect(shellQuote("hello\0 world")).toBe("'hello world'");
+    // A lone null byte strips to an empty string (empty-check runs before strip)
+    expect(shellQuote("\0")).toBe("");
+  });
+
+  it("quotes strings containing newlines", () => {
+    // Newlines are safe inside single quotes (valid POSIX multi-line strings)
+    expect(shellQuote("line1\nline2")).toBe("'line1\nline2'");
+  });
+
+  it("quotes strings containing carriage returns", () => {
+    expect(shellQuote("line1\rline2")).toBe("'line1\rline2'");
+  });
+
+  it("quotes compound injection attempts — semicolons are enclosed in single quotes", () => {
+    // The result must wrap everything in single quotes so `;` is not a shell
+    // command separator. POSIX: content inside '...' is always literal.
+    // Input: '; rm -rf /; echo '
+    // Output: ''\''; rm -rf /; echo '\''' — the semicolons are inside '...' sections
+    const result = shellQuote("'; rm -rf /; echo '");
+    expect(result).toBe("''\\''; rm -rf /; echo '\\'''");
+  });
+
+  it("quotes strings with $() command substitution", () => {
+    expect(shellQuote("$(whoami)")).toBe("'$(whoami)'");
+  });
 });
 
 // ── buildInvokeCommand ──────────────────────────────────────
@@ -57,21 +87,21 @@ describe("buildInvokeCommand", () => {
 
   // All harnesses use interactive mode (no -p) for full TUI with live streaming.
 
-  it("builds claude command with prompt and allowedTools", () => {
+  it("builds claude command with prompt and auto permission mode", () => {
     expect(buildInvokeCommand("claude", "fix the bug")).toBe(
-      "claude 'fix the bug' --allowedTools Read,Grep,Glob,Agent,Skill",
+      "claude 'fix the bug' --permission-mode auto",
     );
   });
 
-  it("builds claude command with prompt, allowedTools, and model", () => {
+  it("builds claude command with prompt, auto permission mode, and model", () => {
     expect(buildInvokeCommand("claude", "fix it", "claude-sonnet-4-6")).toBe(
-      "claude 'fix it' --allowedTools Read,Grep,Glob,Agent,Skill --model claude-sonnet-4-6",
+      "claude 'fix it' --permission-mode auto --model claude-sonnet-4-6",
     );
   });
 
   it("quotes claude prompt with special characters", () => {
     expect(buildInvokeCommand("claude", "what's this?", "opus")).toBe(
-      "claude 'what'\\''s this?' --allowedTools Read,Grep,Glob,Agent,Skill --model opus",
+      "claude 'what'\\''s this?' --permission-mode auto --model opus",
     );
   });
 
@@ -117,6 +147,20 @@ describe("buildInvokeCommand", () => {
     );
   });
 
+  // ── OpenCode ─────────────────────────────────────────────
+
+  it("builds opencode command with positional prompt", () => {
+    expect(buildInvokeCommand("opencode", "add auth")).toBe(
+      "opencode 'add auth'",
+    );
+  });
+
+  it("builds opencode command with model", () => {
+    expect(buildInvokeCommand("opencode", "refactor", "gpt-4o")).toBe(
+      "opencode refactor --model gpt-4o",
+    );
+  });
+
   // ── Unknown harness ─────────────────────────────────────
 
   it("returns null for unknown harness", () => {
@@ -132,5 +176,45 @@ describe("buildInvokeCommand", () => {
   it("all harnesses have unique ids", () => {
     const ids = BUILTIN_HARNESSES.map((h) => h.id);
     expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  // ── Claude permission-mode invariants ────────────────────────
+  // Regression tests: these fail if --permission-mode auto is ever
+  // swapped back for --dangerously-skip-permissions.
+
+  it("claude command always contains --permission-mode auto", () => {
+    const cmd = buildInvokeCommand("claude", "do something");
+    expect(cmd).toContain("--permission-mode auto");
+  });
+
+  it("claude command never contains --dangerously-skip-permissions", () => {
+    const cmd = buildInvokeCommand("claude", "do something");
+    expect(cmd).not.toContain("--dangerously-skip-permissions");
+  });
+
+  it("claude command with model still enforces --permission-mode auto", () => {
+    const cmd = buildInvokeCommand("claude", "task", "claude-opus-4-6");
+    expect(cmd).toContain("--permission-mode auto");
+    expect(cmd).not.toContain("--dangerously-skip-permissions");
+  });
+
+  // ── Model injection prevention ───────────────────────────────
+  // A model value that looks like a shell flag must be quoted so the
+  // shell receives it as a single argument, not separate tokens.
+
+  it("model with embedded flags is shell-quoted, not treated as real flags", () => {
+    const cmd = buildInvokeCommand("claude", "task", "sonnet --dangerously-skip-permissions");
+    expect(cmd).toContain("'sonnet --dangerously-skip-permissions'");
+    expect(cmd).toContain("--permission-mode auto");
+  });
+
+  it("model with spaces is shell-quoted", () => {
+    const cmd = buildInvokeCommand("claude", "task", "claude sonnet");
+    expect(cmd).toContain("'claude sonnet'");
+  });
+
+  it("model with dollar sign is shell-quoted to prevent variable expansion", () => {
+    const cmd = buildInvokeCommand("claude", "task", "$MODEL");
+    expect(cmd).toContain("'$MODEL'");
   });
 });

--- a/apps/desktop/src/lib/harness-definitions.ts
+++ b/apps/desktop/src/lib/harness-definitions.ts
@@ -31,13 +31,9 @@ export const BUILTIN_HARNESSES: HarnessDefinition[] = [
     name: "Claude Code",
     command: "claude",
     buildCommand: (prompt, model) => {
-      // Interactive mode with pre-approved tools so the user doesn't have to
-      // click through permission prompts for every standard coding tool.
-      const allowedTools = [
-        'Read', 'Grep', 'Glob',
-        'Agent', 'Skill',
-      ].join(',');
-      const parts = ["claude", shellQuote(prompt), "--allowedTools", allowedTools];
+      // Auto mode uses AI classifiers to approve non-destructive actions without
+      // blocking on human approval, while still enforcing safety guardrails.
+      const parts = ["claude", shellQuote(prompt), "--permission-mode", "auto"];
       if (model) parts.push("--model", shellQuote(model));
       return parts.join(" ");
     },


### PR DESCRIPTION
## Summary

Switches the Claude Code harness in the board's task execution engine from a static `--allowedTools` whitelist to `--permission-mode auto`. Auto mode uses an AI classifier to approve non-destructive actions (file reads, edits, grep, standard coding operations) without blocking for human confirmation, while still enforcing safety guardrails for destructive operations. This eliminates friction for routine board tasks without sacrificing protection.

## Changes

- **`harness-definitions.ts`**: Replace `--allowedTools Read,Grep,Glob,Agent,Skill` with `--permission-mode auto` in the `claude` harness `buildCommand`. The static allowlist was too narrow — tasks involving `Write`, `Edit`, or `Bash` would still prompt despite being standard coding operations.
- **`harness-definitions.test.ts`**: Update command snapshot assertions; add invariant tests that `--permission-mode auto` is always present and `--dangerously-skip-permissions` never appears (regression guards); add model-arg injection prevention tests; add missing OpenCode harness tests.
- **`useTerminals.test.ts`**: Update command snapshot to match new flag.
- **`useTaskExecution.test.ts`** *(new)*: 17 tests covering prompt construction (title, description, subtask filtering), harness/model resolution priority cascade, and full execution state lifecycle (running → completed/failed/stopped, output accumulation, concurrency limit enforcement).

## Test Plan

- [x] Local tests pass (651/651)
- [ ] CI checks pass
- [x] Permission-mode invariant tests added as regressions against reverting to `--dangerously-skip-permissions`
- [x] Injection-prevention tests verify model arg is always shell-quoted

## Notes

The old board-server `src/execution/runner.ts` (which also used `--dangerously-skip-permissions`) was confirmed dead code — its source was dropped from git tracking after a refactor to harness-agnostic PTY terminals. No changes needed there. The live execution path runs exclusively through `useTaskExecution` → `harness-definitions.ts`.