### PR TITLE
docs: add direct DMG download option to README and installation page

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ brew tap harnessprotocol/tap && brew install harness-kit
 brew tap harnessprotocol/tap  # skip if you already ran this above
 brew install --cask harness-kit
 ```
+Or download the `.dmg` directly from the [latest release](https://github.com/harnessprotocol/harness-kit/releases/latest) and drag **Harness Kit.app** to `/Applications`. Note: the app is not notarized — right-click and select **Open** on first launch.
 
 <details>
 <summary>Fallback: install skills with script (no Node required)</summary>

--- a/website/content/docs/getting-started/installation.mdx
+++ b/website/content/docs/getting-started/installation.mdx
@@ -141,7 +141,7 @@ brew install --cask harness-kit
 </Tab>
 
 <Tab value="Direct download">
-Download `HarnessKit-vX.Y.Z-darwin-arm64.dmg` from [GitHub Releases](https://github.com/harnessprotocol/harness-kit/releases):
+Download `HarnessKit-vX.Y.Z-darwin-arm64.dmg` from the [latest release](https://github.com/harnessprotocol/harness-kit/releases/latest):
 
 1. Open the `.dmg` and drag **Harness Kit** to your Applications folder.
 2. Remove the quarantine flag before first launch:


### PR DESCRIPTION
## Summary

- README: adds a direct DMG download line under the Desktop App install section, with Gatekeeper caveat and a link to `releases/latest`
- Installation docs: aligns the direct download tab to link to `releases/latest` instead of the full releases list for consistency

🤖 Generated with [Claude Code](https://claude.ai/claude-code)