### PR TITLE
feat(security): permission mode selector with auto-detection, scope granularity, and single-instance enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 - **Desktop: Comparator v4** — Rebuilt from terminal multiplexer to structured evaluation workbench with 4-phase workflow (Setup → Execution → Results → Judge), session history rail, SQLite persistence, and shared Comparator types
 - **Marketplace: Ratings and reviews** — install counts, trust tiers, and user ratings on plugin detail pages.
 - **CLI: `detect` and `init` commands** — `harness-kit detect` shows which AI coding platforms are active in the current directory; `harness-kit init` scaffolds a new `harness.yaml` interactively.
+- **Desktop: Permission mode selector** — Security → Permissions now has a Task Execution Mode section with three selectable modes: **Skip All** (`--dangerously-skip-permissions`, default), **Auto** (`--permission-mode auto`, requires Claude team/enterprise/API), and **Allowed Tools** (`--allowedTools <list>`, user-curated checklist). Mode and tool list persist in localStorage and apply globally or per-harness via an expandable overrides section. A one-time first-run modal explains the active mode before the first task runs and links to the settings page. A slide-in Tool Approval panel lets users manage the allowed tools list mid-session from within the terminals view.
+- **Desktop: Security → Permissions redesign** — Permission mode cards with icons, flag badges, and clear selected state. Chip remove buttons now use SVG icons. Improved section hierarchy with a clean divider between execution mode and Claude settings.json controls.
 
 ### Changed
 

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -60,6 +60,137 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,6 +283,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -332,6 +476,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -762,6 +915,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,6 +966,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -962,6 +1163,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1352,6 +1566,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-shell",
+ "tauri-plugin-single-instance",
  "tauri-plugin-window-state",
  "tempfile",
  "tokio",
@@ -1411,6 +1626,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2409,6 +2630,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "os_pipe"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2442,6 +2673,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2678,6 +2915,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2707,6 +2955,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4208,6 +4470,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33a5b7d78f0dec4406b003ea87c40bf928d801b6fd9323a556172c91d8712c1"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-plugin-window-state"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4664,7 +4941,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4732,6 +5021,17 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset 0.9.1",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -5886,6 +6186,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 0.7.15",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+dependencies = [
+ "serde",
+ "winnow 0.7.15",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5982,3 +6343,43 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 0.7.15",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 0.7.15",
+]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -21,6 +21,7 @@ tauri-plugin-fs = "2"
 tauri-plugin-shell = "2"
 tauri-plugin-window-state = "2"
 tauri-plugin-dialog = "2"
+tauri-plugin-single-instance = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "5"

--- a/apps/desktop/src-tauri/src/commands/settings.rs
+++ b/apps/desktop/src-tauri/src/commands/settings.rs
@@ -1,3 +1,50 @@
+#[derive(serde::Serialize)]
+pub struct ClaudeAccountInfo {
+    pub logged_in: bool,
+    pub subscription_type: Option<String>,
+    /// Whether `--permission-mode auto` is available for this account.
+    pub auto_mode_available: bool,
+}
+
+/// Run `claude auth status` and parse the result to determine plan eligibility.
+#[tauri::command]
+pub async fn detect_claude_account() -> ClaudeAccountInfo {
+    let output = std::process::Command::new("claude")
+        .args(["auth", "status"])
+        .output();
+
+    let fallback = ClaudeAccountInfo {
+        logged_in: false,
+        subscription_type: None,
+        auto_mode_available: false,
+    };
+
+    let out = match output {
+        Ok(o) if o.status.success() => o,
+        _ => return fallback,
+    };
+
+    let json_str = String::from_utf8_lossy(&out.stdout);
+    let json: serde_json::Value = match serde_json::from_str(&json_str) {
+        Ok(v) => v,
+        Err(_) => return fallback,
+    };
+
+    let logged_in = json.get("loggedIn").and_then(|v| v.as_bool()).unwrap_or(false);
+    let sub_type = json.get("subscriptionType")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let auth_method = json.get("authMethod").and_then(|v| v.as_str()).unwrap_or("");
+
+    // Auto mode requires team, enterprise, or API key — not available on pro/max.
+    let auto_available = logged_in && (
+        auth_method == "apiKey" ||
+        matches!(sub_type.as_deref(), Some("team") | Some("enterprise") | Some("business"))
+    );
+
+    ClaudeAccountInfo { logged_in, subscription_type: sub_type, auto_mode_available: auto_available }
+}
+
 #[tauri::command]
 pub fn list_claude_dir() -> Result<Vec<String>, String> {
     let claude_dir = dirs::home_dir()

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -25,6 +25,13 @@ pub fn run() {
     let database = db::init(&data_dir).expect("Failed to init database");
 
     tauri::Builder::default()
+        .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            // A second instance was launched — focus the existing window instead.
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = window.show();
+                let _ = window.set_focus();
+            }
+        }))
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_window_state::Builder::default().build())
@@ -68,6 +75,7 @@ pub fn run() {
             commands::profiles::delete_custom_profile,
             // Settings
             commands::settings::list_claude_dir,
+            commands::settings::detect_claude_account,
             // Observatory
             commands::observatory::read_stats_cache,
             commands::observatory::list_sessions_summary,

--- a/apps/desktop/src/components/FirstRunPermissionModal.tsx
+++ b/apps/desktop/src/components/FirstRunPermissionModal.tsx
@@ -1,0 +1,157 @@
+import { useEffect } from "react";
+import { createPortal } from "react-dom";
+import { useNavigate } from "react-router-dom";
+import { getPermissionMode, setPermissionModeAcked } from "../lib/preferences";
+
+const MODE_LABELS: Record<string, { name: string; description: string }> = {
+  skip: {
+    name: "Skip All Permissions",
+    description:
+      "Claude can write files, run shell commands, and access your system without any confirmation prompts.",
+  },
+  auto: {
+    name: "Auto",
+    description:
+      "Claude uses AI classifiers to approve non-destructive actions automatically, while prompting for higher-risk ones.",
+  },
+  "allowed-tools": {
+    name: "Allowed Tools",
+    description:
+      "Only tools on your allow list run without prompting. Everything else requires approval in the terminal.",
+  },
+};
+
+interface FirstRunPermissionModalProps {
+  onProceed: () => void;
+}
+
+export default function FirstRunPermissionModal({ onProceed }: FirstRunPermissionModalProps) {
+  const navigate = useNavigate();
+  const mode = getPermissionMode();
+  const info = MODE_LABELS[mode] ?? MODE_LABELS.skip;
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape" || e.key === "Enter") {
+        e.preventDefault();
+        handleProceed();
+      }
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function handleProceed() {
+    setPermissionModeAcked();
+    onProceed();
+  }
+
+  function handleChange() {
+    navigate("/security/permissions");
+  }
+
+  return createPortal(
+    <div
+      style={{
+        position: "fixed", inset: 0, zIndex: 9000,
+        display: "flex", alignItems: "center", justifyContent: "center",
+        background: "rgba(0,0,0,0.45)",
+        backdropFilter: "blur(4px)",
+        WebkitBackdropFilter: "blur(4px)",
+      }}
+    >
+      <div
+        style={{
+          width: 400,
+          background: "var(--bg-elevated)",
+          border: "1px solid var(--border-base)",
+          borderRadius: "12px",
+          boxShadow: "var(--shadow-lg)",
+          overflow: "hidden",
+        }}
+        onPointerDown={(e) => e.stopPropagation()}
+      >
+        {/* Amber accent bar */}
+        <div style={{ height: "3px", background: "var(--warning)" }} />
+
+        <div style={{ padding: "20px 22px 22px" }}>
+          {/* Header */}
+          <div style={{ marginBottom: "14px" }}>
+            <div style={{
+              fontSize: "14px", fontWeight: 600,
+              color: "var(--fg-base)", letterSpacing: "-0.2px",
+              marginBottom: "4px",
+            }}>
+              Before your first task runs
+            </div>
+            <div style={{ fontSize: "12px", color: "var(--fg-muted)", lineHeight: 1.5 }}>
+              HarnessKit will use the following permission mode:
+            </div>
+          </div>
+
+          {/* Mode card */}
+          <div style={{
+            background: "var(--bg-surface)",
+            border: "1px solid var(--border-base)",
+            borderLeft: "3px solid var(--warning)",
+            borderRadius: "8px",
+            padding: "12px 14px",
+            marginBottom: "14px",
+          }}>
+            <div style={{ fontSize: "12px", fontWeight: 600, color: "var(--fg-base)", marginBottom: "4px" }}>
+              {info.name}
+            </div>
+            <div style={{ fontSize: "11px", color: "var(--fg-muted)", lineHeight: 1.5 }}>
+              {info.description}
+            </div>
+          </div>
+
+          {/* Footer note */}
+          <div style={{ fontSize: "11px", color: "var(--fg-subtle)", marginBottom: "18px", lineHeight: 1.5 }}>
+            You can change this at any time in{" "}
+            <button
+              onClick={handleChange}
+              style={{
+                background: "none", border: "none", padding: 0,
+                color: "var(--accent-text)", cursor: "pointer",
+                fontSize: "11px", fontWeight: 500, textDecoration: "underline",
+                textUnderlineOffset: "2px",
+              }}
+            >
+              Security → Permissions
+            </button>
+            .
+          </div>
+
+          {/* Actions */}
+          <div style={{ display: "flex", gap: "8px", justifyContent: "flex-end" }}>
+            <button
+              onClick={handleChange}
+              style={{
+                fontSize: "12px", fontWeight: 500, padding: "6px 14px",
+                borderRadius: "6px", border: "1px solid var(--border-base)",
+                background: "transparent", color: "var(--fg-muted)",
+                cursor: "pointer",
+              }}
+            >
+              Change it now
+            </button>
+            <button
+              onClick={handleProceed}
+              style={{
+                fontSize: "12px", fontWeight: 500, padding: "6px 16px",
+                borderRadius: "6px", border: "none",
+                background: "var(--accent)", color: "#fff",
+                cursor: "pointer",
+              }}
+            >
+              Got it, proceed
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/desktop/src/components/terminals/ToolApprovalPanel.tsx
+++ b/apps/desktop/src/components/terminals/ToolApprovalPanel.tsx
@@ -1,0 +1,229 @@
+import { useState } from "react";
+import {
+  getAllowedTools,
+  setAllowedTools,
+  getHarnessPermissionOverrides,
+  setHarnessPermissionOverrides,
+  DEFAULT_ALLOWED_TOOLS,
+} from "../../lib/preferences";
+import { TOOL_NAMES } from "../../lib/tool-names";
+
+// ── Close icon ────────────────────────────────────────────────
+
+function CloseIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+      <line x1="18" y1="6" x2="6" y2="18" />
+      <line x1="6" y1="6" x2="18" y2="18" />
+    </svg>
+  );
+}
+
+// ── Check icon ────────────────────────────────────────────────
+
+function CheckIcon() {
+  return (
+    <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+// ── Props ─────────────────────────────────────────────────────
+
+interface ToolApprovalPanelProps {
+  /** The harness ID of the active session — used to look up per-harness overrides. */
+  harnessId?: string;
+  onClose: () => void;
+}
+
+// ── Component ─────────────────────────────────────────────────
+
+export default function ToolApprovalPanel({ harnessId, onClose }: ToolApprovalPanelProps) {
+  // Resolve the effective tool list: harness override → global default
+  const [tools, setToolsState] = useState<string[]>(() => {
+    if (harnessId) {
+      const overrides = getHarnessPermissionOverrides();
+      if (overrides[harnessId]?.allowedTools) return overrides[harnessId].allowedTools!;
+    }
+    return getAllowedTools();
+  });
+
+  const isHarnessOverride = harnessId
+    ? Boolean(getHarnessPermissionOverrides()[harnessId]?.allowedTools)
+    : false;
+  const [hasOverride, setHasOverride] = useState(isHarnessOverride);
+
+  function toggle(tool: string) {
+    const next = tools.includes(tool)
+      ? tools.filter((t) => t !== tool)
+      : [...tools, tool];
+    persist(next);
+  }
+
+  function persist(next: string[]) {
+    setToolsState(next);
+    if (harnessId && hasOverride) {
+      const overrides = getHarnessPermissionOverrides();
+      setHarnessPermissionOverrides({
+        ...overrides,
+        [harnessId]: { ...overrides[harnessId], allowedTools: next },
+      });
+    } else {
+      setAllowedTools(next);
+    }
+  }
+
+  function restoreDefaults() {
+    persist([...DEFAULT_ALLOWED_TOOLS]);
+  }
+
+  function enableHarnessOverride() {
+    if (!harnessId) return;
+    const overrides = getHarnessPermissionOverrides();
+    setHarnessPermissionOverrides({
+      ...overrides,
+      [harnessId]: { ...overrides[harnessId], allowedTools: [...tools] },
+    });
+    setHasOverride(true);
+  }
+
+  function clearHarnessOverride() {
+    if (!harnessId) return;
+    const overrides = getHarnessPermissionOverrides();
+    const next = { ...overrides };
+    if (next[harnessId]) {
+      delete next[harnessId].allowedTools;
+      if (Object.keys(next[harnessId]).length === 0) delete next[harnessId];
+    }
+    setHarnessPermissionOverrides(next);
+    setHasOverride(false);
+    setToolsState(getAllowedTools());
+  }
+
+  return (
+    <div style={{
+      width: 240,
+      height: "100%",
+      display: "flex",
+      flexDirection: "column",
+      background: "var(--bg-surface)",
+      borderLeft: "1px solid var(--border-base)",
+      overflow: "hidden",
+    }}>
+      {/* Header */}
+      <div style={{
+        display: "flex", alignItems: "center", justifyContent: "space-between",
+        padding: "12px 14px 10px",
+        borderBottom: "1px solid var(--separator)",
+        flexShrink: 0,
+      }}>
+        <div>
+          <div style={{ fontSize: "12px", fontWeight: 600, color: "var(--fg-base)" }}>
+            Allowed Tools
+          </div>
+          <div style={{ fontSize: "10px", color: "var(--fg-subtle)", marginTop: "1px" }}>
+            {hasOverride && harnessId ? "This harness" : "Global"}
+          </div>
+        </div>
+        <button
+          onClick={onClose}
+          style={{
+            background: "none", border: "none", padding: "4px",
+            color: "var(--fg-subtle)", cursor: "pointer", borderRadius: "4px",
+            display: "flex", alignItems: "center", justifyContent: "center",
+          }}
+          aria-label="Close panel"
+        >
+          <CloseIcon />
+        </button>
+      </div>
+
+      {/* Tool list */}
+      <div style={{ flex: 1, overflowY: "auto", padding: "8px 0" }}>
+        {TOOL_NAMES.map((tool) => {
+          const checked = tools.includes(tool.name);
+          return (
+            <button
+              key={tool.name}
+              onClick={() => toggle(tool.name)}
+              style={{
+                display: "flex", alignItems: "flex-start", gap: "10px",
+                width: "100%", padding: "7px 14px",
+                background: checked ? "var(--accent-light)" : "transparent",
+                border: "none", cursor: "pointer", textAlign: "left",
+              }}
+            >
+              {/* Checkbox */}
+              <div style={{
+                width: 15, height: 15, borderRadius: "3px", flexShrink: 0,
+                marginTop: "1px",
+                border: checked ? "none" : "1.5px solid var(--border-strong)",
+                background: checked ? "var(--accent)" : "transparent",
+                display: "flex", alignItems: "center", justifyContent: "center",
+                color: "#fff",
+              }}>
+                {checked && <CheckIcon />}
+              </div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{
+                  fontSize: "12px", fontWeight: 500,
+                  color: checked ? "var(--accent-text)" : "var(--fg-base)",
+                  fontFamily: "ui-monospace, monospace",
+                }}>
+                  {tool.name}
+                </div>
+                <div style={{ fontSize: "10px", color: "var(--fg-subtle)", marginTop: "1px", lineHeight: 1.4 }}>
+                  {tool.hint}
+                </div>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Footer */}
+      <div style={{
+        padding: "10px 14px",
+        borderTop: "1px solid var(--separator)",
+        flexShrink: 0,
+        display: "flex",
+        flexDirection: "column",
+        gap: "6px",
+      }}>
+        {harnessId && (
+          hasOverride ? (
+            <button
+              onClick={clearHarnessOverride}
+              style={{
+                fontSize: "11px", color: "var(--fg-muted)", background: "none",
+                border: "none", padding: 0, cursor: "pointer", textAlign: "left",
+              }}
+            >
+              Use global list for this harness
+            </button>
+          ) : (
+            <button
+              onClick={enableHarnessOverride}
+              style={{
+                fontSize: "11px", color: "var(--accent-text)", background: "none",
+                border: "none", padding: 0, cursor: "pointer", textAlign: "left",
+              }}
+            >
+              Override for this harness
+            </button>
+          )
+        )}
+        <button
+          onClick={restoreDefaults}
+          style={{
+            fontSize: "11px", color: "var(--fg-subtle)", background: "none",
+            border: "none", padding: 0, cursor: "pointer", textAlign: "left",
+          }}
+        >
+          Restore defaults
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/hooks/__tests__/useTerminals.test.ts
+++ b/apps/desktop/src/hooks/__tests__/useTerminals.test.ts
@@ -17,6 +17,13 @@ vi.mock("@tauri-apps/api/event", () => ({
   }),
 }));
 
+// Mock preferences — return default (skip) mode so tests are deterministic.
+vi.mock("../../lib/preferences", () => ({
+  getPermissionMode: () => "skip",
+  getAllowedTools: () => ["Read", "Grep", "Glob"],
+  getHarnessPermissionOverrides: () => ({}),
+}));
+
 // ── Wire-format payloads ──────────────────────────────────────
 // These MUST match Rust's serde(rename_all = "camelCase") output.
 // If the Rust struct field names or serde config change, update
@@ -159,11 +166,11 @@ describe("useTerminals", () => {
       await result.current.invokeInTerminal("term-1", "claude", "fix bug", "claude-opus-4-6");
     });
 
-    // Should call write_terminal (not invoke_in_terminal) with the built command
-    // Interactive mode (no -p) for full TUI with live streaming
+    // Should call write_terminal with the built command.
+    // Default permission mode is "skip" (--dangerously-skip-permissions).
     expect(mockInvoke).toHaveBeenCalledWith("write_terminal", {
       terminalId: "term-1",
-      data: "claude 'fix bug' --allowedTools Read,Grep,Glob,Agent,Skill --model claude-opus-4-6\n",
+      data: "claude 'fix bug' --dangerously-skip-permissions --model claude-opus-4-6\n",
     });
     expect(result.current.sessions[0].status).toBe("running");
     expect(result.current.sessions[0].harnessId).toBe("claude");

--- a/apps/desktop/src/hooks/useTaskExecution.ts
+++ b/apps/desktop/src/hooks/useTaskExecution.ts
@@ -2,7 +2,12 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { api } from '../lib/board-api';
-import { buildInvokeCommand } from '../lib/harness-definitions';
+import { buildInvokeCommand, type PermissionConfig } from '../lib/harness-definitions';
+import {
+  getPermissionMode,
+  getAllowedTools,
+  getHarnessPermissionOverrides,
+} from '../lib/preferences';
 import type { Task, Project, ExecutionStatus } from '../lib/board-api';
 
 // ── Types ────────────────────────────────────────────────────
@@ -39,6 +44,25 @@ export interface UseTaskExecutionReturn {
 
 const MAX_RAW_CHUNKS = 5000;
 const DEFAULT_MAX_CONCURRENT = 3;
+
+// ── Permission config resolver ───────────────────────────────
+
+/**
+ * Build the PermissionConfig for a given harness by merging the global mode
+ * with any harness-level override the user has configured.
+ */
+function resolvePermissionConfig(harnessId: string): PermissionConfig {
+  const overrides = getHarnessPermissionOverrides();
+  const override = overrides[harnessId];
+  const mode = override?.mode ?? getPermissionMode();
+  const tools = override?.allowedTools ?? getAllowedTools();
+
+  switch (mode) {
+    case "auto":        return { mode: "auto" };
+    case "allowed-tools": return { mode: "allowed-tools", tools };
+    default:            return { mode: "skip" };
+  }
+}
 
 // ── Prompt builder ───────────────────────────────────────────
 
@@ -128,7 +152,8 @@ export function useTaskExecution(): UseTaskExecutionReturn {
     const terminalId = await invoke<string>('create_terminal', { projectPath: workDir ?? '' });
 
     const prompt = buildPrompt(task);
-    const command = buildInvokeCommand(resolvedHarness, prompt, resolvedModel);
+    const permConfig = resolvePermissionConfig(resolvedHarness);
+    const command = buildInvokeCommand(resolvedHarness, prompt, resolvedModel, permConfig);
     if (!command) throw new Error(`Unknown harness: ${resolvedHarness}`);
 
     executionsRef.current.set(task.id, {

--- a/apps/desktop/src/hooks/useTerminals.ts
+++ b/apps/desktop/src/hooks/useTerminals.ts
@@ -1,7 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import { buildInvokeCommand } from "../lib/harness-definitions";
+import { buildInvokeCommand, type PermissionConfig } from "../lib/harness-definitions";
+import {
+  getPermissionMode,
+  getAllowedTools,
+  getHarnessPermissionOverrides,
+} from "../lib/preferences";
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -22,6 +27,21 @@ interface TerminalOutputPayload {
 interface TerminalExitPayload {
   terminalId: string;
   exitCode: number;
+}
+
+// ── Permission config resolver ───────────────────────────────
+
+function resolvePermissionConfig(harnessId: string): PermissionConfig {
+  const overrides = getHarnessPermissionOverrides();
+  const override = overrides[harnessId];
+  const mode = override?.mode ?? getPermissionMode();
+  const tools = override?.allowedTools ?? getAllowedTools();
+
+  switch (mode) {
+    case "auto":          return { mode: "auto" };
+    case "allowed-tools": return { mode: "allowed-tools", tools };
+    default:              return { mode: "skip" };
+  }
 }
 
 // ── Constants ────────────────────────────────────────────────
@@ -143,7 +163,8 @@ export function useTerminals(): UseTerminalsReturn {
     async (id: string, harnessId: string, prompt: string, model?: string) => {
       // NOTE: write_terminal is an unrestricted shell stdin pipe. All command
       // construction MUST go through buildInvokeCommand to ensure proper quoting.
-      const command = buildInvokeCommand(harnessId, prompt, model);
+      const permConfig = resolvePermissionConfig(harnessId);
+      const command = buildInvokeCommand(harnessId, prompt, model, permConfig);
       if (!command) {
         console.error(`Unknown harness: ${harnessId}`);
         return;

--- a/apps/desktop/src/lib/__tests__/harness-definitions.test.ts
+++ b/apps/desktop/src/lib/__tests__/harness-definitions.test.ts
@@ -139,10 +139,10 @@ describe("buildInvokeCommand — { mode: 'allowed-tools' }", () => {
       .toBe("claude 'fix bug' --allowedTools Read,Grep,Glob");
   });
 
-  it("falls back to --dangerously-skip-permissions when tools list is empty", () => {
+  it("uses no permission flags when tools list is empty (Claude prompts for all)", () => {
     const cfg: PermissionConfig = { mode: "allowed-tools", tools: [] };
     expect(buildInvokeCommand("claude", "task", undefined, cfg))
-      .toBe("claude task --dangerously-skip-permissions");
+      .toBe("claude task");
   });
 
   it("includes model after the tools flag", () => {

--- a/apps/desktop/src/lib/__tests__/harness-definitions.test.ts
+++ b/apps/desktop/src/lib/__tests__/harness-definitions.test.ts
@@ -3,9 +3,10 @@ import {
   shellQuote,
   buildInvokeCommand,
   BUILTIN_HARNESSES,
+  type PermissionConfig,
 } from "../harness-definitions";
 
-// ── shellQuote ──────────────────────────────────────────────
+// ── shellQuote ──────────────────────────────────────────────────────────────
 
 describe("shellQuote", () => {
   it("returns empty quotes for empty string", () => {
@@ -48,83 +49,184 @@ describe("shellQuote", () => {
   it("quotes strings with pipes", () => {
     expect(shellQuote("a | b")).toBe("'a | b'");
   });
+
+  it("strips null bytes before quoting", () => {
+    expect(shellQuote("hello\0world")).toBe("helloworld");
+    expect(shellQuote("hello\0 world")).toBe("'hello world'");
+    expect(shellQuote("\0")).toBe("");
+  });
+
+  it("quotes strings containing newlines", () => {
+    expect(shellQuote("line1\nline2")).toBe("'line1\nline2'");
+  });
+
+  it("quotes strings containing carriage returns", () => {
+    expect(shellQuote("line1\rline2")).toBe("'line1\rline2'");
+  });
+
+  it("quotes compound injection attempts", () => {
+    const result = shellQuote("'; rm -rf /; echo '");
+    expect(result).toBe("''\\''; rm -rf /; echo '\\'''");
+  });
+
+  it("quotes strings with $() command substitution", () => {
+    expect(shellQuote("$(whoami)")).toBe("'$(whoami)'");
+  });
 });
 
-// ── buildInvokeCommand ──────────────────────────────────────
+// ── buildInvokeCommand — default (skip) mode ────────────────────────────────
 
-describe("buildInvokeCommand", () => {
-  // ── Claude Code ─────────────────────────────────────────
-
-  // All harnesses use interactive mode (no -p) for full TUI with live streaming.
-
-  it("builds claude command with prompt and allowedTools", () => {
-    expect(buildInvokeCommand("claude", "fix the bug")).toBe(
-      "claude 'fix the bug' --allowedTools Read,Grep,Glob,Agent,Skill",
-    );
+describe("buildInvokeCommand — default (no config)", () => {
+  it("defaults to --dangerously-skip-permissions when no config given", () => {
+    const cmd = buildInvokeCommand("claude", "fix the bug");
+    expect(cmd).toBe("claude 'fix the bug' --dangerously-skip-permissions");
   });
 
-  it("builds claude command with prompt, allowedTools, and model", () => {
-    expect(buildInvokeCommand("claude", "fix it", "claude-sonnet-4-6")).toBe(
-      "claude 'fix it' --allowedTools Read,Grep,Glob,Agent,Skill --model claude-sonnet-4-6",
-    );
+  it("includes model when provided", () => {
+    const cmd = buildInvokeCommand("claude", "fix it", "claude-sonnet-4-6");
+    expect(cmd).toBe("claude 'fix it' --dangerously-skip-permissions --model claude-sonnet-4-6");
   });
 
-  it("quotes claude prompt with special characters", () => {
-    expect(buildInvokeCommand("claude", "what's this?", "opus")).toBe(
-      "claude 'what'\\''s this?' --allowedTools Read,Grep,Glob,Agent,Skill --model opus",
-    );
+  it("quotes prompts with special characters", () => {
+    const cmd = buildInvokeCommand("claude", "what's this?", "opus");
+    expect(cmd).toBe("claude 'what'\\''s this?' --dangerously-skip-permissions --model opus");
+  });
+});
+
+// ── buildInvokeCommand — skip mode ──────────────────────────────────────────
+
+describe("buildInvokeCommand — { mode: 'skip' }", () => {
+  const cfg: PermissionConfig = { mode: "skip" };
+
+  it("uses --dangerously-skip-permissions", () => {
+    expect(buildInvokeCommand("claude", "do something", undefined, cfg))
+      .toBe("claude 'do something' --dangerously-skip-permissions");
   });
 
-  // ── Cursor Agent ────────────────────────────────────────
+  it("includes model", () => {
+    expect(buildInvokeCommand("claude", "do it", "claude-opus-4-6", cfg))
+      .toBe("claude 'do it' --dangerously-skip-permissions --model claude-opus-4-6");
+  });
+});
 
-  it("builds cursor-agent command with prompt only", () => {
-    expect(buildInvokeCommand("cursor-agent", "refactor auth")).toBe(
-      "agent 'refactor auth'",
-    );
+// ── buildInvokeCommand — auto mode ──────────────────────────────────────────
+
+describe("buildInvokeCommand — { mode: 'auto' }", () => {
+  const cfg: PermissionConfig = { mode: "auto" };
+
+  it("uses --permission-mode auto", () => {
+    expect(buildInvokeCommand("claude", "do something", undefined, cfg))
+      .toBe("claude 'do something' --permission-mode auto");
   });
 
+  it("includes model", () => {
+    expect(buildInvokeCommand("claude", "task", "claude-sonnet-4-6", cfg))
+      .toBe("claude task --permission-mode auto --model claude-sonnet-4-6");
+  });
+
+  it("never contains --dangerously-skip-permissions", () => {
+    expect(buildInvokeCommand("claude", "task", undefined, cfg))
+      .not.toContain("--dangerously-skip-permissions");
+  });
+});
+
+// ── buildInvokeCommand — allowed-tools mode ─────────────────────────────────
+
+describe("buildInvokeCommand — { mode: 'allowed-tools' }", () => {
+  it("uses --allowedTools with the provided list", () => {
+    const cfg: PermissionConfig = { mode: "allowed-tools", tools: ["Read", "Grep", "Glob"] };
+    expect(buildInvokeCommand("claude", "fix bug", undefined, cfg))
+      .toBe("claude 'fix bug' --allowedTools Read,Grep,Glob");
+  });
+
+  it("falls back to --dangerously-skip-permissions when tools list is empty", () => {
+    const cfg: PermissionConfig = { mode: "allowed-tools", tools: [] };
+    expect(buildInvokeCommand("claude", "task", undefined, cfg))
+      .toBe("claude task --dangerously-skip-permissions");
+  });
+
+  it("includes model after the tools flag", () => {
+    const cfg: PermissionConfig = { mode: "allowed-tools", tools: ["Read", "Write"] };
+    expect(buildInvokeCommand("claude", "task", "claude-opus-4-6", cfg))
+      .toBe("claude task --allowedTools Read,Write --model claude-opus-4-6");
+  });
+
+  it("never contains --dangerously-skip-permissions when tools are specified", () => {
+    const cfg: PermissionConfig = { mode: "allowed-tools", tools: ["Read"] };
+    expect(buildInvokeCommand("claude", "task", undefined, cfg))
+      .not.toContain("--dangerously-skip-permissions");
+  });
+});
+
+// ── Non-Claude harnesses ignore permission config ────────────────────────────
+
+describe("buildInvokeCommand — non-Claude harnesses ignore permission config", () => {
+  const skipCfg: PermissionConfig = { mode: "skip" };
+  const autoCfg: PermissionConfig = { mode: "auto" };
+
+  it("cursor-agent is unaffected by config", () => {
+    expect(buildInvokeCommand("cursor-agent", "refactor auth", undefined, skipCfg))
+      .toBe("agent 'refactor auth'");
+    expect(buildInvokeCommand("cursor-agent", "refactor auth", undefined, autoCfg))
+      .toBe("agent 'refactor auth'");
+  });
+
+  it("copilot is unaffected by config", () => {
+    expect(buildInvokeCommand("copilot", "explain this repo", undefined, skipCfg))
+      .toBe("copilot -i 'explain this repo'");
+  });
+
+  it("codex is unaffected by config", () => {
+    expect(buildInvokeCommand("codex", "add tests", undefined, skipCfg))
+      .toBe("codex 'add tests'");
+  });
+
+  it("opencode is unaffected by config", () => {
+    expect(buildInvokeCommand("opencode", "add auth", undefined, skipCfg))
+      .toBe("opencode 'add auth'");
+  });
+});
+
+// ── Other harnesses (no config) ──────────────────────────────────────────────
+
+describe("buildInvokeCommand — other harnesses", () => {
   it("builds cursor-agent command with model", () => {
-    expect(buildInvokeCommand("cursor-agent", "test", "gpt-5.2")).toBe(
-      "agent test --model gpt-5.2",
-    );
+    expect(buildInvokeCommand("cursor-agent", "test", "gpt-5.2")).toBe("agent test --model gpt-5.2");
   });
 
-  // ── GitHub Copilot ──────────────────────────────────────
-
-  it("builds copilot command with -i flag for interactive mode", () => {
-    expect(buildInvokeCommand("copilot", "explain this repo")).toBe(
-      "copilot -i 'explain this repo'",
-    );
+  it("builds copilot command with -i flag", () => {
+    expect(buildInvokeCommand("copilot", "explain this repo")).toBe("copilot -i 'explain this repo'");
   });
 
   it("builds copilot command with model", () => {
-    expect(buildInvokeCommand("copilot", "explain", "claude-sonnet-4")).toBe(
-      "copilot -i explain --model claude-sonnet-4",
-    );
+    expect(buildInvokeCommand("copilot", "explain", "claude-sonnet-4"))
+      .toBe("copilot -i explain --model claude-sonnet-4");
   });
 
-  // ── Codex CLI ───────────────────────────────────────────
-
   it("builds codex command with positional prompt", () => {
-    expect(buildInvokeCommand("codex", "add tests")).toBe(
-      "codex 'add tests'",
-    );
+    expect(buildInvokeCommand("codex", "add tests")).toBe("codex 'add tests'");
   });
 
   it("builds codex command with model", () => {
-    expect(buildInvokeCommand("codex", "refactor", "o4-mini")).toBe(
-      "codex refactor --model o4-mini",
-    );
+    expect(buildInvokeCommand("codex", "refactor", "o4-mini")).toBe("codex refactor --model o4-mini");
   });
 
-  // ── Unknown harness ─────────────────────────────────────
+  it("builds opencode command with positional prompt", () => {
+    expect(buildInvokeCommand("opencode", "add auth")).toBe("opencode 'add auth'");
+  });
+
+  it("builds opencode command with model", () => {
+    expect(buildInvokeCommand("opencode", "refactor", "gpt-4o")).toBe("opencode refactor --model gpt-4o");
+  });
 
   it("returns null for unknown harness", () => {
     expect(buildInvokeCommand("unknown-harness", "hi")).toBeNull();
   });
+});
 
-  // ── Registry ────────────────────────────────────────────
+// ── Registry ─────────────────────────────────────────────────────────────────
 
+describe("BUILTIN_HARNESSES registry", () => {
   it("has 5 built-in harnesses", () => {
     expect(BUILTIN_HARNESSES).toHaveLength(5);
   });
@@ -132,5 +234,24 @@ describe("buildInvokeCommand", () => {
   it("all harnesses have unique ids", () => {
     const ids = BUILTIN_HARNESSES.map((h) => h.id);
     expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+// ── Model injection prevention ────────────────────────────────────────────────
+
+describe("model injection prevention", () => {
+  it("model with embedded flags is shell-quoted, not treated as real flags", () => {
+    const cmd = buildInvokeCommand("claude", "task", "sonnet --dangerously-skip-permissions");
+    expect(cmd).toContain("'sonnet --dangerously-skip-permissions'");
+  });
+
+  it("model with spaces is shell-quoted", () => {
+    const cmd = buildInvokeCommand("claude", "task", "claude sonnet");
+    expect(cmd).toContain("'claude sonnet'");
+  });
+
+  it("model with dollar sign prevents variable expansion", () => {
+    const cmd = buildInvokeCommand("claude", "task", "$MODEL");
+    expect(cmd).toContain("'$MODEL'");
   });
 });

--- a/apps/desktop/src/lib/harness-definitions.ts
+++ b/apps/desktop/src/lib/harness-definitions.ts
@@ -1,4 +1,4 @@
-// ── Shell quoting ───────────────────────────────────────────
+// ── Shell quoting ───────────────────────────────────────────────────────────
 
 /** Wrap a string in single quotes with proper escaping for POSIX shells. */
 export function shellQuote(s: string): string {
@@ -11,7 +11,32 @@ export function shellQuote(s: string): string {
   return "'" + clean.replace(/'/g, "'\\''") + "'";
 }
 
-// ── Harness definition type ─────────────────────────────────
+// ── Permission configuration ────────────────────────────────────────────────
+
+export type PermissionMode = "skip" | "auto" | "allowed-tools";
+
+export type PermissionConfig =
+  | { mode: "skip" }
+  | { mode: "auto" }
+  | { mode: "allowed-tools"; tools: string[] };
+
+const DEFAULT_PERMISSION_CONFIG: PermissionConfig = { mode: "skip" };
+
+/** Build the Claude CLI permission flags for a given config. */
+function buildClaudePermissionFlags(config: PermissionConfig): string[] {
+  switch (config.mode) {
+    case "skip":
+      return ["--dangerously-skip-permissions"];
+    case "auto":
+      return ["--permission-mode", "auto"];
+    case "allowed-tools":
+      // Fall back to skip-all if the tools list is empty.
+      if (config.tools.length === 0) return ["--dangerously-skip-permissions"];
+      return ["--allowedTools", config.tools.join(",")];
+  }
+}
+
+// ── Harness definition type ─────────────────────────────────────────────────
 
 export interface HarnessDefinition {
   id: string;
@@ -19,10 +44,10 @@ export interface HarnessDefinition {
   /** CLI binary name (used for detection and display, not invocation). */
   command: string;
   /** Build the full shell command to invoke this harness with a prompt. */
-  buildCommand: (prompt: string, model?: string) => string;
+  buildCommand: (prompt: string, model?: string, config?: PermissionConfig) => string;
 }
 
-// ── Built-in harness definitions ────────────────────────────
+// ── Built-in harness definitions ────────────────────────────────────────────
 // Verified from official docs — see plan for references.
 
 export const BUILTIN_HARNESSES: HarnessDefinition[] = [
@@ -30,14 +55,9 @@ export const BUILTIN_HARNESSES: HarnessDefinition[] = [
     id: "claude",
     name: "Claude Code",
     command: "claude",
-    buildCommand: (prompt, model) => {
-      // Interactive mode with pre-approved tools so the user doesn't have to
-      // click through permission prompts for every standard coding tool.
-      const allowedTools = [
-        'Read', 'Grep', 'Glob',
-        'Agent', 'Skill',
-      ].join(',');
-      const parts = ["claude", shellQuote(prompt), "--allowedTools", allowedTools];
+    buildCommand: (prompt, model, config = DEFAULT_PERMISSION_CONFIG) => {
+      const permFlags = buildClaudePermissionFlags(config);
+      const parts = ["claude", shellQuote(prompt), ...permFlags];
       if (model) parts.push("--model", shellQuote(model));
       return parts.join(" ");
     },
@@ -85,22 +105,24 @@ export const BUILTIN_HARNESSES: HarnessDefinition[] = [
   },
 ];
 
-// ── Lookup + command builder ────────────────────────────────
+// ── Lookup + command builder ────────────────────────────────────────────────
 
 const harnessMap = new Map(BUILTIN_HARNESSES.map((h) => [h.id, h]));
 
 /**
  * Build the shell command string for a given harness invocation.
  * Returns `null` if the harness ID is unknown (caller should handle custom commands).
+ * Permission config applies to Claude Code only — other harnesses ignore it.
  */
 export function buildInvokeCommand(
   harnessId: string,
   prompt: string,
   model?: string,
+  config?: PermissionConfig,
 ): string | null {
   const def = harnessMap.get(harnessId);
   if (!def) return null;
-  return def.buildCommand(prompt, model);
+  return def.buildCommand(prompt, model, config);
 }
 
 export function getHarness(id: string): HarnessDefinition | undefined {

--- a/apps/desktop/src/lib/harness-definitions.ts
+++ b/apps/desktop/src/lib/harness-definitions.ts
@@ -30,8 +30,8 @@ function buildClaudePermissionFlags(config: PermissionConfig): string[] {
     case "auto":
       return ["--permission-mode", "auto"];
     case "allowed-tools":
-      // Fall back to skip-all if the tools list is empty.
-      if (config.tools.length === 0) return ["--dangerously-skip-permissions"];
+      // Empty list → no permission flag; Claude prompts for each tool (safest default).
+      if (config.tools.length === 0) return [];
       return ["--allowedTools", config.tools.join(",")];
   }
 }

--- a/apps/desktop/src/lib/preferences.ts
+++ b/apps/desktop/src/lib/preferences.ts
@@ -198,6 +198,7 @@ const KEY_PERMISSION_MODE = "harness-kit-permission-mode";
 const KEY_ALLOWED_TOOLS = "harness-kit-allowed-tools";
 const KEY_PERMISSION_MODE_ACKED = "harness-kit-permission-mode-acked";
 const KEY_HARNESS_PERMISSION_OVERRIDES = "harness-kit-harness-permission-overrides";
+const KEY_AUTO_MODE_UNLOCKED = "harness-kit-auto-mode-unlocked";
 
 export const DEFAULT_ALLOWED_TOOLS: string[] = ["Read", "Grep", "Glob"];
 
@@ -216,7 +217,10 @@ export function getAllowedTools(): string[] {
   if (!raw) return [...DEFAULT_ALLOWED_TOOLS];
   try {
     const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed : [...DEFAULT_ALLOWED_TOOLS];
+    if (!Array.isArray(parsed)) return [...DEFAULT_ALLOWED_TOOLS];
+    // Validate each entry: ToolName or ToolName(scope) — no shell metacharacters.
+    const valid = /^[A-Za-z]+(\([^)]+\))?$/;
+    return parsed.filter((t): t is string => typeof t === "string" && valid.test(t));
   } catch {
     return [...DEFAULT_ALLOWED_TOOLS];
   }
@@ -260,6 +264,19 @@ export function resetPermissionDefaults() {
   localStorage.removeItem(KEY_ALLOWED_TOOLS);
   localStorage.removeItem(KEY_PERMISSION_MODE_ACKED);
   localStorage.removeItem(KEY_HARNESS_PERMISSION_OVERRIDES);
+}
+
+/** Whether the user has confirmed they have a qualifying plan for Auto mode. */
+export function getAutoModeUnlocked(): boolean {
+  return localStorage.getItem(KEY_AUTO_MODE_UNLOCKED) === "true";
+}
+
+export function setAutoModeUnlocked(unlocked: boolean) {
+  if (unlocked) {
+    localStorage.setItem(KEY_AUTO_MODE_UNLOCKED, "true");
+  } else {
+    localStorage.removeItem(KEY_AUTO_MODE_UNLOCKED);
+  }
 }
 
 // ── Init ─────────────────────────────────────────────────────

--- a/apps/desktop/src/lib/preferences.ts
+++ b/apps/desktop/src/lib/preferences.ts
@@ -190,6 +190,78 @@ export function setConfigFilesDetailLevel(level: ConfigFilesDetailLevel) {
   localStorage.setItem(KEY_CONFIG_FILES_DETAIL, level);
 }
 
+// ── Permission Mode ───────────────────────────────────────────
+
+export type PermissionMode = "skip" | "auto" | "allowed-tools";
+
+const KEY_PERMISSION_MODE = "harness-kit-permission-mode";
+const KEY_ALLOWED_TOOLS = "harness-kit-allowed-tools";
+const KEY_PERMISSION_MODE_ACKED = "harness-kit-permission-mode-acked";
+const KEY_HARNESS_PERMISSION_OVERRIDES = "harness-kit-harness-permission-overrides";
+
+export const DEFAULT_ALLOWED_TOOLS: string[] = ["Read", "Grep", "Glob"];
+
+export function getPermissionMode(): PermissionMode {
+  const raw = localStorage.getItem(KEY_PERMISSION_MODE);
+  if (raw === "auto" || raw === "allowed-tools") return raw;
+  return "skip";
+}
+
+export function setPermissionMode(mode: PermissionMode) {
+  localStorage.setItem(KEY_PERMISSION_MODE, mode);
+}
+
+export function getAllowedTools(): string[] {
+  const raw = localStorage.getItem(KEY_ALLOWED_TOOLS);
+  if (!raw) return [...DEFAULT_ALLOWED_TOOLS];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [...DEFAULT_ALLOWED_TOOLS];
+  } catch {
+    return [...DEFAULT_ALLOWED_TOOLS];
+  }
+}
+
+export function setAllowedTools(tools: string[]) {
+  localStorage.setItem(KEY_ALLOWED_TOOLS, JSON.stringify(tools));
+}
+
+export function getPermissionModeAcked(): boolean {
+  return localStorage.getItem(KEY_PERMISSION_MODE_ACKED) === "true";
+}
+
+export function setPermissionModeAcked() {
+  localStorage.setItem(KEY_PERMISSION_MODE_ACKED, "true");
+}
+
+export interface HarnessPermissionOverride {
+  mode?: PermissionMode;
+  allowedTools?: string[];
+}
+
+export function getHarnessPermissionOverrides(): Record<string, HarnessPermissionOverride> {
+  const raw = localStorage.getItem(KEY_HARNESS_PERMISSION_OVERRIDES);
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return typeof parsed === "object" && parsed !== null ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+export function setHarnessPermissionOverrides(overrides: Record<string, HarnessPermissionOverride>) {
+  localStorage.setItem(KEY_HARNESS_PERMISSION_OVERRIDES, JSON.stringify(overrides));
+}
+
+/** Clear allowed tools list, first-run ack, and per-harness overrides back to defaults.
+ *  Does NOT change the selected permission mode — the user keeps their choice. */
+export function resetPermissionDefaults() {
+  localStorage.removeItem(KEY_ALLOWED_TOOLS);
+  localStorage.removeItem(KEY_PERMISSION_MODE_ACKED);
+  localStorage.removeItem(KEY_HARNESS_PERMISSION_OVERRIDES);
+}
+
 // ── Init ─────────────────────────────────────────────────────
 
 /** Apply all stored preferences on boot. Call once at app startup. */

--- a/apps/desktop/src/lib/tauri.ts
+++ b/apps/desktop/src/lib/tauri.ts
@@ -165,6 +165,16 @@ export async function listClaudeDir(): Promise<string[]> {
   return invoke<string[]>("list_claude_dir");
 }
 
+export interface ClaudeAccountInfo {
+  logged_in: boolean;
+  subscription_type: string | null;
+  auto_mode_available: boolean;
+}
+
+export async function detectClaudeAccount(): Promise<ClaudeAccountInfo> {
+  return invoke<ClaudeAccountInfo>("detect_claude_account");
+}
+
 // ── Observatory commands ──────────────────────────────────────
 
 export async function readStatsCache(): Promise<StatsCache> {

--- a/apps/desktop/src/lib/tool-names.ts
+++ b/apps/desktop/src/lib/tool-names.ts
@@ -1,0 +1,15 @@
+/** Canonical list of Claude Code tool names with short descriptions. */
+export const TOOL_NAMES: { name: string; hint: string }[] = [
+  { name: "Read",         hint: "Read file contents" },
+  { name: "Write",        hint: "Create or overwrite files" },
+  { name: "Edit",         hint: "Make targeted edits to files" },
+  { name: "Glob",         hint: "Find files by pattern" },
+  { name: "Grep",         hint: "Search file contents" },
+  { name: "Bash",         hint: "Execute shell commands" },
+  { name: "Agent",        hint: "Launch subagent processes" },
+  { name: "WebFetch",     hint: "Fetch URLs" },
+  { name: "WebSearch",    hint: "Search the web" },
+  { name: "Skill",        hint: "Invoke skills" },
+  { name: "NotebookEdit", hint: "Edit Jupyter notebooks" },
+  { name: "LSP",          hint: "Language Server Protocol" },
+];

--- a/apps/desktop/src/lib/tool-names.ts
+++ b/apps/desktop/src/lib/tool-names.ts
@@ -1,15 +1,15 @@
 /** Canonical list of Claude Code tool names with short descriptions. */
-export const TOOL_NAMES: { name: string; hint: string }[] = [
-  { name: "Read",         hint: "Read file contents" },
-  { name: "Write",        hint: "Create or overwrite files" },
-  { name: "Edit",         hint: "Make targeted edits to files" },
-  { name: "Glob",         hint: "Find files by pattern" },
-  { name: "Grep",         hint: "Search file contents" },
-  { name: "Bash",         hint: "Execute shell commands" },
+export const TOOL_NAMES: { name: string; hint: string; scopeHint?: string; scopeLabel?: string }[] = [
+  { name: "Read",         hint: "Read file contents",        scopeHint: "~/repos/**",                scopeLabel: "path" },
+  { name: "Write",        hint: "Create or overwrite files", scopeHint: "~/repos/**",                scopeLabel: "path" },
+  { name: "Edit",         hint: "Make targeted edits",       scopeHint: "~/repos/**",                scopeLabel: "path" },
+  { name: "Glob",         hint: "Find files by pattern",     scopeHint: "src/**",                    scopeLabel: "path" },
+  { name: "Grep",         hint: "Search file contents",      scopeHint: "src/**",                    scopeLabel: "path" },
+  { name: "Bash",         hint: "Execute shell commands",    scopeHint: "git *",                     scopeLabel: "cmd" },
   { name: "Agent",        hint: "Launch subagent processes" },
-  { name: "WebFetch",     hint: "Fetch URLs" },
-  { name: "WebSearch",    hint: "Search the web" },
+  { name: "WebFetch",     hint: "Fetch URLs",                scopeHint: "https://api.github.com/*",  scopeLabel: "url" },
+  { name: "WebSearch",    hint: "Search the web",            scopeHint: "site:docs.anthropic.com *", scopeLabel: "query" },
   { name: "Skill",        hint: "Invoke skills" },
-  { name: "NotebookEdit", hint: "Edit Jupyter notebooks" },
+  { name: "NotebookEdit", hint: "Edit Jupyter notebooks",    scopeHint: "~/notebooks/**",            scopeLabel: "path" },
   { name: "LSP",          hint: "Language Server Protocol" },
 ];

--- a/apps/desktop/src/pages/security/PermissionsPage.tsx
+++ b/apps/desktop/src/pages/security/PermissionsPage.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import {
   readPermissions, updatePermissions,
   listSecurityPresets, applySecurityPreset,
+  detectClaudeAccount,
 } from "../../lib/tauri";
 import type { PermissionsState, SecurityPreset } from "@harness-kit/shared";
 import {
@@ -9,6 +10,7 @@ import {
   getAllowedTools, setAllowedTools,
   getHarnessPermissionOverrides, setHarnessPermissionOverrides,
   resetPermissionDefaults,
+  getAutoModeUnlocked, setAutoModeUnlocked,
   type PermissionMode, type HarnessPermissionOverride,
 } from "../../lib/preferences";
 import { BUILTIN_HARNESSES } from "../../lib/harness-definitions";
@@ -281,7 +283,7 @@ interface ModeCardProps {
   onClick: () => void;
 }
 
-function ModeCard({ id, label, flag, description, icon, accentColor, selected, note, onClick }: ModeCardProps) {
+function ModeCard({ id: _id, label, flag, description, icon, accentColor, selected, note, onClick }: ModeCardProps) {
   return (
     <button
       onClick={onClick}
@@ -358,6 +360,84 @@ function ModeCard({ id, label, flag, description, icon, accentColor, selected, n
   );
 }
 
+// ── Tool entry helpers ────────────────────────────────────────
+
+function parseToolEntry(entry: string): { name: string; scope: string } {
+  const m = entry.match(/^([A-Za-z]+)\((.+)\)$/);
+  if (m) return { name: m[1], scope: m[2] };
+  return { name: entry, scope: "" };
+}
+
+function buildToolEntry(name: string, scope: string): string {
+  const trimmed = scope.trim();
+  return trimmed ? `${name}(${trimmed})` : name;
+}
+
+// ── Current config summary ────────────────────────────────────
+
+function CurrentConfigSummary({
+  mode, tools, overrides,
+}: {
+  mode: PermissionMode;
+  tools: string[];
+  overrides: Record<string, HarnessPermissionOverride>;
+}) {
+  const overrideCount = Object.values(overrides).filter(
+    (o) => o.mode !== undefined || (o.allowedTools && o.allowedTools.length > 0)
+  ).length;
+
+  const modeColor = mode === "skip" ? "#d97706" : mode === "auto" ? "#3b82f6" : "#16a34a";
+  const modeLabel = mode === "skip" ? "Skip All" : mode === "auto" ? "Auto" : "Allowed Tools";
+
+  let detail: React.ReactNode;
+  if (mode === "skip") {
+    detail = <span style={{ color: "var(--fg-muted)" }}>All tool calls proceed without prompting.</span>;
+  } else if (mode === "auto") {
+    detail = <span style={{ color: "var(--fg-muted)" }}>AI classifiers approve non-destructive actions.</span>;
+  } else if (tools.length === 0) {
+    detail = <span style={{ color: "var(--danger)" }}>No tools selected — all actions will prompt.</span>;
+  } else {
+    detail = (
+      <span style={{ color: "var(--fg-muted)", fontFamily: "ui-monospace, monospace", fontSize: "11px" }}>
+        {tools.join("  ·  ")}
+      </span>
+    );
+  }
+
+  return (
+    <div style={{
+      marginBottom: "20px",
+      padding: "10px 14px",
+      borderRadius: "8px",
+      background: "var(--bg-surface)",
+      border: "1px solid var(--border-base)",
+      display: "flex", flexWrap: "wrap", alignItems: "baseline", gap: "8px",
+    }}>
+      <span style={{
+        fontSize: "10px", fontVariantCaps: "all-small-caps", letterSpacing: "0.05em",
+        color: "var(--fg-subtle)", fontWeight: 500, flexShrink: 0,
+      }}>
+        Active
+      </span>
+      <span style={{
+        fontSize: "11px", fontWeight: 600, color: modeColor,
+        background: `${modeColor}18`, padding: "1px 8px",
+        borderRadius: "10px", flexShrink: 0,
+      }}>
+        {modeLabel}
+      </span>
+      <span style={{ flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        {detail}
+      </span>
+      {overrideCount > 0 && (
+        <span style={{ fontSize: "11px", color: "var(--fg-subtle)", flexShrink: 0 }}>
+          {overrideCount} harness override{overrideCount > 1 ? "s" : ""}
+        </span>
+      )}
+    </div>
+  );
+}
+
 // ── Allowed tools checklist ───────────────────────────────────
 
 function AllowedToolsSection({
@@ -366,63 +446,147 @@ function AllowedToolsSection({
   tools: string[];
   onChange: (next: string[]) => void;
 }) {
-  function toggle(name: string) {
-    onChange(
-      tools.includes(name)
-        ? tools.filter((t) => t !== name)
-        : [...tools, name],
-    );
+  const activeEntries = tools.map(parseToolEntry);
+  const activeNames = new Set(activeEntries.map((e) => e.name));
+  const inactiveTools = TOOL_NAMES.filter((t) => !activeNames.has(t.name));
+
+  function add(name: string) {
+    onChange([...tools, name]);
+  }
+
+  function remove(name: string) {
+    onChange(tools.filter((t) => parseToolEntry(t).name !== name));
+  }
+
+  function updateScope(name: string, scope: string) {
+    onChange(tools.map((t) => {
+      const parsed = parseToolEntry(t);
+      return parsed.name === name ? buildToolEntry(name, scope) : t;
+    }));
   }
 
   return (
-    <div style={{ marginTop: "12px", paddingLeft: "0" }}>
+    <div style={{ marginTop: "12px" }}>
       <p style={{
         fontSize: "11px", fontWeight: 500, fontVariantCaps: "all-small-caps",
-        letterSpacing: "0.04em", color: "var(--fg-subtle)",
-        margin: "0 0 8px",
+        letterSpacing: "0.04em", color: "var(--fg-subtle)", margin: "0 0 8px",
       }}>
         Allowed without prompting
       </p>
-      <div style={{
-        display: "grid",
-        gridTemplateColumns: "repeat(auto-fill, minmax(140px, 1fr))",
-        gap: "4px",
-      }}>
-        {TOOL_NAMES.map((tool) => {
-          const checked = tools.includes(tool.name);
-          return (
-            <button
-              key={tool.name}
-              onClick={() => toggle(tool.name)}
-              style={{
-                display: "flex", alignItems: "center", gap: "8px",
-                padding: "6px 10px",
-                borderRadius: "5px",
-                border: "1px solid var(--border-subtle)",
-                background: checked ? "var(--accent-light)" : "var(--bg-base)",
-                cursor: "pointer", textAlign: "left",
-              }}
-            >
-              <div style={{
-                width: 13, height: 13, borderRadius: "3px", flexShrink: 0,
-                border: checked ? "none" : "1.5px solid var(--border-strong)",
-                background: checked ? "var(--accent)" : "transparent",
-                display: "flex", alignItems: "center", justifyContent: "center",
-                color: "#fff",
+
+      {/* Active tools — shown as rows with optional scope input */}
+      {activeEntries.length > 0 && (
+        <div style={{ marginBottom: "10px" }}>
+          {/* Column headers */}
+          <div style={{
+            display: "grid", gridTemplateColumns: "100px 1fr auto",
+            gap: "6px", padding: "0 8px 4px",
+          }}>
+            <span style={{ fontSize: "10px", color: "var(--fg-subtle)", fontVariantCaps: "all-small-caps", letterSpacing: "0.04em" }}>
+              Tool
+            </span>
+            <span style={{ fontSize: "10px", color: "var(--fg-subtle)", fontVariantCaps: "all-small-caps", letterSpacing: "0.04em" }}>
+              Scope pattern (optional)
+            </span>
+          </div>
+
+          {activeEntries.map(({ name, scope }) => {
+            const toolDef = TOOL_NAMES.find((t) => t.name === name);
+            return (
+              <div key={name} style={{
+                display: "grid", gridTemplateColumns: "100px 1fr auto",
+                alignItems: "center", gap: "6px",
+                padding: "5px 8px", marginBottom: "3px",
+                borderRadius: "6px",
+                border: "1px solid rgba(99,102,241,0.2)",
+                background: "var(--accent-light)",
               }}>
-                {checked && <IconCheck />}
+                <span style={{
+                  fontSize: "11px", fontWeight: 600,
+                  color: "var(--accent-text)",
+                  fontFamily: "ui-monospace, monospace",
+                }}>
+                  {name}
+                </span>
+                <input
+                  value={scope}
+                  onChange={(e) => updateScope(name, e.target.value)}
+                  placeholder={
+                    toolDef?.scopeHint
+                      ? `e.g. ${toolDef.scopeHint}`
+                      : "all (leave blank for unrestricted)"
+                  }
+                  style={{
+                    fontSize: "11px", padding: "3px 7px",
+                    borderRadius: "4px",
+                    border: "1px solid var(--border-base)",
+                    background: "var(--bg-base)",
+                    color: "var(--fg-base)",
+                    outline: "none",
+                    fontFamily: "ui-monospace, monospace",
+                    width: "100%",
+                    boxSizing: "border-box",
+                  }}
+                />
+                <button
+                  onClick={() => remove(name)}
+                  title={`Remove ${name}`}
+                  style={{
+                    border: "none", background: "none",
+                    color: "var(--fg-subtle)", cursor: "pointer",
+                    padding: "2px 4px", borderRadius: "3px",
+                    fontSize: "14px", lineHeight: 1,
+                    display: "flex", alignItems: "center",
+                  }}
+                >
+                  <IconRemove />
+                </button>
               </div>
-              <span style={{
-                fontSize: "11px", fontWeight: checked ? 500 : 400,
-                color: checked ? "var(--accent-text)" : "var(--fg-muted)",
-                fontFamily: "ui-monospace, monospace",
-              }}>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Inactive tools — compact add buttons */}
+      {inactiveTools.length > 0 && (
+        <div>
+          <p style={{
+            fontSize: "10px", color: "var(--fg-placeholder)",
+            fontVariantCaps: "all-small-caps", letterSpacing: "0.04em",
+            margin: "0 0 5px",
+          }}>
+            {activeEntries.length > 0 ? "Add another tool" : "Select tools"}
+          </p>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: "4px" }}>
+            {inactiveTools.map((tool) => (
+              <button
+                key={tool.name}
+                onClick={() => add(tool.name)}
+                title={tool.hint}
+                style={{
+                  display: "flex", alignItems: "center", gap: "4px",
+                  padding: "4px 9px",
+                  borderRadius: "5px",
+                  border: "1px solid var(--border-subtle)",
+                  background: "var(--bg-base)",
+                  cursor: "pointer",
+                  fontSize: "11px", color: "var(--fg-muted)",
+                  fontFamily: "ui-monospace, monospace",
+                }}
+              >
+                <span style={{ fontSize: "10px", opacity: 0.6 }}>+</span>
                 {tool.name}
-              </span>
-            </button>
-          );
-        })}
-      </div>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {activeEntries.length === 0 && inactiveTools.length === 0 && (
+        <p style={{ fontSize: "11px", color: "var(--fg-placeholder)", margin: 0 }}>
+          All tools are allowed. Remove some to restrict.
+        </p>
+      )}
     </div>
   );
 }
@@ -552,11 +716,15 @@ export default function PermissionsPage() {
   const [presets, setPresets] = useState<SecurityPreset[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [tauriAvailable] = useState(() =>
+    typeof window !== "undefined" && !!(window as unknown as Record<string, unknown>).__TAURI_INTERNALS__
+  );
   const [saving, setSaving] = useState(false);
   const [confirmPreset, setConfirmPreset] = useState<SecurityPreset | null>(null);
   const [dirty, setDirty] = useState(false);
 
   // HarnessKit permission mode (localStorage)
+  const [autoUnlocked, setAutoUnlockedState] = useState<boolean>(getAutoModeUnlocked);
   const [mode, setMode] = useState<PermissionMode>(getPermissionMode);
   const [allowedTools, setAllowedToolsState] = useState<string[]>(getAllowedTools);
   const [overrides, setOverridesState] = useState<Record<string, HarnessPermissionOverride>>(
@@ -564,6 +732,26 @@ export default function PermissionsPage() {
   );
 
   useEffect(() => {
+    // Tauri APIs are only available in the desktop app. Skip gracefully in browser.
+    if (!tauriAvailable) {
+      setLoading(false);
+      return;
+    }
+    // Detect account plan and auto-unlock Auto mode if eligible.
+    detectClaudeAccount().then((info) => {
+      if (info.auto_mode_available) {
+        setAutoUnlockedState(true);
+        setAutoModeUnlocked(true);
+      } else {
+        // Revoke if account no longer qualifies (e.g. plan downgrade).
+        setAutoUnlockedState(false);
+        setAutoModeUnlocked(false);
+        if (getPermissionMode() === "auto") handleModeChange("skip");
+      }
+    }).catch(() => {
+      // claude CLI not available or not logged in — leave as stored preference.
+    });
+
     Promise.all([readPermissions(), listSecurityPresets()])
       .then(([perms, presetList]) => {
         setPermissions(perms);
@@ -663,33 +851,11 @@ export default function PermissionsPage() {
     }
   }
 
-  if (loading) {
-    return (
-      <div style={{ padding: "20px 24px" }}>
-        <p style={{ fontSize: "13px", color: "var(--fg-subtle)" }}>Loading…</p>
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div style={{ padding: "20px 24px" }}>
-        <h1 className="text-title" style={{ margin: "0 0 16px" }}>Permissions</h1>
-        <div style={{
-          background: "var(--bg-surface)", border: "1px solid var(--danger-light)",
-          borderLeft: "3px solid var(--danger)", borderRadius: "8px",
-          padding: "10px 14px", fontSize: "13px", color: "var(--danger)",
-        }}>
-          {error}
-        </div>
-      </div>
-    );
-  }
 
   return (
     <div style={{ padding: "20px 24px", maxWidth: "700px" }}>
       {/* ── Page header ── */}
-      <div style={{ marginBottom: "24px" }}>
+      <div style={{ marginBottom: "16px" }}>
         <h1 style={{
           fontSize: "17px", fontWeight: 600, letterSpacing: "-0.3px",
           color: "var(--fg-base)", margin: "0 0 3px",
@@ -700,6 +866,9 @@ export default function PermissionsPage() {
           Control how much autonomy Claude and other harnesses have when running tasks.
         </p>
       </div>
+
+      {/* ── Active configuration summary ── */}
+      <CurrentConfigSummary mode={mode} tools={allowedTools} overrides={overrides} />
 
       {/* ── Permission Mode section ── */}
       <section style={{ marginBottom: "28px" }}>
@@ -721,17 +890,18 @@ export default function PermissionsPage() {
             selected={mode === "skip"}
             onClick={() => handleModeChange("skip")}
           />
-          <ModeCard
-            id="auto"
-            label="Auto"
-            flag="--permission-mode auto"
-            description="AI classifiers approve non-destructive actions. Higher-risk operations still prompt."
-            icon={<IconAuto />}
-            accentColor="#3b82f6"
-            selected={mode === "auto"}
-            note="Requires Claude team, enterprise, or API plan"
-            onClick={() => handleModeChange("auto")}
-          />
+          {autoUnlocked && (
+            <ModeCard
+              id="auto"
+              label="Auto"
+              flag="--permission-mode auto"
+              description="AI classifiers approve non-destructive actions. Higher-risk operations still prompt."
+              icon={<IconAuto />}
+              accentColor="#3b82f6"
+              selected={mode === "auto"}
+              onClick={() => handleModeChange("auto")}
+            />
+          )}
           <ModeCard
             id="allowed-tools"
             label="Allowed Tools"
@@ -743,6 +913,7 @@ export default function PermissionsPage() {
             onClick={() => handleModeChange("allowed-tools")}
           />
         </div>
+
 
         {/* Allowed tools checklist — visible when mode is allowed-tools */}
         {mode === "allowed-tools" && (
@@ -776,6 +947,29 @@ export default function PermissionsPage() {
 
       {/* ── Claude settings.json section ── */}
       <section>
+        {!tauriAvailable && (
+          <div style={{
+            background: "var(--bg-surface)", border: "1px solid var(--border-base)",
+            borderLeft: "3px solid var(--border-strong)", borderRadius: "8px",
+            padding: "10px 14px", fontSize: "12px", color: "var(--fg-muted)",
+            marginBottom: "14px",
+          }}>
+            Claude settings.json editing requires the desktop app.
+          </div>
+        )}
+        {tauriAvailable && loading && !error && (
+          <p style={{ fontSize: "12px", color: "var(--fg-subtle)", margin: "0 0 14px" }}>Loading…</p>
+        )}
+        {tauriAvailable && error && (
+          <div style={{
+            background: "var(--bg-surface)", border: "1px solid var(--danger-light)",
+            borderLeft: "3px solid var(--danger)", borderRadius: "8px",
+            padding: "10px 14px", fontSize: "12px", color: "var(--danger)",
+            marginBottom: "14px",
+          }}>
+            {error}
+          </div>
+        )}
         <div style={{ marginBottom: "14px" }}>
           <p style={{
             fontSize: "11px", fontWeight: 500, fontVariantCaps: "all-small-caps",

--- a/apps/desktop/src/pages/security/PermissionsPage.tsx
+++ b/apps/desktop/src/pages/security/PermissionsPage.tsx
@@ -1,27 +1,85 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   readPermissions, updatePermissions,
   listSecurityPresets, applySecurityPreset,
 } from "../../lib/tauri";
 import type { PermissionsState, SecurityPreset } from "@harness-kit/shared";
+import {
+  getPermissionMode, setPermissionMode,
+  getAllowedTools, setAllowedTools,
+  getHarnessPermissionOverrides, setHarnessPermissionOverrides,
+  resetPermissionDefaults,
+  type PermissionMode, type HarnessPermissionOverride,
+} from "../../lib/preferences";
+import { BUILTIN_HARNESSES } from "../../lib/harness-definitions";
+import { TOOL_NAMES } from "../../lib/tool-names";
 
-// ── Suggestion datasets ─────────────────────────────────────
+// ── Icons ─────────────────────────────────────────────────────
 
-const TOOL_SUGGESTIONS: { value: string; hint: string }[] = [
-  { value: "Read", hint: "Read file contents" },
-  { value: "Write", hint: "Create or overwrite files" },
-  { value: "Edit", hint: "Make targeted edits to files" },
-  { value: "Glob", hint: "Find files by pattern" },
-  { value: "Grep", hint: "Search file contents" },
-  { value: "Bash", hint: "Execute shell commands" },
-  { value: "Agent", hint: "Launch subagent processes" },
-  { value: "WebFetch", hint: "Fetch URLs" },
-  { value: "WebSearch", hint: "Search the web" },
-  { value: "Skill", hint: "Invoke skills" },
-  { value: "NotebookEdit", hint: "Edit Jupyter notebooks" },
-  { value: "LSP", hint: "Language Server Protocol" },
+function IconSkip() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+      <line x1="9" y1="9" x2="15" y2="15" />
+      <line x1="15" y1="9" x2="9" y2="15" />
+    </svg>
+  );
+}
+
+function IconAuto() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 3l1.88 5.78 5.88.04-4.77 3.47 1.82 5.78L12 15.08l-4.81 3.0 1.82-5.78L4.24 8.82l5.88-.04z" />
+    </svg>
+  );
+}
+
+function IconTools() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+      <line x1="4" y1="6" x2="20" y2="6" />
+      <line x1="4" y1="12" x2="14" y2="12" />
+      <line x1="4" y1="18" x2="11" y2="18" />
+      <circle cx="18" cy="12" r="3" />
+      <circle cx="15" cy="18" r="3" />
+    </svg>
+  );
+}
+
+function IconRemove() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+      <line x1="18" y1="6" x2="6" y2="18" />
+      <line x1="6" y1="6" x2="18" y2="18" />
+    </svg>
+  );
+}
+
+function IconCheck() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+function IconChevron({ open }: { open: boolean }) {
+  return (
+    <svg
+      width="12" height="12" viewBox="0 0 24 24" fill="none"
+      stroke="currentColor" strokeWidth="2" strokeLinecap="round"
+      style={{ transform: open ? "rotate(90deg)" : "none", transition: "transform 200ms" }}
+    >
+      <polyline points="9 18 15 12 9 6" />
+    </svg>
+  );
+}
+
+// ── Suggestion datasets (shared between tools list and suggest input) ──────
+
+const TOOL_SUGGESTIONS = TOOL_NAMES.map((t) => ({ value: t.name, hint: t.hint })).concat([
   { value: "*", hint: "All tools (wildcard)" },
-];
+]);
 
 const PATH_SUGGESTIONS: { value: string; hint: string }[] = [
   { value: ".", hint: "Current project directory" },
@@ -47,43 +105,47 @@ const HOST_SUGGESTIONS: { value: string; hint: string }[] = [
   { value: "*", hint: "All hosts (wildcard)" },
 ];
 
-function Chip({
-  label, color, onRemove,
-}: {
+// ── Chip ─────────────────────────────────────────────────────
+
+function Chip({ label, color, onRemove }: {
   label: string;
   color: "green" | "red" | "amber";
   onRemove: () => void;
 }) {
   const colors = {
-    green: { bg: "rgba(22,163,74,0.1)", border: "rgba(22,163,74,0.25)", text: "#16a34a" },
-    red: { bg: "rgba(220,38,38,0.1)", border: "rgba(220,38,38,0.25)", text: "#dc2626" },
-    amber: { bg: "rgba(217,119,6,0.1)", border: "rgba(217,119,6,0.25)", text: "#d97706" },
+    green: { bg: "rgba(22,163,74,0.08)", border: "rgba(22,163,74,0.22)", text: "#16a34a" },
+    red:   { bg: "rgba(220,38,38,0.08)",  border: "rgba(220,38,38,0.22)",  text: "#dc2626" },
+    amber: { bg: "rgba(217,119,6,0.08)",  border: "rgba(217,119,6,0.22)",  text: "#d97706" },
   };
   const c = colors[color];
   return (
     <span style={{
-      display: "inline-flex", alignItems: "center", gap: "4px",
-      fontSize: "11px", fontWeight: 500, padding: "2px 8px",
-      borderRadius: "10px", border: `1px solid ${c.border}`,
+      display: "inline-flex", alignItems: "center", gap: "5px",
+      fontSize: "11px", fontWeight: 500, padding: "2px 7px 2px 8px",
+      borderRadius: "4px", border: `1px solid ${c.border}`,
       background: c.bg, color: c.text,
+      fontFamily: "ui-monospace, monospace",
     }}>
       {label}
       <button
         onClick={onRemove}
+        aria-label={`Remove ${label}`}
         style={{
           border: "none", background: "none", color: c.text,
-          cursor: "pointer", padding: 0, fontSize: "13px", lineHeight: 1,
+          cursor: "pointer", padding: 0, display: "flex",
+          alignItems: "center", justifyContent: "center",
+          opacity: 0.7, lineHeight: 1,
         }}
       >
-        x
+        <IconRemove />
       </button>
     </span>
   );
 }
 
-function SuggestInput({
-  onAdd, placeholder, suggestions, existing,
-}: {
+// ── SuggestInput ──────────────────────────────────────────────
+
+function SuggestInput({ onAdd, placeholder, suggestions, existing }: {
   onAdd: (v: string) => void;
   placeholder: string;
   suggestions: { value: string; hint: string }[];
@@ -94,7 +156,6 @@ function SuggestInput({
   const [highlightIdx, setHighlightIdx] = useState(-1);
   const wrapperRef = useRef<HTMLDivElement>(null);
 
-  // Filter: match typed text, exclude already-added values
   const filtered = suggestions.filter(
     (s) =>
       !existing.includes(s.value) &&
@@ -111,11 +172,8 @@ function SuggestInput({
 
   function handleKeyDown(e: React.KeyboardEvent) {
     if (e.key === "Enter") {
-      if (highlightIdx >= 0 && highlightIdx < filtered.length) {
-        select(filtered[highlightIdx].value);
-      } else if (value.trim()) {
-        select(value.trim());
-      }
+      if (highlightIdx >= 0 && highlightIdx < filtered.length) select(filtered[highlightIdx].value);
+      else if (value.trim()) select(value.trim());
     } else if (e.key === "ArrowDown") {
       e.preventDefault();
       setHighlightIdx((i) => Math.min(i + 1, filtered.length - 1));
@@ -128,7 +186,6 @@ function SuggestInput({
     }
   }
 
-  // Close on outside click
   useEffect(() => {
     if (!open) return;
     function onPointerDown(e: PointerEvent) {
@@ -151,15 +208,16 @@ function SuggestInput({
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
           style={{
-            flex: 1, fontSize: "11px", padding: "4px 8px",
+            flex: 1, fontSize: "11px", padding: "5px 8px",
             borderRadius: "5px", border: "1px solid var(--border-base)",
             background: "var(--bg-base)", color: "var(--fg-base)",
+            outline: "none",
           }}
         />
         <button
           onClick={() => { if (value.trim()) select(value.trim()); }}
           style={{
-            fontSize: "11px", padding: "4px 10px", borderRadius: "5px",
+            fontSize: "11px", padding: "5px 10px", borderRadius: "5px",
             border: "1px solid var(--border-base)", background: "var(--bg-surface)",
             color: "var(--fg-muted)", cursor: "pointer",
           }}
@@ -185,7 +243,8 @@ function SuggestInput({
               style={{
                 display: "flex", justifyContent: "space-between", alignItems: "center",
                 width: "100%", padding: "5px 10px",
-                border: "none", borderBottom: i < filtered.length - 1 ? "1px solid var(--separator)" : "none",
+                border: "none",
+                borderBottom: i < filtered.length - 1 ? "1px solid var(--separator)" : "none",
                 background: i === highlightIdx ? "var(--accent-light)" : "transparent",
                 cursor: "pointer", textAlign: "left",
               }}
@@ -208,13 +267,287 @@ function SuggestInput({
   );
 }
 
+// ── Permission mode card ──────────────────────────────────────
+
+interface ModeCardProps {
+  id: PermissionMode;
+  label: string;
+  flag: string;
+  description: string;
+  icon: React.ReactNode;
+  accentColor: string;
+  selected: boolean;
+  note?: string;
+  onClick: () => void;
+}
+
+function ModeCard({ id, label, flag, description, icon, accentColor, selected, note, onClick }: ModeCardProps) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        display: "flex", flexDirection: "column", alignItems: "flex-start",
+        textAlign: "left", padding: "14px", cursor: "pointer",
+        background: selected ? `${accentColor}0d` : "var(--bg-surface)",
+        border: selected
+          ? `1.5px solid ${accentColor}`
+          : "1.5px solid var(--border-base)",
+        borderRadius: "8px",
+        transition: "border-color 150ms, background 150ms",
+        gap: "8px",
+        flex: 1,
+      }}
+      aria-pressed={selected}
+    >
+      {/* Icon + label row */}
+      <div style={{ display: "flex", alignItems: "center", gap: "8px", width: "100%" }}>
+        <div style={{ color: selected ? accentColor : "var(--fg-muted)" }}>
+          {icon}
+        </div>
+        <span style={{
+          fontSize: "12px", fontWeight: 600,
+          color: selected ? accentColor : "var(--fg-base)",
+          flex: 1,
+        }}>
+          {label}
+        </span>
+        {selected && (
+          <div style={{
+            width: 16, height: 16, borderRadius: "50%",
+            background: accentColor,
+            display: "flex", alignItems: "center", justifyContent: "center",
+            color: "#fff", flexShrink: 0,
+          }}>
+            <IconCheck />
+          </div>
+        )}
+      </div>
+
+      {/* Description */}
+      <div style={{
+        fontSize: "11px", color: "var(--fg-muted)", lineHeight: 1.5,
+        paddingLeft: "26px",
+      }}>
+        {description}
+      </div>
+
+      {/* Flag badge */}
+      <div style={{ paddingLeft: "26px" }}>
+        <code style={{
+          fontSize: "10px", fontFamily: "ui-monospace, monospace",
+          color: selected ? accentColor : "var(--fg-subtle)",
+          background: selected ? `${accentColor}14` : "var(--bg-base)",
+          border: `1px solid ${selected ? `${accentColor}30` : "var(--border-subtle)"}`,
+          borderRadius: "3px", padding: "1px 5px",
+        }}>
+          {flag}
+        </code>
+      </div>
+
+      {/* Optional note (e.g. plan requirement) */}
+      {note && (
+        <div style={{
+          paddingLeft: "26px",
+          fontSize: "10px", color: "var(--fg-subtle)",
+          fontStyle: "italic",
+        }}>
+          {note}
+        </div>
+      )}
+    </button>
+  );
+}
+
+// ── Allowed tools checklist ───────────────────────────────────
+
+function AllowedToolsSection({
+  tools, onChange,
+}: {
+  tools: string[];
+  onChange: (next: string[]) => void;
+}) {
+  function toggle(name: string) {
+    onChange(
+      tools.includes(name)
+        ? tools.filter((t) => t !== name)
+        : [...tools, name],
+    );
+  }
+
+  return (
+    <div style={{ marginTop: "12px", paddingLeft: "0" }}>
+      <p style={{
+        fontSize: "11px", fontWeight: 500, fontVariantCaps: "all-small-caps",
+        letterSpacing: "0.04em", color: "var(--fg-subtle)",
+        margin: "0 0 8px",
+      }}>
+        Allowed without prompting
+      </p>
+      <div style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(auto-fill, minmax(140px, 1fr))",
+        gap: "4px",
+      }}>
+        {TOOL_NAMES.map((tool) => {
+          const checked = tools.includes(tool.name);
+          return (
+            <button
+              key={tool.name}
+              onClick={() => toggle(tool.name)}
+              style={{
+                display: "flex", alignItems: "center", gap: "8px",
+                padding: "6px 10px",
+                borderRadius: "5px",
+                border: "1px solid var(--border-subtle)",
+                background: checked ? "var(--accent-light)" : "var(--bg-base)",
+                cursor: "pointer", textAlign: "left",
+              }}
+            >
+              <div style={{
+                width: 13, height: 13, borderRadius: "3px", flexShrink: 0,
+                border: checked ? "none" : "1.5px solid var(--border-strong)",
+                background: checked ? "var(--accent)" : "transparent",
+                display: "flex", alignItems: "center", justifyContent: "center",
+                color: "#fff",
+              }}>
+                {checked && <IconCheck />}
+              </div>
+              <span style={{
+                fontSize: "11px", fontWeight: checked ? 500 : 400,
+                color: checked ? "var(--accent-text)" : "var(--fg-muted)",
+                fontFamily: "ui-monospace, monospace",
+              }}>
+                {tool.name}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ── Per-harness overrides ─────────────────────────────────────
+
+function HarnessOverridesSection({
+  overrides, onChange,
+}: {
+  overrides: Record<string, HarnessPermissionOverride>;
+  onChange: (next: Record<string, HarnessPermissionOverride>) => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  function setHarnessMode(id: string, mode: PermissionMode | undefined) {
+    const next = { ...overrides };
+    if (!next[id]) next[id] = {};
+    if (mode === undefined) {
+      delete next[id].mode;
+      if (Object.keys(next[id]).length === 0) delete next[id];
+    } else {
+      next[id].mode = mode;
+    }
+    onChange(next);
+  }
+
+  const modes: { value: PermissionMode; label: string }[] = [
+    { value: "skip", label: "Skip All" },
+    { value: "auto", label: "Auto" },
+    { value: "allowed-tools", label: "Allowed Tools" },
+  ];
+
+  return (
+    <div style={{ marginTop: "16px" }}>
+      <button
+        onClick={() => setOpen((o) => !o)}
+        style={{
+          display: "flex", alignItems: "center", gap: "6px",
+          background: "none", border: "none", padding: 0, cursor: "pointer",
+          color: "var(--fg-subtle)",
+        }}
+      >
+        <IconChevron open={open} />
+        <span style={{
+          fontSize: "11px", fontWeight: 500,
+          fontVariantCaps: "all-small-caps", letterSpacing: "0.04em",
+          color: "var(--fg-subtle)",
+        }}>
+          Per-harness overrides
+        </span>
+      </button>
+
+      {open && (
+        <div style={{
+          marginTop: "10px",
+          background: "var(--bg-surface)",
+          border: "1px solid var(--border-base)",
+          borderRadius: "7px",
+          overflow: "hidden",
+        }}>
+          {BUILTIN_HARNESSES.map((harness, i) => {
+            const override = overrides[harness.id];
+            const effective = override?.mode;
+            return (
+              <div
+                key={harness.id}
+                style={{
+                  display: "flex", alignItems: "center", justifyContent: "space-between",
+                  padding: "9px 12px",
+                  borderBottom: i < BUILTIN_HARNESSES.length - 1 ? "1px solid var(--separator)" : "none",
+                }}
+              >
+                <span style={{ fontSize: "12px", fontWeight: 500, color: "var(--fg-base)" }}>
+                  {harness.name}
+                </span>
+                <div style={{ display: "flex", gap: "4px" }}>
+                  <button
+                    onClick={() => setHarnessMode(harness.id, undefined)}
+                    style={{
+                      fontSize: "10px", padding: "3px 8px", borderRadius: "4px",
+                      border: "1px solid var(--border-base)",
+                      background: effective === undefined ? "var(--bg-base)" : "transparent",
+                      color: effective === undefined ? "var(--fg-base)" : "var(--fg-subtle)",
+                      cursor: "pointer", fontWeight: effective === undefined ? 500 : 400,
+                    }}
+                  >
+                    Global
+                  </button>
+                  {modes.map((m) => (
+                    <button
+                      key={m.value}
+                      onClick={() => setHarnessMode(harness.id, m.value)}
+                      style={{
+                        fontSize: "10px", padding: "3px 8px", borderRadius: "4px",
+                        border: "1px solid var(--border-base)",
+                        background: effective === m.value ? "var(--accent-light)" : "transparent",
+                        color: effective === m.value ? "var(--accent-text)" : "var(--fg-subtle)",
+                        cursor: "pointer", fontWeight: effective === m.value ? 500 : 400,
+                      }}
+                    >
+                      {m.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Preset colors ─────────────────────────────────────────────
+
 const PRESET_COLORS: Record<string, string> = {
   Strict: "#16a34a",
   Standard: "#3b82f6",
   Permissive: "#d97706",
 };
 
+// ── Page ──────────────────────────────────────────────────────
+
 export default function PermissionsPage() {
+  // Claude settings.json permissions
   const [permissions, setPermissions] = useState<PermissionsState | null>(null);
   const [presets, setPresets] = useState<SecurityPreset[]>([]);
   const [loading, setLoading] = useState(true);
@@ -223,11 +556,15 @@ export default function PermissionsPage() {
   const [confirmPreset, setConfirmPreset] = useState<SecurityPreset | null>(null);
   const [dirty, setDirty] = useState(false);
 
+  // HarnessKit permission mode (localStorage)
+  const [mode, setMode] = useState<PermissionMode>(getPermissionMode);
+  const [allowedTools, setAllowedToolsState] = useState<string[]>(getAllowedTools);
+  const [overrides, setOverridesState] = useState<Record<string, HarnessPermissionOverride>>(
+    getHarnessPermissionOverrides,
+  );
+
   useEffect(() => {
-    Promise.all([
-      readPermissions(),
-      listSecurityPresets(),
-    ])
+    Promise.all([readPermissions(), listSecurityPresets()])
       .then(([perms, presetList]) => {
         setPermissions(perms);
         setPresets(presetList);
@@ -235,6 +572,29 @@ export default function PermissionsPage() {
       .catch((e) => setError(String(e)))
       .finally(() => setLoading(false));
   }, []);
+
+  function handleModeChange(next: PermissionMode) {
+    setMode(next);
+    setPermissionMode(next);
+  }
+
+  function handleToolsChange(next: string[]) {
+    setAllowedToolsState(next);
+    setAllowedTools(next);
+  }
+
+  function handleOverridesChange(next: Record<string, HarnessPermissionOverride>) {
+    setOverridesState(next);
+    setHarnessPermissionOverrides(next);
+  }
+
+  function handleReset() {
+    resetPermissionDefaults();
+    setAllowedToolsState(["Read", "Grep", "Glob"]);
+    setOverridesState({});
+  }
+
+  // ── Claude settings.json helpers ────────────────────────────
 
   function updateLocal(updater: (p: PermissionsState) => PermissionsState) {
     if (!permissions) return;
@@ -249,17 +609,11 @@ export default function PermissionsPage() {
     updateLocal((p) => {
       const next = JSON.parse(JSON.stringify(p)) as PermissionsState;
       if (category === "allow" || category === "deny" || category === "ask") {
-        if (!next.tools[category].includes(value)) {
-          next.tools[category].push(value);
-        }
+        if (!next.tools[category].includes(value)) next.tools[category].push(value);
       } else if (category === "writable" || category === "readonly") {
-        if (!next.paths[category].includes(value)) {
-          next.paths[category].push(value);
-        }
+        if (!next.paths[category].includes(value)) next.paths[category].push(value);
       } else if (category === "allowedHosts") {
-        if (!next.network.allowedHosts.includes(value)) {
-          next.network.allowedHosts.push(value);
-        }
+        if (!next.network.allowedHosts.includes(value)) next.network.allowedHosts.push(value);
       }
       return next;
     });
@@ -312,7 +666,7 @@ export default function PermissionsPage() {
   if (loading) {
     return (
       <div style={{ padding: "20px 24px" }}>
-        <p style={{ fontSize: "13px", color: "var(--fg-subtle)" }}>Loading...</p>
+        <p style={{ fontSize: "13px", color: "var(--fg-subtle)" }}>Loading…</p>
       </div>
     );
   }
@@ -322,8 +676,9 @@ export default function PermissionsPage() {
       <div style={{ padding: "20px 24px" }}>
         <h1 className="text-title" style={{ margin: "0 0 16px" }}>Permissions</h1>
         <div style={{
-          background: "var(--bg-surface)", border: "1px solid var(--border-base)",
-          borderRadius: "8px", padding: "10px 14px", fontSize: "13px", color: "var(--danger)",
+          background: "var(--bg-surface)", border: "1px solid var(--danger-light)",
+          borderLeft: "3px solid var(--danger)", borderRadius: "8px",
+          padding: "10px 14px", fontSize: "13px", color: "var(--danger)",
         }}>
           {error}
         </div>
@@ -332,205 +687,289 @@ export default function PermissionsPage() {
   }
 
   return (
-    <div style={{ padding: "20px 24px", maxWidth: "680px" }}>
-      {/* Header */}
-      <div style={{ marginBottom: "20px" }}>
-        <h1 style={{ fontSize: "17px", fontWeight: 600, letterSpacing: "-0.3px", color: "var(--fg-base)", margin: 0 }}>
+    <div style={{ padding: "20px 24px", maxWidth: "700px" }}>
+      {/* ── Page header ── */}
+      <div style={{ marginBottom: "24px" }}>
+        <h1 style={{
+          fontSize: "17px", fontWeight: 600, letterSpacing: "-0.3px",
+          color: "var(--fg-base)", margin: "0 0 3px",
+        }}>
           Permissions
         </h1>
-        <p style={{ fontSize: "12px", color: "var(--fg-muted)", margin: "3px 0 0" }}>
-          Tool access, file paths, and network rules — written to ~/.claude/settings.json
+        <p style={{ fontSize: "12px", color: "var(--fg-muted)", margin: 0 }}>
+          Control how much autonomy Claude and other harnesses have when running tasks.
         </p>
       </div>
 
-      {/* Presets */}
-      {presets.length > 0 && (
-        <div style={{ marginBottom: "20px" }}>
-          <p style={{ fontSize: "11px", fontWeight: 500, fontVariantCaps: "all-small-caps", letterSpacing: "0.03em", color: "var(--fg-subtle)", margin: "0 0 8px" }}>
-            Quick preset
-          </p>
-          <div style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
-            {presets.map((preset) => (
-              <button
-                key={preset.id}
-                onClick={() => setConfirmPreset(preset)}
-                className="preset-card"
-                style={{
-                  padding: "8px 12px",
-                  background: "var(--bg-surface)",
-                  border: "1px solid var(--border-base)",
-                  borderLeft: `3px solid ${PRESET_COLORS[preset.name] ?? "var(--border-base)"}`,
-                  borderRadius: "6px",
-                  cursor: "pointer",
-                  textAlign: "left",
-                }}
-              >
-                <div style={{ fontSize: "12px", fontWeight: 600, color: "var(--fg-base)" }}>{preset.name}</div>
-                <div style={{ fontSize: "10px", color: "var(--fg-subtle)", marginTop: "2px", lineHeight: 1.3 }}>{preset.description}</div>
-              </button>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* Confirm dialog */}
-      {confirmPreset && (
-        <div style={{
-          background: "var(--bg-surface)", border: "1px solid var(--border-base)",
-          borderRadius: "8px", padding: "14px 16px", marginBottom: "16px",
+      {/* ── Permission Mode section ── */}
+      <section style={{ marginBottom: "28px" }}>
+        <p style={{
+          fontSize: "11px", fontWeight: 500, fontVariantCaps: "all-small-caps",
+          letterSpacing: "0.04em", color: "var(--fg-subtle)", margin: "0 0 10px",
         }}>
-          <p style={{ fontSize: "13px", color: "var(--fg-base)", margin: "0 0 10px" }}>
-            Apply <strong>{confirmPreset.name}</strong> preset? This will overwrite current permissions.
-          </p>
-          <div style={{ display: "flex", gap: "8px" }}>
-            <button
-              onClick={() => handleApplyPreset(confirmPreset)}
-              disabled={saving}
-              style={{
-                fontSize: "12px", padding: "5px 14px", borderRadius: "6px",
-                border: "none", background: "var(--accent)", color: "#fff",
-                cursor: saving ? "default" : "pointer", fontWeight: 500,
-                opacity: saving ? 0.6 : 1,
-              }}
-            >
-              {saving ? "Applying…" : "Apply"}
-            </button>
-            <button
-              onClick={() => setConfirmPreset(null)}
-              style={{
-                fontSize: "12px", padding: "5px 14px", borderRadius: "6px",
-                border: "1px solid var(--border-base)", background: "transparent",
-                color: "var(--fg-muted)", cursor: "pointer",
-              }}
-            >
-              Cancel
-            </button>
-          </div>
+          Task execution mode
+        </p>
+
+        <div style={{ display: "flex", gap: "8px" }}>
+          <ModeCard
+            id="skip"
+            label="Skip All"
+            flag="--dangerously-skip-permissions"
+            description="No prompts. Claude can write files, run commands, and access your system freely."
+            icon={<IconSkip />}
+            accentColor="#d97706"
+            selected={mode === "skip"}
+            onClick={() => handleModeChange("skip")}
+          />
+          <ModeCard
+            id="auto"
+            label="Auto"
+            flag="--permission-mode auto"
+            description="AI classifiers approve non-destructive actions. Higher-risk operations still prompt."
+            icon={<IconAuto />}
+            accentColor="#3b82f6"
+            selected={mode === "auto"}
+            note="Requires Claude team, enterprise, or API plan"
+            onClick={() => handleModeChange("auto")}
+          />
+          <ModeCard
+            id="allowed-tools"
+            label="Allowed Tools"
+            flag="--allowedTools <list>"
+            description="Select which tools run without approval. All others prompt in the terminal."
+            icon={<IconTools />}
+            accentColor="#16a34a"
+            selected={mode === "allowed-tools"}
+            onClick={() => handleModeChange("allowed-tools")}
+          />
         </div>
-      )}
 
-      {permissions && (
-        <>
-          {/* Unified card */}
-          <div style={{
-            background: "var(--bg-surface)",
-            border: "1px solid var(--border-base)",
-            borderRadius: "10px",
-            overflow: "hidden",
-            marginBottom: "16px",
-          }}>
-            {/* Tools */}
-            <div style={{ padding: "14px 16px" }}>
-              <p style={{ fontSize: "11px", fontWeight: 500, fontVariantCaps: "all-small-caps", letterSpacing: "0.03em", color: "var(--fg-subtle)", margin: "0 0 12px" }}>
-                Tools
-              </p>
-              {(() => {
-                const allTools = [...permissions.tools.allow, ...permissions.tools.deny, ...permissions.tools.ask];
-                const rows: { key: "allow" | "deny" | "ask"; label: string; color: string; chipColor: "green" | "red" | "amber" }[] = [
-                  { key: "allow", label: "Allow", color: "#16a34a", chipColor: "green" },
-                  { key: "deny",  label: "Deny",  color: "#dc2626", chipColor: "red"   },
-                  { key: "ask",   label: "Ask",   color: "#d97706", chipColor: "amber" },
-                ];
-                return (
-                  <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
-                    {rows.map(({ key, label, color, chipColor }) => (
-                      <div key={key} style={{ display: "flex", gap: "10px" }}>
-                        <span style={{ fontSize: "11px", fontWeight: 600, color, minWidth: "38px", paddingTop: "5px" }}>{label}</span>
-                        <div style={{ flex: 1 }}>
-                          {permissions.tools[key].length > 0 && (
-                            <div style={{ display: "flex", flexWrap: "wrap", gap: "4px", marginBottom: "4px" }}>
-                              {permissions.tools[key].map((t) => (
-                                <Chip key={t} label={t} color={chipColor} onRemove={() => removeFromList(key, t)} />
-                              ))}
-                            </div>
-                          )}
-                          <SuggestInput
-                            onAdd={(v) => addToList(key, v)}
-                            placeholder={`Add ${label.toLowerCase()} rule…`}
-                            suggestions={TOOL_SUGGESTIONS}
-                            existing={allTools}
-                          />
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                );
-              })()}
-            </div>
+        {/* Allowed tools checklist — visible when mode is allowed-tools */}
+        {mode === "allowed-tools" && (
+          <AllowedToolsSection tools={allowedTools} onChange={handleToolsChange} />
+        )}
 
-            <div style={{ height: "1px", background: "var(--separator)", margin: "0 16px" }} />
+        {/* Per-harness overrides */}
+        <HarnessOverridesSection overrides={overrides} onChange={handleOverridesChange} />
 
-            {/* Paths */}
-            <div style={{ padding: "14px 16px" }}>
-              <p style={{ fontSize: "11px", fontWeight: 500, fontVariantCaps: "all-small-caps", letterSpacing: "0.03em", color: "var(--fg-subtle)", margin: "0 0 12px" }}>
-                Paths
-              </p>
-              {(() => {
-                const allPaths = [...permissions.paths.writable, ...permissions.paths.readonly];
-                return (
-                  <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "20px" }}>
-                    <div>
-                      <p style={{ fontSize: "11px", fontWeight: 600, color: "#16a34a", margin: "0 0 6px" }}>Writable</p>
-                      {permissions.paths.writable.length > 0 && (
-                        <div style={{ display: "flex", flexWrap: "wrap", gap: "4px", marginBottom: "4px" }}>
-                          {permissions.paths.writable.map((p) => (
-                            <Chip key={p} label={p} color="green" onRemove={() => removeFromList("writable", p)} />
-                          ))}
-                        </div>
-                      )}
-                      <SuggestInput onAdd={(v) => addToList("writable", v)} placeholder="Add path…" suggestions={PATH_SUGGESTIONS} existing={allPaths} />
-                    </div>
-                    <div>
-                      <p style={{ fontSize: "11px", fontWeight: 600, color: "#d97706", margin: "0 0 6px" }}>Read-only</p>
-                      {permissions.paths.readonly.length > 0 && (
-                        <div style={{ display: "flex", flexWrap: "wrap", gap: "4px", marginBottom: "4px" }}>
-                          {permissions.paths.readonly.map((p) => (
-                            <Chip key={p} label={p} color="amber" onRemove={() => removeFromList("readonly", p)} />
-                          ))}
-                        </div>
-                      )}
-                      <SuggestInput onAdd={(v) => addToList("readonly", v)} placeholder="Add path…" suggestions={PATH_SUGGESTIONS} existing={allPaths} />
-                    </div>
-                  </div>
-                );
-              })()}
-            </div>
-
-            <div style={{ height: "1px", background: "var(--separator)", margin: "0 16px" }} />
-
-            {/* Network */}
-            <div style={{ padding: "14px 16px" }}>
-              <p style={{ fontSize: "11px", fontWeight: 500, fontVariantCaps: "all-small-caps", letterSpacing: "0.03em", color: "var(--fg-subtle)", margin: "0 0 12px" }}>
-                Network — Allowed Hosts
-              </p>
-              {permissions.network.allowedHosts.length > 0 && (
-                <div style={{ display: "flex", flexWrap: "wrap", gap: "4px", marginBottom: "4px" }}>
-                  {permissions.network.allowedHosts.map((h) => (
-                    <Chip key={h} label={h} color="green" onRemove={() => removeFromList("allowedHosts", h)} />
-                  ))}
-                </div>
-              )}
-              <SuggestInput onAdd={(v) => addToList("allowedHosts", v)} placeholder="Add host…" suggestions={HOST_SUGGESTIONS} existing={permissions.network.allowedHosts} />
-            </div>
-          </div>
-
-          {/* Save */}
+        {/* Reset */}
+        <div style={{ marginTop: "14px" }}>
           <button
-            onClick={handleSave}
-            disabled={!dirty || saving}
+            onClick={handleReset}
             style={{
-              fontSize: "13px", fontWeight: 500, padding: "8px 20px",
-              borderRadius: "6px", border: "none",
-              background: dirty ? "var(--accent)" : "var(--bg-surface)",
-              color: dirty ? "#fff" : "var(--fg-subtle)",
-              cursor: dirty ? "pointer" : "default",
-              opacity: saving ? 0.6 : 1,
+              fontSize: "11px", color: "var(--fg-subtle)",
+              background: "none", border: "none", padding: 0,
+              cursor: "pointer", textDecoration: "underline",
+              textUnderlineOffset: "2px",
             }}
           >
-            {saving ? "Saving…" : "Save Permissions"}
+            Reset to defaults
           </button>
-        </>
-      )}
+          <span style={{ fontSize: "11px", color: "var(--fg-placeholder)", marginLeft: "6px" }}>
+            (clears allowed-tools list, per-harness overrides, and first-run prompt)
+          </span>
+        </div>
+      </section>
+
+      {/* ── Divider ── */}
+      <div style={{ height: "1px", background: "var(--separator)", marginBottom: "24px" }} />
+
+      {/* ── Claude settings.json section ── */}
+      <section>
+        <div style={{ marginBottom: "14px" }}>
+          <p style={{
+            fontSize: "11px", fontWeight: 500, fontVariantCaps: "all-small-caps",
+            letterSpacing: "0.04em", color: "var(--fg-subtle)", margin: "0 0 2px",
+          }}>
+            Claude settings.json
+          </p>
+          <p style={{ fontSize: "11px", color: "var(--fg-placeholder)", margin: 0 }}>
+            Tool access, file paths, and network rules — written to ~/.claude/settings.json
+          </p>
+        </div>
+
+        {/* Quick presets */}
+        {presets.length > 0 && (
+          <div style={{ marginBottom: "16px" }}>
+            <div style={{ display: "flex", gap: "6px", flexWrap: "wrap" }}>
+              {presets.map((preset) => (
+                <button
+                  key={preset.id}
+                  onClick={() => setConfirmPreset(preset)}
+                  style={{
+                    padding: "7px 12px",
+                    background: "var(--bg-surface)",
+                    border: "1px solid var(--border-base)",
+                    borderLeft: `3px solid ${PRESET_COLORS[preset.name] ?? "var(--border-base)"}`,
+                    borderRadius: "6px",
+                    cursor: "pointer", textAlign: "left",
+                  }}
+                >
+                  <div style={{ fontSize: "11px", fontWeight: 600, color: "var(--fg-base)" }}>{preset.name}</div>
+                  <div style={{ fontSize: "10px", color: "var(--fg-subtle)", marginTop: "1px", lineHeight: 1.3 }}>
+                    {preset.description}
+                  </div>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Preset confirm */}
+        {confirmPreset && (
+          <div style={{
+            background: "var(--bg-surface)", border: "1px solid var(--border-base)",
+            borderRadius: "8px", padding: "12px 14px", marginBottom: "14px",
+          }}>
+            <p style={{ fontSize: "12px", color: "var(--fg-base)", margin: "0 0 10px" }}>
+              Apply <strong>{confirmPreset.name}</strong> preset? This will overwrite current settings.
+            </p>
+            <div style={{ display: "flex", gap: "6px" }}>
+              <button
+                onClick={() => handleApplyPreset(confirmPreset)}
+                disabled={saving}
+                className="btn btn-primary btn-sm"
+              >
+                {saving ? "Applying…" : "Apply"}
+              </button>
+              <button onClick={() => setConfirmPreset(null)} className="btn btn-secondary btn-sm">
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+
+        {permissions && (
+          <>
+            {/* Unified card */}
+            <div style={{
+              background: "var(--bg-surface)",
+              border: "1px solid var(--border-base)",
+              borderRadius: "10px",
+              overflow: "hidden",
+              marginBottom: "14px",
+            }}>
+              {/* Tools */}
+              <div style={{ padding: "14px 16px" }}>
+                <p style={{
+                  fontSize: "11px", fontWeight: 500, fontVariantCaps: "all-small-caps",
+                  letterSpacing: "0.04em", color: "var(--fg-subtle)", margin: "0 0 12px",
+                }}>
+                  Tools
+                </p>
+                {(() => {
+                  const allTools = [...permissions.tools.allow, ...permissions.tools.deny, ...permissions.tools.ask];
+                  const rows: { key: "allow" | "deny" | "ask"; label: string; color: string; chipColor: "green" | "red" | "amber" }[] = [
+                    { key: "allow", label: "Allow", color: "#16a34a", chipColor: "green" },
+                    { key: "deny",  label: "Deny",  color: "#dc2626", chipColor: "red"   },
+                    { key: "ask",   label: "Ask",   color: "#d97706", chipColor: "amber" },
+                  ];
+                  return (
+                    <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+                      {rows.map(({ key, label, color, chipColor }) => (
+                        <div key={key} style={{ display: "flex", gap: "10px" }}>
+                          <span style={{
+                            fontSize: "11px", fontWeight: 600, color,
+                            minWidth: "38px", paddingTop: "5px",
+                          }}>
+                            {label}
+                          </span>
+                          <div style={{ flex: 1 }}>
+                            {permissions.tools[key].length > 0 && (
+                              <div style={{ display: "flex", flexWrap: "wrap", gap: "4px", marginBottom: "4px" }}>
+                                {permissions.tools[key].map((t) => (
+                                  <Chip key={t} label={t} color={chipColor} onRemove={() => removeFromList(key, t)} />
+                                ))}
+                              </div>
+                            )}
+                            <SuggestInput
+                              onAdd={(v) => addToList(key, v)}
+                              placeholder={`Add ${label.toLowerCase()} rule…`}
+                              suggestions={TOOL_SUGGESTIONS}
+                              existing={allTools}
+                            />
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  );
+                })()}
+              </div>
+
+              <div style={{ height: "1px", background: "var(--separator)", margin: "0 16px" }} />
+
+              {/* Paths */}
+              <div style={{ padding: "14px 16px" }}>
+                <p style={{
+                  fontSize: "11px", fontWeight: 500, fontVariantCaps: "all-small-caps",
+                  letterSpacing: "0.04em", color: "var(--fg-subtle)", margin: "0 0 12px",
+                }}>
+                  Paths
+                </p>
+                {(() => {
+                  const allPaths = [...permissions.paths.writable, ...permissions.paths.readonly];
+                  return (
+                    <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "20px" }}>
+                      <div>
+                        <p style={{ fontSize: "11px", fontWeight: 600, color: "#16a34a", margin: "0 0 6px" }}>Writable</p>
+                        {permissions.paths.writable.length > 0 && (
+                          <div style={{ display: "flex", flexWrap: "wrap", gap: "4px", marginBottom: "4px" }}>
+                            {permissions.paths.writable.map((p) => (
+                              <Chip key={p} label={p} color="green" onRemove={() => removeFromList("writable", p)} />
+                            ))}
+                          </div>
+                        )}
+                        <SuggestInput onAdd={(v) => addToList("writable", v)} placeholder="Add path…" suggestions={PATH_SUGGESTIONS} existing={allPaths} />
+                      </div>
+                      <div>
+                        <p style={{ fontSize: "11px", fontWeight: 600, color: "#d97706", margin: "0 0 6px" }}>Read-only</p>
+                        {permissions.paths.readonly.length > 0 && (
+                          <div style={{ display: "flex", flexWrap: "wrap", gap: "4px", marginBottom: "4px" }}>
+                            {permissions.paths.readonly.map((p) => (
+                              <Chip key={p} label={p} color="amber" onRemove={() => removeFromList("readonly", p)} />
+                            ))}
+                          </div>
+                        )}
+                        <SuggestInput onAdd={(v) => addToList("readonly", v)} placeholder="Add path…" suggestions={PATH_SUGGESTIONS} existing={allPaths} />
+                      </div>
+                    </div>
+                  );
+                })()}
+              </div>
+
+              <div style={{ height: "1px", background: "var(--separator)", margin: "0 16px" }} />
+
+              {/* Network */}
+              <div style={{ padding: "14px 16px" }}>
+                <p style={{
+                  fontSize: "11px", fontWeight: 500, fontVariantCaps: "all-small-caps",
+                  letterSpacing: "0.04em", color: "var(--fg-subtle)", margin: "0 0 12px",
+                }}>
+                  Network — Allowed Hosts
+                </p>
+                {permissions.network.allowedHosts.length > 0 && (
+                  <div style={{ display: "flex", flexWrap: "wrap", gap: "4px", marginBottom: "4px" }}>
+                    {permissions.network.allowedHosts.map((h) => (
+                      <Chip key={h} label={h} color="green" onRemove={() => removeFromList("allowedHosts", h)} />
+                    ))}
+                  </div>
+                )}
+                <SuggestInput onAdd={(v) => addToList("allowedHosts", v)} placeholder="Add host…" suggestions={HOST_SUGGESTIONS} existing={permissions.network.allowedHosts} />
+              </div>
+            </div>
+
+            {/* Save */}
+            <button
+              onClick={handleSave}
+              disabled={!dirty || saving}
+              className={dirty ? "btn btn-primary" : "btn btn-secondary"}
+              style={{ opacity: saving ? 0.6 : 1 }}
+            >
+              {saving ? "Saving…" : "Save to settings.json"}
+            </button>
+          </>
+        )}
+      </section>
     </div>
   );
 }

--- a/apps/desktop/src/pages/security/__tests__/PermissionsPage.test.tsx
+++ b/apps/desktop/src/pages/security/__tests__/PermissionsPage.test.tsx
@@ -18,6 +18,17 @@ vi.mock("../../../lib/tauri", () => ({
   applySecurityPreset: (...args: unknown[]) => mockApplySecurityPreset(...args),
 }));
 
+vi.mock("../../../lib/preferences", () => ({
+  getPermissionMode: () => "skip",
+  setPermissionMode: vi.fn(),
+  getAllowedTools: () => ["Read", "Grep", "Glob"],
+  setAllowedTools: vi.fn(),
+  getHarnessPermissionOverrides: () => ({}),
+  setHarnessPermissionOverrides: vi.fn(),
+  resetPermissionDefaults: vi.fn(),
+  DEFAULT_ALLOWED_TOOLS: ["Read", "Grep", "Glob"],
+}));
+
 // ── Fixtures ──────────────────────────────────────────────────
 
 const EMPTY_PERMISSIONS: PermissionsState = {
@@ -84,17 +95,17 @@ beforeEach(() => {
 // ── Tests ─────────────────────────────────────────────────────
 
 describe("PermissionsPage — loading state", () => {
-  it("shows 'Loading...' before data arrives", () => {
+  it("shows 'Loading…' before data arrives", () => {
     mockReadPermissions.mockReturnValue(new Promise(() => {}));
     mockListSecurityPresets.mockReturnValue(new Promise(() => {}));
     renderPage();
-    expect(screen.getByText("Loading...")).toBeInTheDocument();
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
   });
 
-  it("hides 'Loading...' after data loads", async () => {
+  it("hides 'Loading…' after data loads", async () => {
     renderPage();
     await waitFor(() =>
-      expect(screen.queryByText("Loading...")).not.toBeInTheDocument(),
+      expect(screen.queryByText("Loading…")).not.toBeInTheDocument(),
     );
   });
 });
@@ -190,7 +201,7 @@ describe("PermissionsPage — preset buttons", () => {
     renderPage();
     // Wait for load to finish
     await waitFor(() =>
-      expect(screen.queryByText("Loading...")).not.toBeInTheDocument(),
+      expect(screen.queryByText("Loading…")).not.toBeInTheDocument(),
     );
     expect(screen.queryByText("Quick preset")).not.toBeInTheDocument();
   });
@@ -204,7 +215,7 @@ describe("PermissionsPage — permissions display", () => {
   it("renders the page heading", async () => {
     renderPage();
     await waitFor(() =>
-      expect(screen.queryByText("Loading...")).not.toBeInTheDocument(),
+      expect(screen.queryByText("Loading…")).not.toBeInTheDocument(),
     );
     expect(screen.getByText("Permissions")).toBeInTheDocument();
   });
@@ -245,7 +256,7 @@ describe("PermissionsPage — permissions display", () => {
 describe("PermissionsPage — Save button state", () => {
   it("Save button starts disabled (not dirty)", async () => {
     renderPage();
-    const saveBtn = await screen.findByRole("button", { name: "Save Permissions" });
+    const saveBtn = await screen.findByRole("button", { name: "Save to settings.json" });
     expect(saveBtn).toBeDisabled();
   });
 
@@ -255,7 +266,7 @@ describe("PermissionsPage — Save button state", () => {
 
     // Wait for the page to finish loading
     await waitFor(() =>
-      expect(screen.queryByText("Loading...")).not.toBeInTheDocument(),
+      expect(screen.queryByText("Loading…")).not.toBeInTheDocument(),
     );
 
     // Type in the Allow input and click Add
@@ -263,7 +274,7 @@ describe("PermissionsPage — Save button state", () => {
     fireEvent.change(inputs[0], { target: { value: "Read" } });
     fireEvent.click(screen.getAllByRole("button", { name: "Add" })[0]);
 
-    const saveBtn = screen.getByRole("button", { name: "Save Permissions" });
+    const saveBtn = screen.getByRole("button", { name: "Save to settings.json" });
     expect(saveBtn).not.toBeDisabled();
   });
 
@@ -272,7 +283,7 @@ describe("PermissionsPage — Save button state", () => {
     renderPage();
 
     await waitFor(() =>
-      expect(screen.queryByText("Loading...")).not.toBeInTheDocument(),
+      expect(screen.queryByText("Loading…")).not.toBeInTheDocument(),
     );
 
     // Dirty the state by adding a tool
@@ -280,7 +291,7 @@ describe("PermissionsPage — Save button state", () => {
     fireEvent.change(inputs[0], { target: { value: "Read" } });
     fireEvent.click(screen.getAllByRole("button", { name: "Add" })[0]);
 
-    const saveBtn = screen.getByRole("button", { name: "Save Permissions" });
+    const saveBtn = screen.getByRole("button", { name: "Save to settings.json" });
     fireEvent.click(saveBtn);
 
     await waitFor(() => {
@@ -326,7 +337,7 @@ describe("PermissionsPage — add/remove items", () => {
     renderPage();
 
     await waitFor(() =>
-      expect(screen.queryByText("Loading...")).not.toBeInTheDocument(),
+      expect(screen.queryByText("Loading…")).not.toBeInTheDocument(),
     );
 
     const hostInput = screen.getByPlaceholderText("Add host…");
@@ -344,7 +355,7 @@ describe("PermissionsPage — add/remove items", () => {
     renderPage();
 
     await waitFor(() =>
-      expect(screen.queryByText("Loading...")).not.toBeInTheDocument(),
+      expect(screen.queryByText("Loading…")).not.toBeInTheDocument(),
     );
 
     const hostInput = screen.getByPlaceholderText("Add host…");
@@ -359,7 +370,7 @@ describe("PermissionsPage — section labels", () => {
   it("shows Tools section label", async () => {
     renderPage();
     await waitFor(() =>
-      expect(screen.queryByText("Loading...")).not.toBeInTheDocument(),
+      expect(screen.queryByText("Loading…")).not.toBeInTheDocument(),
     );
     expect(screen.getByText("Tools")).toBeInTheDocument();
   });
@@ -367,7 +378,7 @@ describe("PermissionsPage — section labels", () => {
   it("shows Paths section label", async () => {
     renderPage();
     await waitFor(() =>
-      expect(screen.queryByText("Loading...")).not.toBeInTheDocument(),
+      expect(screen.queryByText("Loading…")).not.toBeInTheDocument(),
     );
     expect(screen.getByText("Paths")).toBeInTheDocument();
   });
@@ -375,7 +386,7 @@ describe("PermissionsPage — section labels", () => {
   it("shows Network section label", async () => {
     renderPage();
     await waitFor(() =>
-      expect(screen.queryByText("Loading...")).not.toBeInTheDocument(),
+      expect(screen.queryByText("Loading…")).not.toBeInTheDocument(),
     );
     expect(screen.getByText(/Network/)).toBeInTheDocument();
   });

--- a/apps/desktop/src/pages/security/__tests__/PermissionsPage.test.tsx
+++ b/apps/desktop/src/pages/security/__tests__/PermissionsPage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import type { PermissionsState, SecurityPreset } from "@harness-kit/shared";
@@ -16,6 +16,7 @@ vi.mock("../../../lib/tauri", () => ({
   updatePermissions: (...args: unknown[]) => mockUpdatePermissions(...args),
   listSecurityPresets: () => mockListSecurityPresets(),
   applySecurityPreset: (...args: unknown[]) => mockApplySecurityPreset(...args),
+  detectClaudeAccount: () => Promise.resolve({ logged_in: false, subscription_type: null, auto_mode_available: false }),
 }));
 
 vi.mock("../../../lib/preferences", () => ({
@@ -26,6 +27,8 @@ vi.mock("../../../lib/preferences", () => ({
   getHarnessPermissionOverrides: () => ({}),
   setHarnessPermissionOverrides: vi.fn(),
   resetPermissionDefaults: vi.fn(),
+  getAutoModeUnlocked: () => false,
+  setAutoModeUnlocked: vi.fn(),
   DEFAULT_ALLOWED_TOOLS: ["Read", "Grep", "Glob"],
 }));
 
@@ -86,10 +89,16 @@ function renderPage() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Simulate Tauri desktop environment so tauriAvailable === true
+  (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {};
   mockReadPermissions.mockResolvedValue(EMPTY_PERMISSIONS);
   mockUpdatePermissions.mockResolvedValue(undefined);
   mockListSecurityPresets.mockResolvedValue([STRICT_PRESET, STANDARD_PRESET, PERMISSIVE_PRESET]);
   mockApplySecurityPreset.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
 });
 
 // ── Tests ─────────────────────────────────────────────────────

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -15,8 +15,8 @@ export default defineConfig(async () => ({
     port: 1422,
     strictPort: true,
     watch: {
-      // 3. tell vite to ignore watching `src-tauri`
-      ignored: ["**/src-tauri/**"],
+      // 3. tell vite to ignore watching `src-tauri` and worktree artifacts
+      ignored: ["**/src-tauri/**", "**/.auto-claude/**"],
     },
   },
 


### PR DESCRIPTION
## Summary

Adds a fully-featured permission mode selector to the Security → Permissions page, with automatic Claude account detection to gate Auto mode, per-tool scope granularity (e.g. `Read(~/repos/**)` patterns), a live "Current configuration" summary banner, graceful degradation when running outside the Tauri desktop environment, and single-instance window enforcement.

## Changes

- **Permission mode selector**: Mode cards (Default, Skip, Auto) rendered from localStorage with first-run modal. Auto mode card only shown when the user's Claude account qualifies (team/enterprise/business/API key — not max/pro).
- **Auto account detection**: New `detect_claude_account` Tauri command runs `claude auth status`, parses subscription type, and returns `auto_mode_available`. Frontend calls this on mount and auto-shows/hides the Auto card without a manual disclosure toggle.
- **Tool scope granularity**: Allowed tools checklist now supports `Tool(pattern)` entries (e.g. `Read(~/repos/**)`, `Bash(git *)`, `WebFetch(https://api.github.com/*)`). Active tools render as rows with a scope input column; inactive tools render as `+ ToolName` chips.
- **Current configuration summary**: Live banner above the settings.json section showing active mode, tool list, and override count.
- **Graceful degradation**: When `window.__TAURI_INTERNALS__` is absent (browser/dev), the settings.json section shows "requires the desktop app" instead of a raw TypeError.
- **Single-instance enforcement**: `tauri-plugin-single-instance` focuses the existing window when a second instance is launched.
- **Test fixes**: Added `window.__TAURI_INTERNALS__` setup/teardown in `beforeEach`/`afterEach` and missing mock entries (`detectClaudeAccount`, `getAutoModeUnlocked`, `setAutoModeUnlocked`) so all 638 tests pass.

## Test Plan

- [x] All 638 tests pass (`pnpm test --run` in `apps/desktop`)
- [x] Permission mode cards render and persist to localStorage
- [x] Auto card hidden when `auto_mode_available: false`, shown when true
- [x] Tool scope inputs accept and persist `Tool(pattern)` format
- [x] Settings.json section shows graceful message outside desktop app
- [x] Second app launch focuses existing window instead of opening new one
- [ ] CI checks pass

## Notes

The `detect_claude_account` command shells out to `claude auth status` — if the Claude CLI is not installed, it returns `{ logged_in: false, auto_mode_available: false }` gracefully. The Auto mode card is suppressed in that case.