### PR TITLE
feat: Observatory cost analytics + budget guards

### DIFF
--- a/apps/desktop/src/components/observatory/BudgetAlertBanner.tsx
+++ b/apps/desktop/src/components/observatory/BudgetAlertBanner.tsx
@@ -1,0 +1,94 @@
+import { useState } from "react";
+import { formatCost } from "../../lib/pricing";
+
+interface Props {
+  tokensToday: number;
+  tokenLimit?: number;
+  costToday: number;
+  costLimit?: number;
+  onDismiss?: () => void;
+}
+
+const fontStack = '-apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif';
+
+export default function BudgetAlertBanner({
+  tokensToday,
+  tokenLimit,
+  costToday,
+  costLimit,
+  onDismiss,
+}: Props) {
+  const [dismissed, setDismissed] = useState(false);
+
+  const tokenOver  = tokenLimit != null && tokensToday > tokenLimit;
+  const costOver   = costLimit  != null && costToday  > costLimit;
+  const isOver     = tokenOver || costOver;
+
+  if (!isOver || dismissed) return null;
+
+  const messages: string[] = [];
+  if (tokenOver && tokenLimit != null) {
+    messages.push(
+      `${tokensToday.toLocaleString()} tokens today (limit: ${tokenLimit.toLocaleString()})`,
+    );
+  }
+  if (costOver && costLimit != null) {
+    messages.push(
+      `${formatCost(costToday)} today (limit: ${formatCost(costLimit)})`,
+    );
+  }
+
+  function handleDismiss() {
+    setDismissed(true);
+    onDismiss?.();
+  }
+
+  return (
+    <div
+      role="alert"
+      data-testid="budget-alert-banner"
+      style={{
+        display: "flex",
+        alignItems: "flex-start",
+        justifyContent: "space-between",
+        gap: "12px",
+        padding: "12px 16px",
+        marginBottom: "20px",
+        borderRadius: "8px",
+        background: "rgba(217,119,6,0.08)",
+        border: "1px solid rgba(217,119,6,0.3)",
+        fontFamily: fontStack,
+        fontSize: "13px",
+        color: "var(--fg-base)",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "flex-start", gap: "10px" }}>
+        <span style={{ fontSize: "16px", flexShrink: 0 }}>⚠</span>
+        <div>
+          <span style={{ fontWeight: 600, color: "#d97706" }}>
+            Daily budget exceeded:&nbsp;
+          </span>
+          {messages.join(" · ")}
+        </div>
+      </div>
+
+      <button
+        data-testid="budget-dismiss-btn"
+        onClick={handleDismiss}
+        aria-label="Dismiss budget alert"
+        style={{
+          flexShrink: 0,
+          border: "none",
+          background: "none",
+          color: "#d97706",
+          cursor: "pointer",
+          fontSize: "16px",
+          lineHeight: 1,
+          padding: "0 2px",
+        }}
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/observatory/CostBreakdownSection.tsx
+++ b/apps/desktop/src/components/observatory/CostBreakdownSection.tsx
@@ -1,0 +1,133 @@
+import { useMemo } from "react";
+import { estimateCost, formatCost } from "../../lib/pricing";
+
+interface ModelUsageEntry {
+  inputTokens?: number;
+  outputTokens?: number;
+}
+
+interface CostRow {
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cost: number;
+}
+
+interface Props {
+  modelUsage: Record<string, ModelUsageEntry>;
+}
+
+const fontStack = '-apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif';
+
+export default function CostBreakdownSection({ modelUsage }: Props) {
+  const rows: CostRow[] = useMemo(() => {
+    return Object.entries(modelUsage)
+      .map(([model, usage]) => {
+        const inputTokens  = usage.inputTokens  ?? 0;
+        const outputTokens = usage.outputTokens ?? 0;
+        return {
+          model,
+          inputTokens,
+          outputTokens,
+          cost: estimateCost(model, inputTokens, outputTokens),
+        };
+      })
+      .filter((r) => r.inputTokens > 0 || r.outputTokens > 0)
+      .sort((a, b) => b.cost - a.cost);
+  }, [modelUsage]);
+
+  if (rows.length === 0) {
+    return (
+      <div style={{
+        padding: "24px",
+        textAlign: "center",
+        color: "var(--fg-subtle)",
+        fontSize: "13px",
+        fontFamily: fontStack,
+      }}>
+        No token usage data for this period.
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ fontFamily: fontStack, marginTop: "24px" }}>
+      <h3 style={{
+        margin: "0 0 12px",
+        fontSize: "13px",
+        fontWeight: 600,
+        color: "var(--fg-muted)",
+        textTransform: "uppercase",
+        letterSpacing: "0.06em",
+      }}>
+        Cost Breakdown by Model
+      </h3>
+
+      <div style={{
+        background: "var(--bg-surface)",
+        border: "1px solid var(--border-base)",
+        borderRadius: "8px",
+        overflow: "hidden",
+      }}>
+        {/* Header */}
+        <div style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 120px 120px 90px",
+          padding: "10px 16px",
+          background: "var(--bg-elevated)",
+          borderBottom: "1px solid var(--border-base)",
+          fontSize: "11px",
+          fontWeight: 600,
+          color: "var(--fg-subtle)",
+          textTransform: "uppercase",
+          letterSpacing: "0.06em",
+        }}>
+          <span>Model</span>
+          <span style={{ textAlign: "right" }}>Input tokens</span>
+          <span style={{ textAlign: "right" }}>Output tokens</span>
+          <span style={{ textAlign: "right" }}>Est. cost</span>
+        </div>
+
+        {/* Rows */}
+        {rows.map((row, i) => (
+          <div
+            key={row.model}
+            data-testid="cost-row"
+            style={{
+              display: "grid",
+              gridTemplateColumns: "1fr 120px 120px 90px",
+              padding: "10px 16px",
+              fontSize: "13px",
+              color: "var(--fg-base)",
+              borderBottom: i < rows.length - 1 ? "1px solid var(--border-subtle)" : "none",
+            }}
+          >
+            <span style={{
+              fontFamily: "monospace",
+              fontSize: "12px",
+              color: "var(--fg-muted)",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}>
+              {row.model}
+            </span>
+            <span style={{ textAlign: "right", color: "var(--fg-muted)" }}>
+              {row.inputTokens.toLocaleString()}
+            </span>
+            <span style={{ textAlign: "right", color: "var(--fg-muted)" }}>
+              {row.outputTokens.toLocaleString()}
+            </span>
+            <span style={{
+              textAlign: "right",
+              fontWeight: 600,
+              color: "var(--accent-text)",
+            }}>
+              {formatCost(row.cost)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/observatory/__tests__/BudgetAlertBanner.test.tsx
+++ b/apps/desktop/src/components/observatory/__tests__/BudgetAlertBanner.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import BudgetAlertBanner from "../BudgetAlertBanner";
+
+describe("BudgetAlertBanner", () => {
+  it("renders when tokens exceed limit", () => {
+    render(
+      <BudgetAlertBanner
+        tokensToday={600_000}
+        tokenLimit={500_000}
+        costToday={0}
+      />
+    );
+    expect(screen.getByTestId("budget-alert-banner")).toBeInTheDocument();
+    expect(screen.getByText(/Daily budget exceeded/)).toBeInTheDocument();
+  });
+
+  it("renders when cost exceeds limit", () => {
+    render(
+      <BudgetAlertBanner
+        tokensToday={0}
+        costToday={6.50}
+        costLimit={5.00}
+      />
+    );
+    expect(screen.getByTestId("budget-alert-banner")).toBeInTheDocument();
+  });
+
+  it("does not render when within token limit", () => {
+    render(
+      <BudgetAlertBanner
+        tokensToday={100_000}
+        tokenLimit={500_000}
+        costToday={0.30}
+      />
+    );
+    expect(screen.queryByTestId("budget-alert-banner")).not.toBeInTheDocument();
+  });
+
+  it("does not render when no limits are set", () => {
+    render(
+      <BudgetAlertBanner
+        tokensToday={1_000_000}
+        costToday={18.00}
+      />
+    );
+    expect(screen.queryByTestId("budget-alert-banner")).not.toBeInTheDocument();
+  });
+
+  it("dismiss button hides the banner and calls onDismiss", () => {
+    const onDismiss = vi.fn();
+    render(
+      <BudgetAlertBanner
+        tokensToday={600_000}
+        tokenLimit={500_000}
+        costToday={0}
+        onDismiss={onDismiss}
+      />
+    );
+
+    expect(screen.getByTestId("budget-alert-banner")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("budget-dismiss-btn"));
+    expect(screen.queryByTestId("budget-alert-banner")).not.toBeInTheDocument();
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("shows both token and cost messages when both are exceeded", () => {
+    render(
+      <BudgetAlertBanner
+        tokensToday={600_000}
+        tokenLimit={500_000}
+        costToday={6.00}
+        costLimit={5.00}
+      />
+    );
+
+    const banner = screen.getByTestId("budget-alert-banner");
+    expect(banner.textContent).toContain("600,000 tokens today");
+    expect(banner.textContent).toContain("$6.00 today");
+  });
+});

--- a/apps/desktop/src/components/observatory/__tests__/CostBreakdownSection.test.tsx
+++ b/apps/desktop/src/components/observatory/__tests__/CostBreakdownSection.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import CostBreakdownSection from "../CostBreakdownSection";
+
+describe("CostBreakdownSection", () => {
+  it("renders a cost row for each model with usage", () => {
+    render(
+      <CostBreakdownSection
+        modelUsage={{
+          "claude-sonnet-4-6": { inputTokens: 100_000, outputTokens: 10_000 },
+          "claude-haiku-4-5":  { inputTokens: 50_000,  outputTokens: 5_000  },
+        }}
+      />
+    );
+
+    const rows = screen.getAllByTestId("cost-row");
+    expect(rows).toHaveLength(2);
+  });
+
+  it("sorts rows by cost descending", () => {
+    render(
+      <CostBreakdownSection
+        modelUsage={{
+          "claude-haiku-4-5":  { inputTokens: 1_000_000, outputTokens: 1_000_000 },
+          "claude-sonnet-4-6": { inputTokens: 1_000_000, outputTokens: 1_000_000 },
+        }}
+      />
+    );
+
+    const rows = screen.getAllByTestId("cost-row");
+    // sonnet ($18) should appear before haiku ($4.80)
+    expect(rows[0].textContent).toContain("sonnet");
+    expect(rows[1].textContent).toContain("haiku");
+  });
+
+  it("shows empty state when no usage data", () => {
+    render(<CostBreakdownSection modelUsage={{}} />);
+    expect(screen.getByText(/No token usage data/)).toBeInTheDocument();
+  });
+
+  it("excludes models with zero tokens from the table", () => {
+    render(
+      <CostBreakdownSection
+        modelUsage={{
+          "claude-sonnet-4-6": { inputTokens: 0, outputTokens: 0 },
+          "claude-haiku-4-5":  { inputTokens: 100, outputTokens: 0 },
+        }}
+      />
+    );
+
+    const rows = screen.getAllByTestId("cost-row");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].textContent).toContain("haiku");
+  });
+
+  it("renders correct cost for sonnet usage", () => {
+    // 1M input + 0 output = $3.00
+    render(
+      <CostBreakdownSection
+        modelUsage={{
+          "claude-sonnet-4-6": { inputTokens: 1_000_000, outputTokens: 0 },
+        }}
+      />
+    );
+
+    expect(screen.getByText("$3.00")).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/lib/__tests__/pricing.test.ts
+++ b/apps/desktop/src/lib/__tests__/pricing.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { estimateCost, estimateTotalCost, formatCost, MODEL_PRICING } from "../pricing";
+
+describe("pricing", () => {
+  describe("estimateCost", () => {
+    it("calculates correct cost for a known model (sonnet: 1M input + 1M output = $18.00)", () => {
+      const cost = estimateCost("claude-sonnet-4-6", 1_000_000, 1_000_000);
+      expect(cost).toBeCloseTo(18.00, 5);
+    });
+
+    it("calculates correct cost for haiku (1M input + 1M output = $4.80)", () => {
+      const cost = estimateCost("claude-haiku-4-5", 1_000_000, 1_000_000);
+      expect(cost).toBeCloseTo(4.80, 5);
+    });
+
+    it("falls back to default pricing for an unknown model", () => {
+      const cost = estimateCost("unknown-model-xyz", 1_000_000, 1_000_000);
+      // Default is sonnet-equivalent: $3 + $15 = $18
+      expect(cost).toBeCloseTo(18.00, 5);
+    });
+
+    it("returns $0.00 for zero tokens", () => {
+      expect(estimateCost("claude-sonnet-4-6", 0, 0)).toBe(0);
+    });
+
+    it("handles fractional token counts (real-world small sessions)", () => {
+      // 10k input, 2k output for sonnet: (10/1000)*3 + (2/1000)*15 = 0.03 + 0.03 = 0.06
+      const cost = estimateCost("claude-sonnet-4-6", 10_000, 2_000);
+      expect(cost).toBeCloseTo(0.06, 5);
+    });
+  });
+
+  describe("estimateTotalCost", () => {
+    it("sums costs across multiple models correctly", () => {
+      const usage = {
+        "claude-sonnet-4-6": { inputTokens: 1_000_000, outputTokens: 0 },
+        "claude-haiku-4-5":  { inputTokens: 0, outputTokens: 1_000_000 },
+      };
+      // sonnet: $3.00 input, haiku: $4.00 output → $7.00
+      expect(estimateTotalCost(usage)).toBeCloseTo(7.00, 5);
+    });
+
+    it("returns $0.00 for empty usage map", () => {
+      expect(estimateTotalCost({})).toBe(0);
+    });
+
+    it("handles missing inputTokens or outputTokens (defaults to 0)", () => {
+      const cost = estimateTotalCost({
+        "claude-sonnet-4-6": { inputTokens: 1_000_000 }, // no outputTokens
+      });
+      expect(cost).toBeCloseTo(3.00, 5);
+    });
+  });
+
+  describe("formatCost", () => {
+    it("formats zero as $0.00", () => {
+      expect(formatCost(0)).toBe("$0.00");
+    });
+
+    it("formats sub-cent amounts as <$0.01", () => {
+      expect(formatCost(0.001)).toBe("<$0.01");
+    });
+
+    it("formats normal amounts with 2 decimal places", () => {
+      expect(formatCost(1.234)).toBe("$1.23");
+      expect(formatCost(0.84)).toBe("$0.84");
+    });
+  });
+
+  describe("MODEL_PRICING table", () => {
+    it("contains entries for all major Claude model families", () => {
+      const keys = Object.keys(MODEL_PRICING);
+      expect(keys.some((k) => k.includes("sonnet"))).toBe(true);
+      expect(keys.some((k) => k.includes("haiku"))).toBe(true);
+      expect(keys.some((k) => k.includes("opus"))).toBe(true);
+    });
+  });
+});

--- a/apps/desktop/src/lib/preferences.ts
+++ b/apps/desktop/src/lib/preferences.ts
@@ -279,6 +279,33 @@ export function setAutoModeUnlocked(unlocked: boolean) {
   }
 }
 
+// ── Budget Guard ─────────────────────────────────────────────
+
+export interface BudgetGuardConfig {
+  enabled: boolean;
+  dailyTokenLimit?: number;
+  dailyEstimatedCostUSD?: number;
+}
+
+const BUDGET_GUARD_KEY = "harness-kit-budget-guard";
+
+const BUDGET_GUARD_DEFAULT: BudgetGuardConfig = { enabled: false };
+
+export function getBudgetGuard(): BudgetGuardConfig {
+  const raw = localStorage.getItem(BUDGET_GUARD_KEY);
+  if (!raw) return { ...BUDGET_GUARD_DEFAULT };
+  try {
+    return JSON.parse(raw) as BudgetGuardConfig;
+  } catch {
+    return { ...BUDGET_GUARD_DEFAULT };
+  }
+}
+
+export function setBudgetGuard(config: BudgetGuardConfig): void {
+  localStorage.setItem(BUDGET_GUARD_KEY, JSON.stringify(config));
+  window.dispatchEvent(new CustomEvent("harness-kit-prefs-changed"));
+}
+
 // ── Init ─────────────────────────────────────────────────────
 
 /** Apply all stored preferences on boot. Call once at app startup. */

--- a/apps/desktop/src/lib/pricing.ts
+++ b/apps/desktop/src/lib/pricing.ts
@@ -1,0 +1,47 @@
+export interface ModelPricing {
+  inputPer1M: number;   // USD per 1M input tokens
+  outputPer1M: number;  // USD per 1M output tokens
+}
+
+export const MODEL_PRICING: Record<string, ModelPricing> = {
+  // Claude 4.x
+  "claude-sonnet-4-6":              { inputPer1M: 3.00,  outputPer1M: 15.00 },
+  "claude-opus-4-6":                { inputPer1M: 15.00, outputPer1M: 75.00 },
+  "claude-haiku-4-5":               { inputPer1M: 0.80,  outputPer1M: 4.00  },
+  "claude-haiku-4-5-20251001":      { inputPer1M: 0.80,  outputPer1M: 4.00  },
+  // Claude 3.x
+  "claude-3-5-sonnet-20241022":     { inputPer1M: 3.00,  outputPer1M: 15.00 },
+  "claude-3-5-haiku-20241022":      { inputPer1M: 0.80,  outputPer1M: 4.00  },
+  "claude-3-opus-20240229":         { inputPer1M: 15.00, outputPer1M: 75.00 },
+  "claude-3-sonnet-20240229":       { inputPer1M: 3.00,  outputPer1M: 15.00 },
+  "claude-3-haiku-20240307":        { inputPer1M: 0.25,  outputPer1M: 1.25  },
+};
+
+const DEFAULT_PRICING: ModelPricing = { inputPer1M: 3.00, outputPer1M: 15.00 };
+
+export function estimateCost(
+  model: string,
+  inputTokens: number,
+  outputTokens: number,
+): number {
+  const pricing = MODEL_PRICING[model] ?? DEFAULT_PRICING;
+  return (
+    (inputTokens  / 1_000_000) * pricing.inputPer1M +
+    (outputTokens / 1_000_000) * pricing.outputPer1M
+  );
+}
+
+export function estimateTotalCost(
+  modelUsage: Record<string, { inputTokens?: number; outputTokens?: number }>,
+): number {
+  return Object.entries(modelUsage).reduce((sum, [model, usage]) => {
+    return sum + estimateCost(model, usage.inputTokens ?? 0, usage.outputTokens ?? 0);
+  }, 0);
+}
+
+/** Format a USD cost value for display (e.g. "$0.84", "$1.20"). */
+export function formatCost(usd: number): string {
+  if (usd === 0) return "$0.00";
+  if (usd < 0.01) return "<$0.01";
+  return `$${usd.toFixed(2)}`;
+}

--- a/apps/desktop/src/pages/observatory/DashboardPage.tsx
+++ b/apps/desktop/src/pages/observatory/DashboardPage.tsx
@@ -11,7 +11,7 @@ import { useObservatoryData } from "../../hooks/useObservatoryData";
 import { formatNumber, formatDate, formatHour, shortModelName } from "../../lib/format";
 import type { DailyActivity, DailyModelTokens, ModelUsageEntry } from "@harness-kit/shared";
 import { estimateTotalCost, formatCost } from "../../lib/pricing";
-import { getBudgetGuard } from "../../lib/preferences";
+import { getBudgetGuard, type BudgetGuardConfig } from "../../lib/preferences";
 import CostBreakdownSection from "../../components/observatory/CostBreakdownSection";
 import BudgetAlertBanner from "../../components/observatory/BudgetAlertBanner";
 
@@ -530,11 +530,26 @@ export default function DashboardPage() {
     [mergedModelUsage],
   );
 
-  const budgetGuard = useMemo(() => getBudgetGuard(), []);
+  const [budgetGuard, setBudgetGuardLocal] = useState<BudgetGuardConfig>(() => getBudgetGuard());
+
+  useEffect(() => {
+    function onPrefsChanged() {
+      setBudgetGuardLocal(getBudgetGuard());
+    }
+    window.addEventListener("harness-kit-prefs-changed", onPrefsChanged);
+    return () => window.removeEventListener("harness-kit-prefs-changed", onPrefsChanged);
+  }, []);
 
   const todayModelUsage = useMemo(() => {
     const today = new Date().toISOString().slice(0, 10);
     const todayEntry = liveStats?.dailyModelTokens?.find((d) => d.date === today);
+    // NOTE: tokensByModel values are TOTAL tokens (input + output + cache_read +
+    // cache_creation) as accumulated by observatory.rs. There is no per-day
+    // input/output split in this data structure. We expose the total as
+    // `inputTokens` so that token-limit checks and the daily cost estimate have
+    // a value to work with. The cost estimate will be an approximation priced
+    // at input rates only; use the all-time `mergedModelUsage` for accurate
+    // split-rate cost figures.
     return todayEntry?.tokensByModel
       ? Object.fromEntries(
           Object.entries(todayEntry.tokensByModel).map(([model, tokens]) => [

--- a/apps/desktop/src/pages/observatory/DashboardPage.tsx
+++ b/apps/desktop/src/pages/observatory/DashboardPage.tsx
@@ -10,6 +10,10 @@ import HKTooltip from "../../components/Tooltip";
 import { useObservatoryData } from "../../hooks/useObservatoryData";
 import { formatNumber, formatDate, formatHour, shortModelName } from "../../lib/format";
 import type { DailyActivity, DailyModelTokens, ModelUsageEntry } from "@harness-kit/shared";
+import { estimateTotalCost, formatCost } from "../../lib/pricing";
+import { getBudgetGuard } from "../../lib/preferences";
+import CostBreakdownSection from "../../components/observatory/CostBreakdownSection";
+import BudgetAlertBanner from "../../components/observatory/BudgetAlertBanner";
 
 const MODEL_COLORS = ["#5b50e8", "#0d9488", "#ea580c", "#16a34a", "#2563eb", "#e11d48"];
 
@@ -521,6 +525,39 @@ export default function DashboardPage() {
     };
   }, [mergedModelUsage]);
 
+  const totalEstimatedCost = useMemo(() =>
+    estimateTotalCost(mergedModelUsage),
+    [mergedModelUsage],
+  );
+
+  const budgetGuard = useMemo(() => getBudgetGuard(), []);
+
+  const todayModelUsage = useMemo(() => {
+    const today = new Date().toISOString().slice(0, 10);
+    const todayEntry = liveStats?.dailyModelTokens?.find((d) => d.date === today);
+    return todayEntry?.tokensByModel
+      ? Object.fromEntries(
+          Object.entries(todayEntry.tokensByModel).map(([model, tokens]) => [
+            model,
+            { inputTokens: tokens, outputTokens: 0 },
+          ])
+        )
+      : {};
+  }, [liveStats]);
+
+  const costToday = useMemo(() => estimateTotalCost(todayModelUsage), [todayModelUsage]);
+  const tokensToday = useMemo(() =>
+    Object.values(todayModelUsage).reduce((sum, u) => sum + (u.inputTokens ?? 0), 0),
+    [todayModelUsage],
+  );
+
+  const budgetExceeded = useMemo(() => {
+    if (!budgetGuard.enabled) return false;
+    const tokenOver = budgetGuard.dailyTokenLimit != null && tokensToday > budgetGuard.dailyTokenLimit;
+    const costOver  = budgetGuard.dailyEstimatedCostUSD != null && costToday > budgetGuard.dailyEstimatedCostUSD;
+    return tokenOver || costOver;
+  }, [budgetGuard, tokensToday, costToday]);
+
   const { dailyTokensChartData, allModelNames } = useMemo(() => {
     if (!mergedDailyTokens.length) return { dailyTokensChartData: [], allModelNames: [] };
 
@@ -662,6 +699,16 @@ export default function DashboardPage() {
         onResetOverrides={() => setChartOverrides({})}
       />
 
+      {/* Budget alert — shown above stats when daily limit is exceeded */}
+      {budgetExceeded && (
+        <BudgetAlertBanner
+          tokensToday={tokensToday}
+          tokenLimit={budgetGuard.dailyTokenLimit}
+          costToday={costToday}
+          costLimit={budgetGuard.dailyEstimatedCostUSD}
+        />
+      )}
+
       {/* Stats bar */}
       <div style={{ display: "flex", gap: "10px", marginBottom: "18px", flexWrap: "wrap" }}>
         <StatCard label="Sessions" value={formatNumber(cache?.totalSessions ?? 0)} tooltip="Unique Claude Code sessions" accent="#5b50e8" />
@@ -678,6 +725,13 @@ export default function DashboardPage() {
           sub="read / total input"
           tooltip="Cache read tokens as a percentage of total input tokens"
           accent="#16a34a"
+        />
+        <StatCard
+          label="Est. Cost"
+          value={formatCost(totalEstimatedCost)}
+          sub="all time"
+          tooltip="Estimated cost based on Anthropic public pricing. Actual billing may differ."
+          accent="#9333ea"
         />
       </div>
 
@@ -827,6 +881,9 @@ export default function DashboardPage() {
           )}
         </ChartCard>
       </div>
+
+      {/* Cost breakdown table */}
+      <CostBreakdownSection modelUsage={mergedModelUsage} />
     </div>
   );
 }

--- a/apps/desktop/src/pages/security/PermissionsPage.tsx
+++ b/apps/desktop/src/pages/security/PermissionsPage.tsx
@@ -11,7 +11,8 @@ import {
   getHarnessPermissionOverrides, setHarnessPermissionOverrides,
   resetPermissionDefaults,
   getAutoModeUnlocked, setAutoModeUnlocked,
-  type PermissionMode, type HarnessPermissionOverride,
+  getBudgetGuard, setBudgetGuard,
+  type PermissionMode, type HarnessPermissionOverride, type BudgetGuardConfig,
 } from "../../lib/preferences";
 import { BUILTIN_HARNESSES } from "../../lib/harness-definitions";
 import { TOOL_NAMES } from "../../lib/tool-names";
@@ -723,6 +724,16 @@ export default function PermissionsPage() {
   const [confirmPreset, setConfirmPreset] = useState<SecurityPreset | null>(null);
   const [dirty, setDirty] = useState(false);
 
+  const [budgetGuard, setBudgetGuardState] = useState<BudgetGuardConfig>(() => getBudgetGuard());
+
+  function handleBudgetGuardChange(update: Partial<BudgetGuardConfig>) {
+    setBudgetGuardState((prev) => {
+      const next = { ...prev, ...update };
+      setBudgetGuard(next);
+      return next;
+    });
+  }
+
   // HarnessKit permission mode (localStorage)
   const [autoUnlocked, setAutoUnlockedState] = useState<boolean>(getAutoModeUnlocked);
   const [mode, setMode] = useState<PermissionMode>(getPermissionMode);
@@ -1163,6 +1174,88 @@ export default function PermissionsPage() {
             </button>
           </>
         )}
+      </section>
+
+      {/* ── Daily Budget Guard ─────────────────────────────────── */}
+      <section style={{ marginTop: "32px" }}>
+        <h2 style={{ fontSize: "14px", fontWeight: 600, color: "var(--fg-base)", margin: "0 0 12px" }}>
+          Daily Budget Guard
+        </h2>
+        <div style={{
+          background: "var(--bg-surface)",
+          border: "1px solid var(--border-base)",
+          borderRadius: "8px",
+          padding: "16px",
+          display: "flex",
+          flexDirection: "column",
+          gap: "14px",
+        }}>
+          {/* Enable toggle */}
+          <label style={{ display: "flex", alignItems: "center", gap: "10px", cursor: "pointer" }}>
+            <input
+              type="checkbox"
+              checked={budgetGuard.enabled}
+              onChange={(e) => handleBudgetGuardChange({ enabled: e.target.checked })}
+              style={{ accentColor: "var(--accent)", width: "14px", height: "14px" }}
+            />
+            <span style={{ fontSize: "13px", color: "var(--fg-base)", fontWeight: 500 }}>
+              Enable daily budget alerts
+            </span>
+          </label>
+
+          {budgetGuard.enabled && (
+            <>
+              {/* Token limit */}
+              <div style={{ display: "flex", flexDirection: "column", gap: "5px" }}>
+                <label style={{ fontSize: "11px", fontWeight: 600, color: "var(--fg-subtle)", textTransform: "uppercase", letterSpacing: "0.06em" }}>
+                  Daily token limit (optional)
+                </label>
+                <input
+                  type="number"
+                  min={0}
+                  step={10000}
+                  placeholder="e.g. 500000"
+                  value={budgetGuard.dailyTokenLimit ?? ""}
+                  onChange={(e) => handleBudgetGuardChange({
+                    dailyTokenLimit: e.target.value ? Number(e.target.value) : undefined,
+                  })}
+                  style={{
+                    fontSize: "13px", padding: "7px 10px", borderRadius: "6px",
+                    border: "1px solid var(--border-base)", background: "var(--bg-elevated)",
+                    color: "var(--fg-base)", width: "200px",
+                  }}
+                />
+              </div>
+
+              {/* Cost limit */}
+              <div style={{ display: "flex", flexDirection: "column", gap: "5px" }}>
+                <label style={{ fontSize: "11px", fontWeight: 600, color: "var(--fg-subtle)", textTransform: "uppercase", letterSpacing: "0.06em" }}>
+                  Daily cost limit in USD (optional)
+                </label>
+                <input
+                  type="number"
+                  min={0}
+                  step={0.5}
+                  placeholder="e.g. 5.00"
+                  value={budgetGuard.dailyEstimatedCostUSD ?? ""}
+                  onChange={(e) => handleBudgetGuardChange({
+                    dailyEstimatedCostUSD: e.target.value ? Number(e.target.value) : undefined,
+                  })}
+                  style={{
+                    fontSize: "13px", padding: "7px 10px", borderRadius: "6px",
+                    border: "1px solid var(--border-base)", background: "var(--bg-elevated)",
+                    color: "var(--fg-base)", width: "200px",
+                  }}
+                />
+              </div>
+
+              <p style={{ margin: 0, fontSize: "12px", color: "var(--fg-subtle)" }}>
+                When today's usage exceeds a limit, an alert banner appears in Observatory.
+                Limits are checked against estimated cost using Anthropic public pricing.
+              </p>
+            </>
+          )}
+        </div>
       </section>
     </div>
   );

--- a/apps/desktop/src/pages/security/__tests__/PermissionsPage.test.tsx
+++ b/apps/desktop/src/pages/security/__tests__/PermissionsPage.test.tsx
@@ -30,6 +30,8 @@ vi.mock("../../../lib/preferences", () => ({
   getAutoModeUnlocked: () => false,
   setAutoModeUnlocked: vi.fn(),
   DEFAULT_ALLOWED_TOOLS: ["Read", "Grep", "Glob"],
+  getBudgetGuard: () => ({ enabled: false }),
+  setBudgetGuard: vi.fn(),
 }));
 
 // ── Fixtures ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds estimated cost tracking per model using live token data already collected by Observatory
- Adds configurable daily budget alerts (token limit + cost limit) with dismissable banner
- Pure TypeScript — no new Rust commands; reuses existing `compute_live_stats` data

## Changes

- `src/lib/pricing.ts` — `MODEL_PRICING` table + `estimateCost` / `estimateTotalCost` / `formatCost` helpers
- `src/lib/preferences.ts` — `BudgetGuardConfig` type + `getBudgetGuard` / `setBudgetGuard`
- `src/components/observatory/CostBreakdownSection.tsx` — model cost table sorted by cost descending
- `src/components/observatory/BudgetAlertBanner.tsx` — amber dismissable banner when daily limit exceeded
- `src/pages/observatory/DashboardPage.tsx` — 6th stat card (Est. Cost), budget alert, cost breakdown section
- `src/pages/security/PermissionsPage.tsx` — Daily Budget Guard settings (toggle + token/cost limits)
- 12 pricing tests, 5 cost breakdown tests, 6 budget alert tests

## Test plan

- [ ] All existing tests pass (`pnpm test --run`)
- [ ] Observatory shows "Est. Cost" stat card
- [ ] Budget banner appears when a daily limit is configured and exceeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)