### PR TITLE
fix(desktop): use IndexedRandom::choose for rand 0.10 compatibility

### DIFF
--- a/apps/desktop/src-tauri/src/relay_server.rs
+++ b/apps/desktop/src-tauri/src/relay_server.rs
@@ -76,12 +76,12 @@ pub type SharedRelayState = Arc<Mutex<RelayState>>;
 // ── Room code generation ─────────────────────────────────────
 
 fn generate_code() -> String {
-    use rand::Rng;
+    use rand::seq::IndexedRandom;
     let mut rng = rand::rng();
     let consonants: Vec<char> = "BCDFGHJKLMNPQRSTVWXYZ".chars().collect();
     let alphanum: Vec<char> = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789".chars().collect();
-    let prefix: String = (0..3).map(|_| consonants[rng.random_range(0..consonants.len())]).collect();
-    let suffix: String = (0..3).map(|_| alphanum[rng.random_range(0..alphanum.len())]).collect();
+    let prefix: String = (0..3).map(|_| *consonants.choose(&mut rng).unwrap()).collect();
+    let suffix: String = (0..3).map(|_| *alphanum.choose(&mut rng).unwrap()).collect();
     format!("{}-{}", prefix, suffix)
 }
 


### PR DESCRIPTION
## Summary
- Replaces `rng.random_range()` with `slice.choose()` in `generate_code()` in `relay_server.rs`
- `random_range` on `ThreadRng` is not available in rand 0.10.x; `IndexedRandom::choose` works across both rand 0.9 and 0.10
- Unblocks the Dependabot PR that bumps `rand` to 0.10.1 (previously closed as #121)

## Test plan
- [ ] `cargo check` passes locally against rand 0.9 ✓
- [ ] CI desktop-build-test passes
- [ ] After merge, re-open/recreate Dependabot rand 0.10.1 bump PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)