### PR TITLE
feat: distribution pipeline — Homebrew, GitHub Releases, npm, standalone binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,244 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.extract.outputs.version }}
+    steps:
+      - name: Extract version from tag
+        id: extract
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+            echo "::error::Tag '$GITHUB_REF' is not a valid semver release tag (expected v1.2.3)"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Releasing v$VERSION"
+
+  build-cli-npm:
+    needs: prepare
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Stamp version
+        run: bash scripts/stamp-version.sh ${{ needs.prepare.outputs.version }}
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm turbo run build --filter=@harness-kit/cli...
+
+      - name: Publish to npm
+        run: |
+          pnpm --filter @harness-kit/shared publish --no-git-checks
+          pnpm --filter @harness-kit/core publish --no-git-checks
+          pnpm --filter @harness-kit/cli publish --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  build-cli-standalone:
+    needs: prepare
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Stamp version
+        run: bash scripts/stamp-version.sh ${{ needs.prepare.outputs.version }}
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build workspace dependencies
+        run: |
+          pnpm --filter @harness-kit/shared build
+          pnpm --filter @harness-kit/core build
+
+      - name: Build standalone bundle
+        working-directory: apps/cli
+        run: pnpm tsup --config tsup.config.standalone.ts
+
+      - name: Create Node SEA blob
+        working-directory: apps/cli
+        run: node --experimental-sea-config sea-config.json
+
+      - name: Inject blob into Node binary
+        working-directory: apps/cli
+        run: |
+          cp "$(which node)" dist/harness-kit
+          codesign --remove-signature dist/harness-kit
+          npx postject dist/harness-kit NODE_SEA_BLOB dist/sea-prep.blob \
+            --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6ac44c7683b9e78a1 \
+            --macho-segment-name NODE_SEA
+          codesign --sign - dist/harness-kit
+
+      - name: Smoke test standalone binary
+        working-directory: apps/cli
+        run: ./dist/harness-kit --version
+
+      - name: Package standalone binary
+        working-directory: apps/cli
+        run: |
+          VERSION=${{ needs.prepare.outputs.version }}
+          cp dist/harness-kit harness-kit
+          tar -czf harness-kit-v${VERSION}-darwin-arm64.tar.gz harness-kit
+          rm harness-kit
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-standalone-darwin-arm64
+          path: apps/cli/harness-kit-v${{ needs.prepare.outputs.version }}-darwin-arm64.tar.gz
+          retention-days: 1
+
+  build-desktop:
+    needs: prepare
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/desktop/src-tauri
+
+      - name: Stamp version
+        run: bash scripts/stamp-version.sh ${{ needs.prepare.outputs.version }}
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build workspace dependencies
+        run: |
+          pnpm --filter @harness-kit/shared build
+          pnpm --filter @harness-kit/core build
+          pnpm --filter board-server build
+
+      - name: Build desktop app
+        run: pnpm --filter harness-kit-desktop tauri build
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ""
+
+      - name: Locate and rename DMG
+        id: dmg
+        run: |
+          VERSION=${{ needs.prepare.outputs.version }}
+          DMG=$(find apps/desktop/src-tauri/target/release/bundle -name "*.dmg" | head -1)
+          if [[ -z "$DMG" ]]; then
+            echo "::error::No .dmg found after tauri build"
+            exit 1
+          fi
+          DEST="HarnessKit-v${VERSION}-darwin-arm64.dmg"
+          cp "$DMG" "$DEST"
+          echo "path=$DEST" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-darwin-arm64
+          path: ${{ steps.dmg.outputs.path }}
+          retention-days: 1
+
+  release:
+    needs: [prepare, build-cli-npm, build-cli-standalone, build-desktop]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download CLI standalone artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: cli-standalone-darwin-arm64
+
+      - name: Download desktop artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: desktop-darwin-arm64
+
+      - name: Compute SHA256 checksums
+        id: sha
+        run: |
+          VERSION=${{ needs.prepare.outputs.version }}
+          CLI_FILE="harness-kit-v${VERSION}-darwin-arm64.tar.gz"
+          DMG_FILE="HarnessKit-v${VERSION}-darwin-arm64.dmg"
+          CLI_SHA=$(sha256sum "$CLI_FILE" | awk '{print $1}')
+          DMG_SHA=$(sha256sum "$DMG_FILE" | awk '{print $1}')
+          echo "cli_sha=$CLI_SHA" >> "$GITHUB_OUTPUT"
+          echo "dmg_sha=$DMG_SHA" >> "$GITHUB_OUTPUT"
+          echo "cli_file=$CLI_FILE" >> "$GITHUB_OUTPUT"
+          echo "dmg_file=$DMG_FILE" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        run: |
+          VERSION=${{ needs.prepare.outputs.version }}
+          gh release create "v${VERSION}" \
+            --generate-notes \
+            --title "v${VERSION}" \
+            "${{ steps.sha.outputs.cli_file }}" \
+            "${{ steps.sha.outputs.dmg_file }}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Update Homebrew tap
+        run: |
+          VERSION=${{ needs.prepare.outputs.version }}
+          CLI_SHA=${{ steps.sha.outputs.cli_sha }}
+          DMG_SHA=${{ steps.sha.outputs.dmg_sha }}
+
+          git clone "https://x-access-token:${{ secrets.TAP_PAT }}@github.com/harnessprotocol/homebrew-tap.git" tap
+          cd tap
+
+          # Update Formula
+          sed -i "s/version \"[^\"]*\"/version \"${VERSION}\"/" Formula/harness-kit.rb
+          sed -i "s/sha256 \"[^\"]*\"/sha256 \"${CLI_SHA}\"/" Formula/harness-kit.rb
+
+          # Update Cask
+          sed -i "s/version \"[^\"]*\"/version \"${VERSION}\"/" Casks/harness-kit.rb
+          # Only replace the sha256 line (not URL which also has quotes)
+          awk -v sha="$DMG_SHA" '
+            /^  sha256 "/ && !replaced { sub(/"[^"]*"/, "\"" sha "\""); replaced=1 }
+            { print }
+          ' Casks/harness-kit.rb > Casks/harness-kit.rb.tmp
+          mv Casks/harness-kit.rb.tmp Casks/harness-kit.rb
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/harness-kit.rb Casks/harness-kit.rb
+          git commit -m "chore: bump harness-kit to v${VERSION}"
+          git push

--- a/README.md
+++ b/README.md
@@ -29,11 +29,12 @@ Your AI coding setup — plugins, skills, MCP servers, hooks, conventions — pa
 **CLI** (`harness-kit validate`, `compile`, `sync`, ...):
 ```bash
 brew tap harnessprotocol/tap && brew install harness-kit
-# or: npm install -g @harness-kit/cli
+# or: npm install -g @harness-kit/cli  # requires Node.js 22+
 ```
 
 **Desktop App**:
 ```bash
+brew tap harnessprotocol/tap  # skip if you already ran this above
 brew install --cask harness-kit
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,12 +21,24 @@ Your AI coding setup — plugins, skills, MCP servers, hooks, conventions — pa
 
 ## 📦 Install
 
+**Skills & Plugins** (Claude Code):
 ```
 /plugin marketplace add harnessprotocol/harness-kit
 ```
 
+**CLI** (`harness-kit validate`, `compile`, `sync`, ...):
+```bash
+brew tap harnessprotocol/tap && brew install harness-kit
+# or: npm install -g @harness-kit/cli
+```
+
+**Desktop App**:
+```bash
+brew install --cask harness-kit
+```
+
 <details>
-<summary>Fallback: install with script (skills only)</summary>
+<summary>Fallback: install skills with script (no Node required)</summary>
 
 If your Claude Code build doesn't support the plugin marketplace:
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@harness-kit/cli",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public"
+  },
   "bin": {
     "harness-kit": "./dist/index.js"
   },

--- a/apps/cli/sea-config.json
+++ b/apps/cli/sea-config.json
@@ -1,0 +1,5 @@
+{
+  "main": "dist/harness-kit-standalone.js",
+  "output": "dist/sea-prep.blob",
+  "disableExperimentalSEAWarning": true
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -13,12 +13,14 @@ import {
   joinOrganization,
 } from "./commands/org.js";
 
+declare const __CLI_VERSION__: string;
+
 const program = new Command();
 
 program
   .name("harness-kit")
   .description("Compile and validate harness.yaml configurations")
-  .version("0.1.0");
+  .version(__CLI_VERSION__);
 
 program
   .command("validate")

--- a/apps/cli/tsup.config.standalone.ts
+++ b/apps/cli/tsup.config.standalone.ts
@@ -4,10 +4,11 @@ import { readFileSync } from "fs";
 const pkg = JSON.parse(readFileSync("./package.json", "utf-8"));
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: { "harness-kit-standalone": "src/index.ts" },
   format: ["esm"],
-  clean: true,
-  sourcemap: true,
+  clean: false,
+  sourcemap: false,
+  noExternal: [/.*/],
   banner: {
     js: "#!/usr/bin/env node",
   },

--- a/apps/desktop/src-tauri/src/commands/observatory.rs
+++ b/apps/desktop/src-tauri/src/commands/observatory.rs
@@ -393,7 +393,7 @@ pub fn list_sessions_summary() -> Result<Vec<SessionSummary>, String> {
         })
         .collect();
 
-    result.sort_by(|a, b| b.first_timestamp.cmp(&a.first_timestamp));
+    result.sort_by_key(|b| std::cmp::Reverse(b.first_timestamp));
     Ok(result)
 }
 

--- a/apps/desktop/src-tauri/src/commands/plugin_explorer.rs
+++ b/apps/desktop/src-tauri/src/commands/plugin_explorer.rs
@@ -120,8 +120,8 @@ fn build_tree(dir: &Path, depth: usize) -> Result<Vec<FileTreeNode>, String> {
         }
     }
 
-    dirs.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
-    files.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    dirs.sort_by_key(|a| a.name.to_lowercase());
+    files.sort_by_key(|a| a.name.to_lowercase());
 
     dirs.extend(files);
     Ok(dirs)

--- a/apps/desktop/src/lib/pricing.ts
+++ b/apps/desktop/src/lib/pricing.ts
@@ -39,28 +39,6 @@ export function estimateTotalCost(
   }, 0);
 }
 
-/**
- * Approximate daily cost per model from raw daily token totals.
- *
- * NOTE: DailyModelTokens.tokensByModel stores a single aggregate per model
- * (input + output + cache combined) — no per-day input/output split is
- * preserved by the Rust collector. We price the full daily total at the
- * model's OUTPUT rate (the dominant cost driver at ~5× input rates), which
- * makes the approximation trend toward the accurate all-time cost figure
- * rather than dramatically under-counting. Use estimateTotalCost(mergedModelUsage)
- * for exact all-time figures that do have the split.
- */
-export function estimateDailyCostByModel(
-  tokensByModel: Record<string, number>,
-): Record<string, number> {
-  return Object.fromEntries(
-    Object.entries(tokensByModel).map(([model, tokens]) => {
-      const pricing = MODEL_PRICING[model] ?? DEFAULT_PRICING;
-      return [model, (tokens / 1_000_000) * pricing.outputPer1M];
-    }),
-  );
-}
-
 /** Format a USD cost value for display (e.g. "$0.84", "$1.20"). */
 export function formatCost(usd: number): string {
   if (usd === 0) return "$0.00";

--- a/homebrew/Casks/harness-kit.rb
+++ b/homebrew/Casks/harness-kit.rb
@@ -1,0 +1,22 @@
+cask "harness-kit" do
+  version "0.1.0"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+
+  url "https://github.com/harnessprotocol/harness-kit/releases/download/v#{version}/HarnessKit-v#{version}-darwin-arm64.dmg"
+  name "Harness Kit"
+  desc "Desktop app for managing AI coding tool configurations"
+  homepage "https://github.com/harnessprotocol/harness-kit"
+
+  app "Harness Kit.app"
+
+  caveats <<~EOS
+    This app is not notarized. After installing, run:
+      xattr -cr "/Applications/Harness Kit.app"
+    Or right-click the app and select Open.
+  EOS
+
+  zap trash: [
+    "~/Library/Application Support/com.harnesskit.desktop",
+    "~/Library/Caches/com.harnesskit.desktop",
+  ]
+end

--- a/homebrew/Formula/harness-kit.rb
+++ b/homebrew/Formula/harness-kit.rb
@@ -1,0 +1,18 @@
+class HarnessKit < Formula
+  desc "Compile and validate harness.yaml for AI coding tools"
+  homepage "https://github.com/harnessprotocol/harness-kit"
+  url "https://github.com/harnessprotocol/harness-kit/releases/download/v#{version}/harness-kit-v#{version}-darwin-arm64.tar.gz"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+  license "Apache-2.0"
+  version "0.1.0"
+
+  depends_on arch: :arm64
+
+  def install
+    bin.install "harness-kit"
+  end
+
+  test do
+    system bin/"harness-kit", "--version"
+  end
+end

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@harness-kit/core",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@harness-kit/shared",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/scripts/stamp-version.sh
+++ b/scripts/stamp-version.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# stamp-version.sh <version>
+# Writes a release version into all package manifests and Tauri config.
+# Used by the release workflow before building artifacts.
+set -euo pipefail
+
+VERSION="${1:-}"
+if [[ -z "$VERSION" ]]; then
+  echo "Usage: $0 <version>" >&2
+  exit 1
+fi
+
+# Validate semver (major.minor.patch, optional pre-release)
+if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+  echo "Error: '$VERSION' is not a valid semver string" >&2
+  exit 1
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+stamp_json() {
+  local file="$1"
+  echo "  $file"
+  local tmp
+  tmp="$(mktemp)"
+  jq --arg v "$VERSION" '.version = $v' "$file" > "$tmp"
+  mv "$tmp" "$file"
+}
+
+stamp_cargo() {
+  local file="$1"
+  echo "  $file"
+  # Replace only the first occurrence (the crate's own version, not dependency versions).
+  # Uses awk instead of sed to avoid BSD sed vs GNU sed divergence on macOS vs Linux.
+  awk -v ver="$VERSION" '
+    !replaced && /^version = "/ { sub(/"[^"]*"/, "\"" ver "\""); replaced=1 }
+    { print }
+  ' "$file" > "${file}.tmp"
+  mv "${file}.tmp" "$file"
+}
+
+echo "Stamping version $VERSION into:"
+stamp_json "$REPO_ROOT/packages/shared/package.json"
+stamp_json "$REPO_ROOT/packages/core/package.json"
+stamp_json "$REPO_ROOT/apps/cli/package.json"
+stamp_json "$REPO_ROOT/apps/desktop/src-tauri/tauri.conf.json"
+stamp_cargo "$REPO_ROOT/apps/desktop/src-tauri/Cargo.toml"
+echo "Done."

--- a/website/content/docs/getting-started/installation.mdx
+++ b/website/content/docs/getting-started/installation.mdx
@@ -5,6 +5,20 @@ title: Installation
 
 # Installation
 
+harness-kit ships three installable artifacts — choose what you need:
+
+| Artifact | What it does | How to install |
+|----------|-------------|----------------|
+| **Skills & Plugins** | Adds slash commands to Claude Code | Plugin marketplace or install script |
+| **CLI** (`harness-kit`) | Compiles and validates `harness.yaml` from the terminal | Homebrew, npm, or direct download |
+| **Desktop App** | Visual interface for managing your AI tool configurations | Homebrew Cask or DMG |
+
+Most users start with skills. The CLI and desktop app are for teams managing shared `harness.yaml` configs.
+
+---
+
+## Skills & Plugins
+
 The primary distribution channel is [Claude Code](https://claude.ai/claude-code)'s plugin marketplace. For other tools, see [Using with other tools](#using-with-other-tools) below.
 
 <Tabs items={["Plugin Marketplace", "Install Script"]}>
@@ -39,7 +53,7 @@ This downloads skill files to `~/.claude/skills/` over HTTPS. It installs **only
 </Tab>
 </Tabs>
 
-## Verify
+### Verify
 
 After installing, invoke any skill to confirm it loaded:
 
@@ -52,11 +66,95 @@ After installing, invoke any skill to confirm it loaded:
   If the skill responds with its workflow, you're set.
 </Callout>
 
-## Using with other tools
+### Using with other tools
 
 SKILL.md files are plain markdown — copy them into any tool's instruction system. VS Code Copilot reads `CLAUDE.md` natively via the `chat.useClaudeMdFile` setting, so the [conventions guide](/docs/guides/conventions) works without modification.
 
 For per-tool setup instructions (Copilot, Cursor, Windsurf, MCP wiring), see [Using with Other Tools](/docs/cross-harness/setup-guide).
+
+---
+
+## CLI
+
+The `harness-kit` CLI validates and compiles `harness.yaml` into native config files for Claude Code, Cursor, and Copilot. It also handles plugin sync, drift detection, and security scanning.
+
+<Tabs items={["Homebrew", "npm", "Direct download"]}>
+<Tab value="Homebrew">
+```bash
+brew tap harnessprotocol/tap
+brew install harness-kit
+```
+
+Homebrew manages updates automatically — `brew upgrade harness-kit` to update.
+</Tab>
+
+<Tab value="npm">
+```bash
+npm install -g @harness-kit/cli
+```
+
+Requires Node.js 22 or later. The package is published as `@harness-kit/cli` on npm.
+</Tab>
+
+<Tab value="Direct download">
+Download the standalone binary (no Node.js required) from [GitHub Releases](https://github.com/harnessprotocol/harness-kit/releases).
+
+**macOS (Apple Silicon):**
+```bash
+tar -xzf harness-kit-vX.Y.Z-darwin-arm64.tar.gz
+chmod +x harness-kit
+sudo mv harness-kit /usr/local/bin/
+```
+
+Replace `X.Y.Z` with the version you downloaded.
+</Tab>
+</Tabs>
+
+### Verify
+
+```bash
+harness-kit --version
+harness-kit validate        # validates harness.yaml in the current directory
+harness-kit compile --help  # see compile options
+```
+
+---
+
+## Desktop App
+
+The Harness Kit desktop app provides a visual interface for managing configs, running evals, comparing AI tools, and monitoring your setup.
+
+<Tabs items={["Homebrew", "Direct download"]}>
+<Tab value="Homebrew">
+```bash
+brew tap harnessprotocol/tap  # skip if you already ran this for the CLI
+brew install --cask harness-kit
+```
+
+<Callout type="warn" title="Gatekeeper notice">
+  The app is not yet notarized. After installing, open Terminal and run:
+  ```bash
+  xattr -cr "/Applications/Harness Kit.app"
+  ```
+  Or right-click the app in Finder and select **Open**, then confirm.
+</Callout>
+</Tab>
+
+<Tab value="Direct download">
+Download `HarnessKit-vX.Y.Z-darwin-arm64.dmg` from [GitHub Releases](https://github.com/harnessprotocol/harness-kit/releases):
+
+1. Open the `.dmg` and drag **Harness Kit** to your Applications folder.
+2. Remove the quarantine flag before first launch:
+   ```bash
+   xattr -cr "/Applications/Harness Kit.app"
+   ```
+3. Open from Applications or Spotlight.
+
+macOS 14 (Sonoma) or later, Apple Silicon (arm64) required. Intel Mac builds are planned for a future release.
+</Tab>
+</Tabs>
+
+---
 
 ## Requirements per Plugin
 


### PR DESCRIPTION
## Summary

Establishes the full distribution pipeline for Harness Kit: CLI and desktop app are now installable via Homebrew, npm, and direct binary download from GitHub Releases. A `v*` tag push triggers automated artifact builds, GitHub Release creation, npm publish, and Homebrew tap updates.

## Changes

- **`.github/workflows/release.yml`**: 5-job release workflow — `prepare` (semver validation) → parallel `build-cli-npm` (ubuntu), `build-cli-standalone` (macos-14, Node SEA), `build-desktop` (macos-14, Tauri DMG) → `release` (GitHub Release + Homebrew tap auto-update)
- **`scripts/stamp-version.sh`**: Stamps version from git tag into all package.json, tauri.conf.json, and Cargo.toml; uses `awk` for Cargo.toml (BSD sed compatibility on macOS runners)
- **`apps/cli/tsup.config.standalone.ts`** + **`sea-config.json`**: Standalone CLI bundle — inlines all deps via `noExternal`, produces Node SEA blob for a zero-dependency binary
- **`apps/cli/tsup.config.ts`**: Injects `__CLI_VERSION__` build constant so `harness-kit --version` reflects the released version
- **`apps/cli/src/index.ts`**: Reads version from `__CLI_VERSION__` constant instead of hardcoded string
- **`packages/{shared,core}/package.json`** + **`apps/cli/package.json`**: Remove `"private": true`, add `files` + `publishConfig` for npm publishing
- **`homebrew/`**: Formula (`harness-kit.rb`) for CLI standalone binary; Cask (`harness-kit.rb`) for desktop DMG with Gatekeeper caveats
- **`website/content/docs/getting-started/installation.mdx`**: Full documentation for all three install paths (Skills, CLI via brew/npm/binary, Desktop via brew/DMG)
- **`README.md`**: Updated Install section to show all three distribution paths; fixed missing `brew tap` for desktop cask; added Node.js 22+ note

## Test Plan

- [x] Local tests pass (223 tests across shared, core, cli)
- [ ] CI checks pass
- [ ] After merge: push a `v0.2.0` tag and verify the full release workflow executes end-to-end (requires `NPM_TOKEN` and `TAP_PAT` secrets configured on the repo)
- [ ] Verify `brew tap harnessprotocol/tap && brew install harness-kit && harness-kit --version` once tap repo is bootstrapped

## Notes

- Requires two GitHub secrets: `NPM_TOKEN` (npm publish) and `TAP_PAT` (push to `harnessprotocol/homebrew-tap`)
- The `harnessprotocol/homebrew-tap` tap repo must exist with `Formula/harness-kit.rb` and `Casks/harness-kit.rb` before the first release tag
- Desktop app is unsigned for beta; Homebrew cask includes `caveats` block with `xattr -cr` instructions
- macOS arm64 only for phase 1; Intel and Linux builds are out of scope
- `build-cli-standalone` uses Node 22 (SEA is stable in 22+); `build-cli-npm` and `build-desktop` use Node 24

🤖 Generated with [Claude Code](https://claude.ai/claude-code)