### PR TITLE
feat(docs): agent skill banner, install page redesign, CSS polish

### DIFF
--- a/skills/harness-docs/SKILL.md
+++ b/skills/harness-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-docs
-description: Harness Kit documentation — installation, plugin catalog, creating plugins, cross-harness setup, architecture, and FAQ. Use when working with or configuring harness-kit plugins, understanding the plugin/skill system, installing slash commands, setting up AI coding tool configuration, answering questions about the plugin marketplace, writing SKILL.md files, using harness.yaml, or integrating with Copilot, Cursor, or Windsurf. Do NOT use for general Claude Code questions unrelated to harness-kit.
+description: Harness Kit documentation — installation, plugin catalog, creating plugins, cross-harness setup, architecture, and FAQ. Use when working with or configuring harness-kit plugins, understanding the plugin/skill system, installing slash commands, setting up AI coding tool configuration, answering questions about the plugin marketplace, writing SKILL.md files, using harness.yaml, or integrating with Copilot, Cursor, or Codex. Do NOT use for general Claude Code questions unrelated to harness-kit.
 user-invocable: false
 ---
 
@@ -20,7 +20,7 @@ This is a background knowledge skill. When the user asks about harness-kit, load
 | Installation, architecture, quick start | `getting-started.md` |
 | Plugin list, what each plugin does | `plugin-catalog.md` |
 | Creating plugins, writing SKILL.md, frontmatter | `creating-plugins.md` |
-| Using with Copilot, Cursor, Windsurf | `cross-harness.md` |
+| Using with Copilot, Cursor, Codex | `cross-harness.md` |
 | Core concepts, FAQ, harness.yaml, comparison with MCP/A2A | `concepts-and-faq.md` |
 
 Load with: `Read ${CLAUDE_SKILL_DIR}/references/<filename>.md`

--- a/skills/harness-docs/SKILL.md
+++ b/skills/harness-docs/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: harness-docs
+description: Harness Kit documentation — installation, plugin catalog, creating plugins, cross-harness setup, architecture, and FAQ. Use when working with or configuring harness-kit plugins, understanding the plugin/skill system, installing slash commands, setting up AI coding tool configuration, answering questions about the plugin marketplace, writing SKILL.md files, using harness.yaml, or integrating with Copilot, Cursor, or Windsurf. Do NOT use for general Claude Code questions unrelated to harness-kit.
+user-invocable: false
+---
+
+# Harness Kit Documentation
+
+harness-kit is a harness-agnostic framework for AI coding tools. Plugins, skills, MCP servers, hooks, and conventions live in one portable config. It works with Claude Code today and is designed to travel across tools.
+
+**Repo:** https://github.com/harnessprotocol/harness-kit  
+**Docs:** https://harnesskit.ai/docs
+
+## How to Use This Skill
+
+This is a background knowledge skill. When the user asks about harness-kit, load the relevant reference file from `${CLAUDE_SKILL_DIR}/references/` and answer from it.
+
+| Topic | Reference file |
+|-------|---------------|
+| Installation, architecture, quick start | `getting-started.md` |
+| Plugin list, what each plugin does | `plugin-catalog.md` |
+| Creating plugins, writing SKILL.md, frontmatter | `creating-plugins.md` |
+| Using with Copilot, Cursor, Windsurf | `cross-harness.md` |
+| Core concepts, FAQ, harness.yaml, comparison with MCP/A2A | `concepts-and-faq.md` |
+
+Load with: `Read ${CLAUDE_SKILL_DIR}/references/<filename>.md`
+
+## Quick Reference: 16 Plugins
+
+| Plugin | Slash command | What it does |
+|--------|---------------|-------------|
+| research | `/research` | Process any source (URL, GitHub, YouTube, PDF) into a structured knowledge base |
+| orient | `/orient` | Topic-focused session orientation across knowledge graph and research |
+| capture | `/capture` | Capture session info into a staging file for later reflection |
+| review | `/review` | Structured code review for branches, PRs, or file paths with severity labels |
+| explain | `/explain` | Layered explanations of files, functions, directories, or concepts |
+| lineage | `/lineage` | Column-level lineage tracing through SQL, Kafka, Spark, JDBC |
+| docgen | `/docgen` | Generate or update README, API docs, architecture overview, or changelog |
+| open-pr | `/open-pr` | Pre-flight checks and PR creation: tests, review, CI |
+| merge-pr | `/merge-pr` | Merge a ready PR: verify CI, sync base, squash merge, clean up |
+| pr-sweep | `/pr-sweep` | Cross-repo PR sweep: triage, review, merge, fix CI |
+| harness-share | `/harness-export`, `/harness-import` | Compile, export, import, and sync harness configs across AI tools |
+| stats | `/stats` | Interactive HTML dashboard for Claude Code token and session usage |
+| iterm-notify | — | macOS desktop notifications and iTerm2 badge management for Claude Code events |
+| board | `/board` | Kanban project board with real-time Claude-to-web sync via MCP |
+| frontend-design | `/frontend-design` | Production-grade frontend design rules: OKLCH color, typography, motion, accessibility |
+| membrain | `/membrain` | Graph-based agent memory — search, trace, and manage a persistent knowledge graph |
+
+## Key Concepts
+
+**Skill** — A `SKILL.md` file: the workflow Claude reads when you type a slash command.  
+**Plugin** — The package wrapping a skill: a directory with `plugin.json`, the skill, optional scripts, hooks, and agents.  
+**harness** — Your complete AI tool setup: CLAUDE.md, plugins, MCP servers, hooks, permissions.  
+**harness.yaml** — A portable snapshot of your complete harness. Export with `/harness-export`, restore with `/harness-import`.
+
+## Install
+
+```
+/plugin marketplace add harnessprotocol/harness-kit
+/plugin install <plugin-name>@harness-kit
+```

--- a/skills/harness-docs/references/concepts-and-faq.md
+++ b/skills/harness-docs/references/concepts-and-faq.md
@@ -1,0 +1,122 @@
+# Concepts and FAQ
+
+<!-- Source: website/content/docs/concepts/plugins-vs-skills.md, concepts/comparison.md, faq.md -->
+
+## Core Concepts
+
+### What is harness-kit?
+
+harness-kit is a harness-agnostic framework for AI coding tools. Plugins, skills, MCP servers, hooks, and conventions live in one portable config. It works with Claude Code today and is designed to travel across tools (Copilot, Cursor, Windsurf, whatever comes next).
+
+Plugins are the entry point: installable slash commands that bundle complete workflows and follow you across every project. Export your full setup as a `harness.yaml`, share it with a teammate, and they're up and running.
+
+### What is a harness?
+
+Every AI coding tool has its own setup folder — Claude Code's `~/.claude`, Cursor's `.cursor`, Copilot's config. A **harness** is that setup: the configuration that tells your AI how to work in a given session. **Harness Kit** is the app that operates all of them, collapsing the per-tool harnesses into one `harness.yaml`.
+
+### Skill vs. Plugin
+
+A **skill** is a `SKILL.md` file — the workflow Claude reads when you type a slash command.  
+A **plugin** is the package that wraps it: a directory with the skill, optional scripts, and a version number.  
+You install the plugin; Claude reads the skill.
+
+```
+Marketplace
+ └── Plugin (distribution unit)
+      ├── .claude-plugin/plugin.json    ← metadata, version
+      ├── skills/
+      │    └── my-skill/
+      │         ├── SKILL.md            ← the prompt (runtime unit)
+      │         └── README.md           ← docs
+      ├── agents/                       ← optional specialist workers
+      ├── scripts/                      ← optional automation
+      └── hooks/                        ← optional triggers
+```
+
+### How is SKILL.md different from a regular prompt?
+
+A prompt tells Claude what to do. A SKILL.md specifies how: step ordering, input parsing, output format, error handling, and known failure modes. That structure makes the same command produce consistent output every time.
+
+### Progressive Disclosure (three loading levels)
+
+```
+Level 1: YAML frontmatter          ← always loaded (~100 tokens per skill)
+          name, description          → Claude reads to decide when to activate
+                ↓
+Level 2: SKILL.md body             ← loaded when skill is selected
+          workflow, steps, rules     → actual instructions Claude follows
+                ↓
+Level 3: references/ files         ← loaded on demand
+          tag taxonomies, lookup     → detail pulled in only when needed
+```
+
+This is why description quality matters: Claude reads Level 1 for every installed skill, every turn.
+
+### How many skills can I install?
+
+**20–30 skills** is the practical sweet spot. Claude loads all skill descriptions into roughly 2% of the context window (~16K chars). Beyond ~30 skills, some descriptions may be silently excluded. Run `/context` to check current context usage.
+
+## harness.yaml
+
+A portable snapshot of your complete AI assistant setup. Captures:
+- Plugins (sources and versions)
+- MCP server configurations  
+- Environment variable declarations
+- Instructions injected into CLAUDE.md or AGENT.md
+- Permissions
+
+Export: `/harness-export` — writes `harness.yaml`  
+Restore: `/harness-import harness.yaml` — interactive picker, teammates choose what they want
+
+## How harness-kit Compares
+
+### vs. MCP Servers
+
+MCP servers give your AI new tools — database access, web search, external APIs.  
+harness-kit is about what to do with those tools: structured workflows with defined steps and outputs.  
+They work at different levels and compose well: a `harness.yaml` can declare MCP servers.
+
+### vs. A2A / Claude Agent SDK
+
+| Layer | What it solves | Example |
+|-------|---------------|---------|
+| Configuration | How is this agent set up? | harness-kit |
+| Tool communication | How does the agent call tools? | MCP |
+| Runtime communication | How do agents talk to each other? | A2A |
+| Developer SDK | How do I build an agent? | Claude Agent SDK |
+
+### vs. Just Writing Prompts
+
+Good prompts tend to disappear — scattered across projects, left behind on new machines. Plugins give them a stable home with a version number.
+
+## Harness Protocol
+
+The [Harness Protocol](https://harnessprotocol.io) is an open specification for portable AI coding harness configuration. It defines a vendor-neutral `harness.yaml` format validated by JSON Schema. harness-kit is the reference implementation. Any tool that correctly validates and applies `harness.yaml` per the spec is a conformant implementation.
+
+## FAQ
+
+**Is this safe? What does installing a plugin actually do?**  
+Plugins are plain markdown files. No binaries, no background processes, no network calls on install. Some plugins include shell scripts (like `research`'s index rebuild) that only run when you invoke the skill.
+
+**Do I need to pay for anything?**  
+No. harness-kit is free and open source (Apache 2.0). You only need Claude Code.
+
+**Can I use this across multiple projects?**  
+Yes. Plugins install to your harness globally, not per-project. Project-specific config goes in `CLAUDE.md`.
+
+**Can I modify the built-in plugins?**  
+The installed files are plain text — edit them directly. For something lasting, fork the repo and point your marketplace at your fork.
+
+**Do any plugins need API keys?**  
+Two plugins have optional environment variable dependencies:
+- **research** — `GH_TOKEN` enables fetching from GitHub repos. Without it, research works for all other source types.
+- **review** — `GH_TOKEN` enables reviewing PRs by number. Without it, review works for local branches and paths.
+
+**What is the `harness.yaml.example`?**  
+See https://github.com/harnessprotocol/harness-kit/blob/main/harness.yaml.example for the full format reference.
+
+**I already have prompts in my CLAUDE.md. Should I move them?**  
+Project-specific workflows belong in `CLAUDE.md`. If you find yourself copying the same prompt into every new project, that's a sign it would work better as a plugin.
+
+**How is the open standard defined?**  
+The Agent Skills specification is published at [agentskills.io](https://agentskills.io). Skills built to this spec are portable across Claude Code, Copilot, and any other compliant platform.

--- a/skills/harness-docs/references/creating-plugins.md
+++ b/skills/harness-docs/references/creating-plugins.md
@@ -1,0 +1,232 @@
+# Creating Plugins
+
+<!-- Source: website/content/docs/guides/creating-plugins.md -->
+
+## Directory Structure
+
+```
+plugins/<plugin-name>/
+├── .claude-plugin/
+│   └── plugin.json
+├── agents/               # optional, for specialist subagents
+├── scripts/              # optional, for bundled utilities
+└── skills/
+    └── <skill-name>/
+        ├── SKILL.md
+        └── README.md
+```
+
+Reference bundled files in SKILL.md via `${CLAUDE_SKILL_DIR}`.
+
+## Plugin Manifest (`plugin.json`)
+
+```json
+{
+  "name": "<plugin-name>",
+  "description": "One sentence describing what this plugin does.",
+  "version": "0.1.0"
+}
+```
+
+### Declaring Environment Variables
+
+```json
+{
+  "name": "<plugin-name>",
+  "description": "...",
+  "version": "0.1.0",
+  "requires": {
+    "env": [
+      {
+        "name": "MY_API_KEY",
+        "description": "API key for My Service — used to authenticate requests",
+        "required": false,
+        "sensitive": true,
+        "when": "When the plugin calls My Service"
+      }
+    ]
+  }
+}
+```
+
+Set `required: true` only if the plugin can't function at all without it. Prefer `required: false` with graceful degradation.
+
+## Register in Marketplace
+
+Add to `.claude-plugin/marketplace.json` under `plugins`:
+
+```json
+{
+  "name": "<plugin-name>",
+  "source": "./<plugin-name>",
+  "description": "One sentence describing what this plugin does.",
+  "version": "0.1.0",
+  "author": { "name": "your-github-handle" },
+  "license": "Apache-2.0"
+}
+```
+
+`source` is relative to `pluginRoot` (`./plugins`).
+
+## SKILL.md
+
+The SKILL.md is what Claude Code reads at runtime.
+
+### Frontmatter
+
+```yaml
+---
+name: my-skill
+description: Use when user invokes /my-skill with [argument types]. [Behavior.] Do NOT use for [anti-patterns].
+dependencies: python>=3.10, pandas>=1.5.0
+disable-model-invocation: true
+user-invocable: true
+---
+```
+
+### Frontmatter Field Reference
+
+| Field | Required | Constraint | Purpose |
+|-------|----------|------------|---------|
+| `name` | yes | 64 chars max, lowercase, hyphenated | Slash command name |
+| `description` | yes | 1,024 chars max, no `<` or `>` | Activation trigger — Claude reads this to decide when to load the skill |
+| `dependencies` | no | Comma-separated package specs | Runtime dependencies |
+| `disable-model-invocation` | no | boolean | `true` = only user can invoke, not auto-triggered |
+| `user-invocable` | no | boolean | `false` = Claude-only background knowledge, not a slash command |
+| `context` | no | `fork` | Runs skill in isolated subagent with no conversation history |
+| `agent` | no | `Explore`, `Plan` | Specialized subagent execution environment |
+
+### Description Best Practices
+
+The description is Claude's routing signal — loaded for every installed skill on every turn.
+
+- Start with "Use when" and name the invocation pattern explicitly
+- Include specific phrases a user would type
+- Include negative triggers: "Do NOT use for X — use /other-skill instead"
+- Format: `[What it does] + [When to use it] + [Key triggers] + [Anti-patterns]`
+- No XML angle brackets; max 1,024 characters
+
+Good: `Use when user invokes /research with a URL, GitHub repo, YouTube video, or local file. Processes sources into indexed research. Do NOT use for quick factual questions — use /explain instead.`
+
+### Size Guidelines
+
+- Keep SKILL.md under **500 lines / 5,000 words**
+- Move reference tables, tag taxonomies, and lookup data to `references/` subdirectory
+- Reference bundled files: `${CLAUDE_SKILL_DIR}/references/filename.md`
+- Put critical instructions at the top
+
+```
+skills/
+└── my-skill/
+    ├── SKILL.md
+    └── references/
+        ├── tag-taxonomy.md
+        └── quick-reference.md
+```
+
+### Required Sections
+
+| Section | Required when |
+|---------|--------------|
+| `## Overview` with core principles | Always |
+| `## Workflow` with numbered steps | Always (even 1-step skills) |
+| `## Common Mistakes` table | Any skill with 3+ steps or file writes |
+| `## Scope Controls` | Any skill that touches files |
+| `## Argument Types` table | Any parameterized skill |
+
+### Argument Substitution
+
+`$ARGUMENTS` — full argument string from slash command invocation. Positional: `$0`, `$1`, etc.
+
+```markdown
+## Workflow
+The user invoked: /my-skill $ARGUMENTS
+```
+
+### Dynamic Context Injection
+
+Use `` `!command` `` to run a shell command and inject its output at skill load time:
+
+```markdown
+Current git diff:
+`!git diff main...HEAD`
+```
+
+### Workflow Conventions
+
+- Number all steps. Label mandatory order: `## Workflow (MANDATORY — follow in order)`
+- Each step: one action, concrete command where applicable
+- Use Bash blocks for exact commands Claude should run
+- If a step requires stopping to verify: `**STOP HERE until file is written.**`
+
+## Versioning
+
+Versions in `plugin.json` and `marketplace.json` must always match.
+
+- **Patch** (0.1.0 → 0.1.1): Bug fixes, typos, docs. No behavior change.
+- **Minor** (0.1.0 → 0.2.0): New features. Existing behavior unchanged.
+- **Major** (0.x → 1.0): Breaking changes — renamed commands, removed features, changed output structure.
+
+## Release Checklist
+
+1. Bump `version` in both `plugin.json` and `marketplace.json` (must match)
+2. Commit: `chore: bump <plugin> to vX.Y.Z`
+3. Create release: `gh release create vX.Y.Z --generate-notes`
+
+## CI Validation
+
+Two checks run on every PR:
+- JSON manifests valid: `marketplace.json` and all `plugin.json` files parse without error
+- Version alignment: `version` in `plugin.json` and `marketplace.json` must match exactly
+
+## Agent Definitions (Optional)
+
+If your plugin needs a specialist worker, add agent definitions under `agents/`:
+
+```
+plugins/<plugin-name>/
+├── agents/
+│   └── <agent-name>.md    # YAML frontmatter + system prompt
+```
+
+Minimal agent definition:
+
+```yaml
+---
+name: code-explorer
+description: Read-only codebase explorer
+tools: [Read, Glob, Grep, Bash]
+model: haiku
+permissionMode: plan
+---
+
+You are a read-only codebase explorer. Search, read, and map code structure. Never modify files.
+```
+
+Invoke from a skill:
+```markdown
+## Step 3: Explore the Codebase
+Use the Agent tool with agent `code-explorer` to map the directory structure.
+```
+
+## Hook Scripts (Optional)
+
+Place hooks under `scripts/`. Hooks are NOT auto-configured on install — users must wire them manually in `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "Stop": [{
+      "hooks": [{
+        "type": "command",
+        "command": "${CLAUDE_PLUGIN_ROOT}/scripts/my-hook.sh"
+      }]
+    }]
+  }
+}
+```
+
+Hook best practices:
+- Read hook input from stdin (JSON with `session_id`, `transcript_path`, `cwd`)
+- Exit 0 quickly — hooks block Claude Code's lifecycle
+- Use anti-recursion guards if your hook spawns `claude -p`

--- a/skills/harness-docs/references/cross-harness.md
+++ b/skills/harness-docs/references/cross-harness.md
@@ -1,0 +1,96 @@
+# Cross-Harness Usage
+
+<!-- Source: website/content/docs/cross-harness/setup-guide.mdx, concept-mapping.mdx, ide-support.md -->
+
+harness-kit plugins are plain markdown — any tool that reads prompt files or instruction markdown can use the workflows.
+
+The skill format follows the [Agent Skills specification](https://agentskills.io) — an open standard for cross-platform skill portability.
+
+## GitHub Copilot
+
+**Plugin install (Copilot CLI):**
+```
+copilot plugin install harnessprotocol/harness-kit
+```
+
+**Manual — repo-wide instructions:**  
+Copy a plugin's `SKILL.md` to `.github/copilot-instructions.md`. Copilot picks it up automatically for all conversations in that repo.
+
+**Path-scoped instructions:**  
+Drop it in `.github/instructions/<name>.instructions.md` with an `applyTo` glob:
+
+```markdown
+---
+applyTo: "src/**"
+---
+
+[SKILL.md content here]
+```
+
+**CLAUDE.md native support:**  
+VS Code Copilot reads `CLAUDE.md` natively when `chat.useClaudeMdFile` is enabled in settings. A single `CLAUDE.md` can serve both Claude Code and Copilot simultaneously — no separate instruction files needed.
+
+**Skills directories:**  
+Some VS Code Copilot configurations recognize `.claude/skills/` alongside `.github/skills/`.
+
+## Cursor
+
+Copy a plugin's `SKILL.md` to `.cursor/rules/<name>.mdc`. Use Cursor's `globs:` frontmatter to restrict a skill to specific paths:
+
+```markdown
+---
+globs: "src/**/*.ts"
+---
+
+[SKILL.md content here]
+```
+
+## Windsurf
+
+Copy the `SKILL.md` content into `.windsurfrules`, or paste it through Windsurf's project rules UI. No frontmatter needed — Windsurf applies rules project-wide.
+
+## MCP Servers
+
+MCP has 100% cross-platform support. The wiring location varies by tool:
+
+| Tool | MCP config file |
+|------|----------------|
+| Claude Code | `.mcp.json` |
+| Copilot (VS Code) | `.vscode/mcp.json` |
+| Cursor | `.cursor/mcp.json` |
+
+Plugins that depend on MCP (like `orient` and `capture`) work in any of these tools as long as the server is wired up.
+
+## Feature Comparison
+
+| Feature | Claude Code | Copilot | Cursor | Windsurf |
+|---------|-------------|---------|--------|----------|
+| Marketplace install/update | One command | Copilot CLI | Manual | Manual |
+| Hooks | Auto-triggered | Not supported | Not supported | Not supported |
+| Auto-execution scripts | Bundled | Manual | Manual | Manual |
+| SKILL.md workflows | Full support | Full support | Full support | Full support |
+| MCP server support | Full support | Full support | Full support | Varies |
+
+## Configuration Primitives Across Tools
+
+Every AI coding tool uses the same five configuration primitives with different names:
+
+| Primitive | Claude Code | Copilot (VS Code) | Cursor |
+|-----------|-------------|-------------------|--------|
+| Instructions | `CLAUDE.md`, `.claude/rules/*.md` | `.github/copilot-instructions.md` | `.cursor/rules/*.mdc` |
+| Prompt Templates | `SKILL.md` in `.claude/skills/` | `.github/prompts/*.prompt.md` | Rule files with glob scope |
+| Agent Definitions | `.claude/agents/*.md` | `.github/agents/*.agent.md` | Not yet supported |
+| Skills | `.claude/skills/` | `.github/skills/` | Not yet supported |
+| Tool Servers | `.mcp.json` | `.vscode/mcp.json` | `.cursor/mcp.json` |
+
+## Three-Tier Scoping
+
+All three tools use the same three-tier model:
+
+| Tier | Claude Code | Copilot | Cursor |
+|------|-------------|---------|--------|
+| Personal | `~/.claude/CLAUDE.md` | VS Code user settings | `~/.cursor/rules/` |
+| Project | `CLAUDE.md` / `.claude/` | `.github/` | `.cursor/` |
+| Organization | Enterprise policy | GitHub Copilot policies | Cursor Business |
+
+harness-kit targets the project tier.

--- a/skills/harness-docs/references/cross-harness.md
+++ b/skills/harness-docs/references/cross-harness.md
@@ -45,9 +45,19 @@ globs: "src/**/*.ts"
 [SKILL.md content here]
 ```
 
-## Windsurf
+## Codex
 
-Copy the `SKILL.md` content into `.windsurfrules`, or paste it through Windsurf's project rules UI. No frontmatter needed — Windsurf applies rules project-wide.
+Copy a plugin's `SKILL.md` into your `AGENTS.md` file at the repo root. Codex reads `AGENTS.md` as its persistent instruction context — the same role `CLAUDE.md` plays for Claude Code.
+
+```bash
+cat plugins/research/skills/research/SKILL.md >> AGENTS.md
+```
+
+**MCP servers:** Codex supports MCP via the `--mcp` flag:
+
+```bash
+codex --mcp .mcp.json
+```
 
 ## MCP Servers
 
@@ -63,13 +73,13 @@ Plugins that depend on MCP (like `orient` and `capture`) work in any of these to
 
 ## Feature Comparison
 
-| Feature | Claude Code | Copilot | Cursor | Windsurf |
-|---------|-------------|---------|--------|----------|
+| Feature | Claude Code | Copilot | Cursor | Codex |
+|---------|-------------|---------|--------|-------|
 | Marketplace install/update | One command | Copilot CLI | Manual | Manual |
 | Hooks | Auto-triggered | Not supported | Not supported | Not supported |
 | Auto-execution scripts | Bundled | Manual | Manual | Manual |
 | SKILL.md workflows | Full support | Full support | Full support | Full support |
-| MCP server support | Full support | Full support | Full support | Varies |
+| MCP server support | Full support | Full support | Full support | Full support |
 
 ## Configuration Primitives Across Tools
 

--- a/skills/harness-docs/references/getting-started.md
+++ b/skills/harness-docs/references/getting-started.md
@@ -1,0 +1,136 @@
+# Getting Started with Harness Kit
+
+<!-- Source: website/content/docs/getting-started/installation.mdx, quick-start.mdx, architecture.mdx -->
+
+## Installation
+
+harness-kit ships three installable artifacts:
+
+| Artifact | What it does | How to install |
+|----------|-------------|----------------|
+| **Skills & Plugins** | Adds slash commands to Claude Code | Plugin marketplace or install script |
+| **CLI** (`harness-kit`) | Compiles and validates `harness.yaml` from the terminal | Homebrew, npm, or direct download |
+| **Desktop App** | Visual interface for managing your AI tool configurations | Homebrew Cask or DMG |
+
+Most users start with skills. The CLI and desktop app are for teams managing shared `harness.yaml` configs.
+
+### Install via Plugin Marketplace (recommended)
+
+Add the marketplace once, then install any plugin by name:
+
+```
+/plugin marketplace add harnessprotocol/harness-kit
+/plugin install research@harness-kit
+```
+
+Install additional plugins:
+
+```
+/plugin install explain@harness-kit
+/plugin install lineage@harness-kit
+/plugin install orient@harness-kit
+/plugin install capture@harness-kit
+/plugin install review@harness-kit
+/plugin install docgen@harness-kit
+```
+
+### Install via Script (fallback)
+
+If your Claude Code build doesn't support the plugin marketplace yet:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/harnessprotocol/harness-kit/main/install.sh | bash
+```
+
+This downloads skill files to `~/.claude/skills/`. It installs only skill files — bundled scripts require the full marketplace install.
+
+### Verify Installation
+
+```
+/research
+/explain src/main.ts
+```
+
+If the skill responds with its workflow, installation succeeded.
+
+### Install CLI
+
+```bash
+# Homebrew
+brew tap harnessprotocol/tap
+brew install harness-kit
+
+# npm
+npm install -g @harness-kit/cli
+
+# Verify
+harness-kit --version
+harness-kit validate
+```
+
+## Requirements per Plugin
+
+| Plugin | Requirements |
+|--------|-------------|
+| research | `gh` CLI (GitHub sources only), Python 3.10+ (index rebuild) |
+| explain | None |
+| lineage | None |
+| orient | None (optional: MCP Memory Server) |
+| capture | None |
+| review | `gh` CLI (PR review only) |
+| docgen | None |
+| open-pr | `gh` CLI |
+| merge-pr | `gh` CLI |
+| pr-sweep | `gh` CLI, review plugin |
+| harness-share | None |
+| stats | Python 3.10+ |
+| board | Node.js (board server) |
+| iterm-notify | macOS, iTerm2, terminal-notifier, jq |
+| membrain | Go 1.25+, membrain MCP server |
+| frontend-design | None |
+
+## Architecture
+
+### Plugin Lifecycle
+
+1. **Source** — Register harness-kit as a plugin source in your AI tool.
+2. **Install** — Install a plugin by name. Your harness downloads the plugin directory locally.
+3. **Discovery** — At session start, your harness scans installed plugins and registers any skills it finds.
+4. **Invocation** — You type a command (e.g. `/research`). Your harness loads the matching `SKILL.md` into context as the workflow definition.
+5. **Execution** — The AI follows the steps in SKILL.md, using available tools (file I/O, web fetch, shell commands, MCP servers).
+
+### Plugin Anatomy
+
+```
+plugins/<name>/
+├── .claude-plugin/
+│   └── plugin.json         # name, version, description
+├── skills/
+│   └── <name>/
+│       ├── SKILL.md        # the workflow (what Claude reads)
+│       └── README.md       # human documentation
+└── scripts/                # optional: automation scripts
+    hooks/                  # optional: event hooks
+    agents/                 # optional: agent configurations
+```
+
+### What Makes a Skill Different from a Prompt
+
+A SKILL.md specifies: mandatory step ordering, input parsing rules, tool usage patterns, output structure, error handling, and common mistakes. This structure makes skills repeatable across sessions.
+
+### Sharing Your Setup
+
+1. **Export** — `/harness-export` captures your installed plugins and sources into `harness.yaml`.
+2. **Share** — Commit to a repo, drop in Slack, include in onboarding docs.
+3. **Import** — `/harness-import harness.yaml` presents an interactive list. Teammates pick what they want.
+
+## Using with Other Tools
+
+SKILL.md files are plain markdown — copy them into any tool's instruction system:
+
+- **GitHub Copilot** — Copy to `.github/copilot-instructions.md` or install via `copilot plugin install harnessprotocol/harness-kit`
+- **Cursor** — Copy to `.cursor/rules/<name>.mdc`
+- **Windsurf** — Paste into `.windsurfrules`
+- **VS Code Copilot** — Reads `CLAUDE.md` natively via `chat.useClaudeMdFile` setting
+
+See `cross-harness.md` in this references directory for full details.

--- a/skills/harness-docs/references/plugin-catalog.md
+++ b/skills/harness-docs/references/plugin-catalog.md
@@ -1,0 +1,86 @@
+# Plugin Catalog
+
+<!-- Source: website/content/docs/plugins/overview.md and individual plugin pages -->
+
+harness-kit ships 16 plugins across 7 categories.
+
+## All Plugins
+
+| Plugin | Category | Slash command | Dependencies |
+|--------|----------|---------------|-------------|
+| research | Research & Knowledge | `/research` | `gh` CLI (GitHub only), Python 3.10+ |
+| orient | Research & Knowledge | `/orient` | None (optional: MCP Memory Server) |
+| capture | Research & Knowledge | `/capture` | None |
+| membrain | Research & Knowledge | `/membrain` | Go 1.25+, membrain MCP server |
+| review | Code Quality | `/review` | `gh` CLI (PR review only) |
+| explain | Code Quality | `/explain` | None |
+| lineage | Data Engineering | `/lineage` | None |
+| docgen | Documentation | `/docgen` | None |
+| open-pr | DevOps | `/open-pr` | `gh` CLI |
+| merge-pr | DevOps | `/merge-pr` | `gh` CLI |
+| pr-sweep | DevOps | `/pr-sweep` | `gh` CLI, review plugin |
+| harness-share | Productivity | `/harness-export`, `/harness-import` | None |
+| stats | Productivity | `/stats` | Python 3.10+ |
+| iterm-notify | Productivity | — (hooks-based) | macOS, iTerm2, terminal-notifier, jq |
+| board | Productivity | `/board` | Node.js (board server) |
+| frontend-design | Design | `/frontend-design` | None |
+
+## Plugin Descriptions
+
+### research
+Process any source into a structured, compounding knowledge base. Accepts URLs, GitHub repos, YouTube videos, podcast pages, academic papers, local files, PDFs, and Reddit posts. Outputs raw source preservation in `resources/` plus synthesized analysis in `research/[category]/`. Builds a cumulative index across sessions.
+
+### orient
+Topic-focused session orientation. Searches across knowledge graph, journal entries, and research index for a given topic, entity, or project. Returns a synthesis of what's known, what's uncertain, and what to read next. Requires context from prior `research` runs or `membrain` entries.
+
+### capture
+Capture session information into a staging file for later reflection or knowledge-base integration. Useful for preserving decisions, findings, and context at the end of a working session.
+
+### membrain
+Graph-based agent memory. Search, trace, and manage a persistent knowledge graph powered by the membrain MCP server. For teams building AI agents that need to retain context across sessions.
+
+### review
+Structured code review for branches, PRs, or file paths. Applies severity labels (critical, major, minor, nit) and produces a structured report. Works on local branches or GitHub PRs (requires `gh` CLI for PR review by number).
+
+### explain
+Layered explanations of code — files, directories, functions, classes, or cross-cutting concepts. Adaptive depth: a single function gets a deep-dive, a directory gets a map first. Project-aware: references `CLAUDE.md` architecture section to ground explanations in the project's own terminology.
+
+### lineage
+Column-level data lineage tracing through SQL transformations, Kafka streams, Spark jobs, and JDBC pipelines. Maps how a specific column moves through a data system from source to sink.
+
+### docgen
+Generate or update documentation: README, API reference, architecture overview, or changelog. Produces markdown output that matches the project's existing doc conventions.
+
+### open-pr
+Pre-flight checks and PR creation workflow. Runs tests, creates the PR, assigns reviewers, and monitors CI status. Requires `gh` CLI.
+
+### merge-pr
+Merge a ready pull request. Verifies CI, syncs with base branch, squash merges, cleans up the branch. Requires `gh` CLI.
+
+### pr-sweep
+Cross-repository PR sweep. Triages, reviews, merges, or fixes CI across multiple open PRs. Useful for batch PR cleanup sessions. Requires `gh` CLI and the review plugin.
+
+### harness-share
+Compile, export, import, and sync harness configurations across AI tools. Key commands: `/harness-export` (write `harness.yaml`), `/harness-import` (apply a `harness.yaml` interactively).
+
+### stats
+Interactive HTML dashboard for Claude Code token and session usage. Reads from `~/.claude/projects/` and generates a visual report. Requires Python 3.10+.
+
+### iterm-notify
+macOS desktop notifications and iTerm2 badge management for Claude Code events. Hooks-based — fires on session stop. Requires macOS, iTerm2, terminal-notifier, and jq.
+
+### board
+Kanban project board with real-time Claude-to-web sync via MCP. Tracks tasks across six columns with AI-assisted card creation and updates. Requires the Node.js board server.
+
+### frontend-design
+Production-grade frontend design rules covering OKLCH color system, typography, layout, motion, and accessibility. Used as a style guide for UI generation tasks.
+
+## Profiles (Pre-configured Bundles)
+
+| Profile | Who it's for | Plugins included |
+|---------|-------------|-----------------|
+| research-knowledge | Research-focused roles | research, orient, capture, explain, docgen |
+| data-engineer | Data engineers with SQL pipelines | lineage, research, orient, capture, explain, docgen, review |
+| full-stack-engineer | Full-stack feature shipping | review, open-pr, merge-pr, pr-sweep, explain, docgen, harness-share |
+
+Install a profile's plugins with `/harness-import` and the profile's YAML.

--- a/website/app/docs/[[...slug]]/page.tsx
+++ b/website/app/docs/[[...slug]]/page.tsx
@@ -12,6 +12,8 @@ import { Callout } from 'fumadocs-ui/components/callout';
 import { Step, Steps } from 'fumadocs-ui/components/steps';
 import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 import { MarkdownViewer } from '@/components/markdown-viewer';
+import { AgentSkillBanner } from '@/components/agent-skill-banner';
+import { InstallMethodCards } from '@/components/install-method-cards';
 
 const mdxComponents = {
   ...defaultMdxComponents,
@@ -23,6 +25,7 @@ const mdxComponents = {
   Accordion,
   Accordions,
   MarkdownViewer,
+  InstallMethodCards,
 };
 
 export default async function Page(props: {
@@ -39,6 +42,7 @@ export default async function Page(props: {
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
       <DocsBody>
+        <AgentSkillBanner />
         <MDX components={mdxComponents} />
       </DocsBody>
     </DocsPage>

--- a/website/app/docs/[[...slug]]/page.tsx
+++ b/website/app/docs/[[...slug]]/page.tsx
@@ -14,6 +14,7 @@ import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 import { MarkdownViewer } from '@/components/markdown-viewer';
 import { AgentSkillBanner } from '@/components/agent-skill-banner';
 import { InstallMethodCards } from '@/components/install-method-cards';
+import { ArchitectureDiagram } from '@/components/architecture-diagram';
 
 const mdxComponents = {
   ...defaultMdxComponents,
@@ -26,6 +27,7 @@ const mdxComponents = {
   Accordions,
   MarkdownViewer,
   InstallMethodCards,
+  ArchitectureDiagram,
 };
 
 export default async function Page(props: {

--- a/website/app/docs/layout.tsx
+++ b/website/app/docs/layout.tsx
@@ -11,18 +11,19 @@ export default function Layout({ children }: { children: ReactNode }) {
           <span className="flex items-center gap-2 font-bold">
             <svg
               xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 32 32"
+              viewBox="0 0 28 28"
               className="size-6"
+              style={{ filter: 'drop-shadow(0 0 5px rgba(34,177,236,0.4))' }}
             >
-              <rect width="32" height="32" rx="6" fill="#0d0d12" />
+              <rect width="28" height="28" rx="6" fill="#0d1016" />
               <text
-                x="16"
-                y="22"
+                x="14"
+                y="19"
                 textAnchor="middle"
                 fontFamily="system-ui, sans-serif"
                 fontWeight="700"
-                fontSize="16"
-                fill="#8b7aff"
+                fontSize="12"
+                fill="#4ec7f2"
               >
                 hk
               </text>

--- a/website/app/explore/page.tsx
+++ b/website/app/explore/page.tsx
@@ -55,7 +55,7 @@ const NAV_GROUPS: Group[] = [
         id: 'observatory',
         title: 'Observatory',
         description: 'Every session, every tool call, every minute. See what your AI actually did.',
-        href: '/docs/evals',
+        href: '/docs/getting-started/architecture',
         accent: 'var(--cat-blue)',
         icon: (
           <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
@@ -67,7 +67,7 @@ const NAV_GROUPS: Group[] = [
         id: 'agents',
         title: 'Agents',
         description: 'Monitor and control specialist subagents running across your harness — live status, output, and history.',
-        href: '/docs/concepts/architecture',
+        href: '/docs/concepts/agents',
         accent: 'var(--cat-purple)',
         icon: (
           <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
@@ -126,7 +126,7 @@ const NAV_GROUPS: Group[] = [
         id: 'board',
         title: 'Board',
         description: 'Agents pick up cards, draft commits, open PRs. You review. Kanban built for AI-first teams.',
-        href: '/docs/plugins/productivity',
+        href: '/docs/plugins/productivity/board',
         accent: 'var(--cat-purple)',
         icon: (
           <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
@@ -138,7 +138,7 @@ const NAV_GROUPS: Group[] = [
         id: 'roadmap',
         title: 'Roadmap',
         description: 'AI-generated quarterly roadmaps and competitor analysis, tied to your board and harness.',
-        href: '/docs/plugins/productivity',
+        href: '/docs/plugins/productivity/board',
         accent: 'var(--cat-purple)',
         icon: (
           <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
@@ -163,7 +163,7 @@ const NAV_GROUPS: Group[] = [
         id: 'memory',
         title: 'Memory',
         description: 'A knowledge graph your AI can orient itself in. Teammates, decisions, conventions — persistent across every tool.',
-        href: '/docs/plugins/research-knowledge',
+        href: '/docs/plugins/research-knowledge/membrain',
         accent: 'var(--cat-cyan)',
         icon: (
           <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">

--- a/website/app/global.css
+++ b/website/app/global.css
@@ -66,24 +66,31 @@ body {
   --shadow-lg: 0 8px 24px rgba(0,0,0,.14), 0 4px 8px rgba(0,0,0,.08);
 }
 
-/* ── Dark theme — deep, blue-tinted ── */
+/* ── Dark theme — matches harness-kit desktop app tokens ── */
 .dark {
-  --color-fd-primary: 199 82% 55%;
+  /* Accent: #22b1ec — exact match to desktop --accent */
+  --color-fd-primary: 199 82% 53%;
   --color-fd-primary-foreground: 0 0% 100%;
-  --color-fd-background: 220 25% 5%;
-  --color-fd-foreground: 220 15% 91%;
-  --color-fd-card: 220 22% 8%;
-  --color-fd-card-foreground: 220 15% 91%;
-  --color-fd-muted: 220 18% 12%;
-  --color-fd-muted-foreground: 220 8% 52%;
-  --color-fd-border: 220 20% 13%;
+  /* Background: matches desktop --bg-base #0b0d12 */
+  --color-fd-background: 220 24% 6%;
+  /* Foreground: matches desktop --fg-base #e6e8ee */
+  --color-fd-foreground: 220 15% 92%;
+  /* Card: matches desktop --bg-surface #12151c */
+  --color-fd-card: 220 22% 9%;
+  --color-fd-card-foreground: 220 15% 92%;
+  /* Muted: matches desktop --bg-elevated #1a1e27 */
+  --color-fd-muted: 220 18% 13%;
+  /* Muted fg: matches desktop --fg-muted #9aa0ad */
+  --color-fd-muted-foreground: 220 8% 62%;
+  /* Border: matches desktop --border-base feel */
+  --color-fd-border: 220 18% 14%;
   --color-fd-accent: 199 40% 12%;
   --color-fd-accent-foreground: 199 75% 65%;
-  --color-fd-popover: 220 22% 6%;
-  --color-fd-popover-foreground: 220 15% 91%;
-  --color-fd-secondary: 220 18% 10%;
-  --color-fd-secondary-foreground: 220 15% 91%;
-  --color-fd-ring: 199 82% 55%;
+  --color-fd-popover: 220 22% 7%;
+  --color-fd-popover-foreground: 220 15% 92%;
+  --color-fd-secondary: 220 18% 11%;
+  --color-fd-secondary-foreground: 220 15% 92%;
+  --color-fd-ring: 199 82% 53%;
   --cat-blue:   #3b82f6;
   --cat-cyan:   #06b6d4;
   --cat-purple: #a855f7;
@@ -192,15 +199,12 @@ h1, h2, h3 {
 /* ── Content spacing — breathing room ── */
 [data-fumadocs-body] {
   line-height: 1.8;
-  position: relative;
 }
 [data-fumadocs-body] p {
   margin-bottom: 1.25em;
 }
 [data-fumadocs-body] h2 {
-  margin-top: 2.5em;
-  position: relative;
-  padding-top: 1.5em;
+  margin-top: 2.25em;
 }
 [data-fumadocs-body] h3 {
   margin-top: 1.75em;
@@ -215,61 +219,67 @@ h1, h2, h3 {
   margin: 1.5em 0;
 }
 
-/* ── Nav bar gradient border ── */
+/* ── Nav bar ── */
 .dark [data-fumadocs-nav] {
-  position: relative;
-  border-bottom: none;
-  background: hsla(220, 25%, 4%, 0.85);
+  border-bottom: 1px solid hsl(var(--color-fd-border) / 0.6);
+  background: hsla(220, 25%, 3%, 0.9);
   backdrop-filter: blur(16px);
 }
-.dark [data-fumadocs-nav]::after {
-  content: '';
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(34, 177, 236, 0.2), transparent);
-}
 
-/* ── Sidebar — spread out with icons + cyan glow active ── */
+/* ── Sidebar ── */
 [data-fumadocs-sidebar] {
   padding: 1rem 0.5rem;
 }
 
 [data-fumadocs-sidebar] a {
-  transition: background-color 0.2s ease, padding-left 0.2s ease, border-color 0.2s ease;
-  border-left: 2px solid transparent;
-  padding: 0.625rem 0.875rem;
-  border-radius: 0.5rem;
-  gap: 0.75rem;
+  transition: background-color 0.15s ease, color 0.15s ease;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.4rem;
+  gap: 0.625rem;
   font-size: 0.875rem;
 }
 [data-fumadocs-sidebar] a:hover {
   background: hsla(220, 10%, 50%, 0.08);
 }
 .dark [data-fumadocs-sidebar] a:hover {
-  background: hsla(220, 10%, 50%, 0.1);
+  background: hsla(220, 15%, 55%, 0.09);
 }
 [data-fumadocs-sidebar] [aria-current="page"],
 [data-fumadocs-sidebar] [data-active="true"] {
-  border-left: 2px solid var(--accent);
-  background: linear-gradient(
-    90deg,
-    var(--accent-light) 0%,
-    rgba(14, 165, 233, 0.02) 100%
-  );
-  padding-left: 10px;
-  transition: all 0.2s ease;
+  background: var(--accent-light);
+  color: hsl(var(--color-fd-primary));
+  font-weight: 500;
 }
 .dark [data-fumadocs-sidebar] [aria-current="page"],
 .dark [data-fumadocs-sidebar] [data-active="true"] {
-  background: linear-gradient(
-    90deg,
-    var(--accent-light) 0%,
-    rgba(34, 177, 236, 0.03) 100%
-  );
-  box-shadow: 0 0 20px -6px var(--accent-glow);
+  background: hsla(199, 60%, 50%, 0.1);
+  color: hsl(var(--color-fd-primary));
+}
+
+/* Sidebar folder/group headings — category label treatment */
+[data-sidebar-panel] [data-state] > button,
+[data-sidebar-panel] [data-state] button:first-child {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  padding-top: 1rem;
+  padding-bottom: 0.35rem;
+  opacity: 0.55;
+}
+[data-sidebar-panel] [data-state] > button:hover,
+[data-sidebar-panel] [data-state] button:first-child:hover {
+  background: transparent;
+  opacity: 0.85;
+}
+.dark [data-sidebar-panel] [data-state] > button,
+.dark [data-sidebar-panel] [data-state] button:first-child {
+  color: hsla(220, 10%, 72%, 1);
+}
+
+/* Sidebar: matches desktop --bg-sidebar-solid #0d1016 */
+.dark [data-sidebar-panel] {
+  background: #0d1016;
 }
 
 /* ── TOC — smooth active indicator ── */
@@ -288,6 +298,11 @@ h1, h2, h3 {
 [data-fumadocs-nav] input:focus-visible {
   box-shadow: 0 0 0 2px var(--accent-glow);
   outline: none;
+}
+
+/* ── Fumadocs Tabs — remove outer container border ── */
+div[data-orientation="horizontal"]:not([role="tablist"]):not([role="tabpanel"]) {
+  border: none !important;
 }
 
 /* ── Code blocks — clean with depth shadow ── */
@@ -358,6 +373,14 @@ blockquote {
   background: hsla(220, 18%, 8%, 0.5) !important;
 }
 
+/* ── Horizontal rules — very faint ── */
+[data-fumadocs-body] hr {
+  border: none;
+  border-top: 1px solid hsl(var(--color-fd-border));
+  margin: 2em 0;
+  opacity: 0.5;
+}
+
 /* ── Tables — borderless with row tinting ── */
 table {
   border: none !important;
@@ -388,16 +411,28 @@ table th {
 }
 
 /* ── Cards — hover with subtle lift ── */
-[data-card] {
+/* Fumadocs puts data-card on heading anchor links too — exclude those */
+[data-card]:not(a) {
   border: 1px solid hsla(0, 0%, 50%, 0.1) !important;
   border-radius: 0.75rem;
   transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
 }
-[data-card]:hover {
+[data-card]:not(a):hover {
   transform: scale(1.02);
   border-color: hsla(199, 82%, 53%, 0.3) !important;
   box-shadow: 0 8px 24px -8px hsla(199, 65%, 45%, 0.15),
               0 0 0 1px hsla(199, 82%, 53%, 0.1);
+}
+/* Explicitly reset heading anchor links — belt and suspenders */
+h1 > a[data-card], h2 > a[data-card],
+h3 > a[data-card], h4 > a[data-card],
+h5 > a[data-card], h6 > a[data-card] {
+  border: none !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+  transform: none !important;
+  background: transparent !important;
+  padding: 0 !important;
 }
 
 /* ── Steps — warm accent badges + styled line ── */
@@ -433,37 +468,17 @@ pre code {
   letter-spacing: -0.03em;
 }
 
+/* ── Docs page title — display font, bold, harness-kit brand ── */
+#nd-docs-layout h1 {
+  font-family: var(--font-display), ui-sans-serif, system-ui, sans-serif;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  font-size: 2rem;
+}
+
 /* ── Gradient accent moments ── */
 
-/* H2 section dividers — gradient line above */
-[data-fumadocs-body] h2::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, hsla(199, 82%, 53%, 0.2), transparent);
-}
-
-/* First H2 on page — no divider (title already separates it) */
-[data-fumadocs-body] > h2:first-of-type::before {
-  display: none;
-}
-
-/* Page title area — subtle radial glow */
-[data-fumadocs-body]::before {
-  content: '';
-  position: absolute;
-  top: -60px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 500px;
-  height: 300px;
-  background: radial-gradient(ellipse, hsla(199, 70%, 50%, 0.06) 0%, transparent 70%);
-  pointer-events: none;
-  z-index: -1;
-}
+/* No h2 dividers */
 
 /* ── MarkdownViewer — raw/preview toggle ── */
 .markdown-viewer {
@@ -609,4 +624,75 @@ pre code {
   color: hsl(199, 82%, 65%);
   text-decoration: underline;
   text-decoration-style: dotted;
+}
+
+/* ── Agent Skill Banner ── */
+.agent-skill-banner {
+  border-left: 3px solid hsl(199, 82%, 55%);
+  border-radius: 0 0.75rem 0.75rem 0;
+  background: hsla(199, 25%, 9%, 0.5);
+  padding: 0.75rem 1rem;
+  margin-bottom: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.asb-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: hsl(199, 60%, 75%);
+}
+.asb-icon {
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+  color: hsl(199, 82%, 55%);
+}
+.asb-label {
+  line-height: 1.4;
+}
+.asb-command-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: hsla(220, 20%, 6%, 0.7);
+  border-radius: 0.5rem;
+  padding: 0.4rem 0.6rem 0.4rem 0.75rem;
+}
+.asb-command {
+  flex: 1;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.75rem;
+  color: hsl(199, 75%, 80%);
+  background: transparent;
+  border: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  user-select: all;
+}
+.asb-copy-btn {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border: none;
+  border-radius: 0.375rem;
+  background: transparent;
+  color: hsl(199, 60%, 65%);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.asb-copy-btn:hover {
+  background: hsla(199, 82%, 55%, 0.12);
+  color: hsl(199, 82%, 75%);
+}
+.asb-copy-icon {
+  width: 0.875rem;
+  height: 0.875rem;
 }

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -5,6 +5,7 @@ import { CommandBox } from '@/components/site/CommandBox';
 import { SectionHeader } from '@/components/site/SectionHeader';
 import { FeatureTile } from '@/components/site/FeatureTile';
 import { DesktopMock } from '@/components/site/DesktopMock';
+import { AgentSkillBanner } from '@/components/agent-skill-banner';
 
 /* ── Icons (inline SVG, no icon library) ── */
 const ConfigureIcon = () => (
@@ -109,6 +110,9 @@ export default function HomePage() {
             >
               Explore the app →
             </Link>
+          </div>
+          <div className="mt-6 text-left">
+            <AgentSkillBanner />
           </div>
         </div>
 

--- a/website/components/agent-skill-banner.tsx
+++ b/website/components/agent-skill-banner.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useState } from 'react';
+
+const NPX_COMMAND =
+  'npx skills add https://github.com/harnessprotocol/harness-kit --skill harness-docs';
+
+export function AgentSkillBanner() {
+  const [copied, setCopied] = useState(false);
+
+  function handleCopy() {
+    navigator.clipboard.writeText(NPX_COMMAND).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  return (
+    <div className="agent-skill-banner" aria-label="Install docs as a skill">
+      <div className="asb-header">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          aria-hidden="true"
+          className="asb-icon"
+        >
+          <path
+            fillRule="evenodd"
+            d="M3.25 3A2.25 2.25 0 0 0 1 5.25v9.5A2.25 2.25 0 0 0 3.25 17h13.5A2.25 2.25 0 0 0 19 14.75v-9.5A2.25 2.25 0 0 0 16.75 3H3.25Zm.943 8.752a.75.75 0 0 1-.25-1.43l4.5-1.5a.75.75 0 0 1 .5 0l4.5 1.5a.75.75 0 0 1-.5 1.43l-4.25-1.416-4.25 1.416a.75.75 0 0 1-.25.014ZM6 9.5a.75.75 0 0 1 .75-.75h.5a.75.75 0 0 1 0 1.5h-.5A.75.75 0 0 1 6 9.5Z"
+            clipRule="evenodd"
+          />
+        </svg>
+        <span className="asb-label">
+          Using a coding agent? Install the Harness Kit docs as a skill:
+        </span>
+      </div>
+      <div className="asb-command-row">
+        <code className="asb-command">{NPX_COMMAND}</code>
+        <button
+          className="asb-copy-btn"
+          onClick={handleCopy}
+          aria-label={copied ? 'Copied!' : 'Copy command'}
+          title={copied ? 'Copied!' : 'Copy to clipboard'}
+        >
+          {copied ? (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 16 16"
+              fill="currentColor"
+              aria-hidden="true"
+              className="asb-copy-icon"
+            >
+              <path
+                fillRule="evenodd"
+                d="M12.416 3.376a.75.75 0 0 1 .208 1.04l-5 7.5a.75.75 0 0 1-1.154.114l-3-3a.75.75 0 0 1 1.06-1.06l2.353 2.353 4.493-6.74a.75.75 0 0 1 1.04-.207Z"
+                clipRule="evenodd"
+              />
+            </svg>
+          ) : (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 16 16"
+              fill="currentColor"
+              aria-hidden="true"
+              className="asb-copy-icon"
+            >
+              <path d="M3.5 2A1.5 1.5 0 0 0 2 3.5v9A1.5 1.5 0 0 0 3.5 14h6a1.5 1.5 0 0 0 1.5-1.5v-7L8.5 2H3.5Z" />
+              <path d="M9 3.25a.25.25 0 0 0-.25-.25H8v2.5a.75.75 0 0 0 .75.75H11v-.25A2.75 2.75 0 0 0 9 3.25Z" />
+              <path d="M8.5 2v2A.5.5 0 0 0 9 4.5H11.5" />
+            </svg>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/website/components/architecture-diagram.tsx
+++ b/website/components/architecture-diagram.tsx
@@ -33,7 +33,7 @@ const pluginParts = [
 ];
 
 // Harnesses sourced from cross-harness/ide-support.md support matrix
-const harnesses = ['Claude Code', 'Copilot', 'Cursor', 'Windsurf', 'Codex'];
+const harnesses = ['Claude Code', 'Copilot', 'Cursor', 'Codex'];
 
 // 3 rows × 2 columns; values shortened to fit 286px value column
 const yamlFields = [
@@ -353,17 +353,17 @@ export function ArchitectureDiagram() {
           HARNESSES
         </text>
 
-        {/* 3+2 grid; chipW=98, gap=8; 3×98+2×8=310 in 340 */}
+        {/* 2×2 grid; chipW=155, gap=8; 2×155+8=318 in 340 */}
         {harnesses.map((tool, i) => {
-          const col = i % 3;
-          const row = Math.floor(i / 3);
-          const tx  = AT.x + 14 + col * 106;
+          const col = i % 2;
+          const row = Math.floor(i / 2);
+          const tx  = AT.x + 14 + col * 163;
           const ty  = AT.y + 26 + row * 30;
           return (
             <g key={tool}>
-              <rect x={tx} y={ty} width={98} height={20} rx={4}
+              <rect x={tx} y={ty} width={155} height={20} rx={4}
                 fill={SURFACE} stroke={BORDER_MID} />
-              <text x={tx + 49} y={ty + 13.5}
+              <text x={tx + 77.5} y={ty + 13.5}
                 fontFamily={FONT} fontSize={9} fill={MUTED} textAnchor="middle">
                 {tool}
               </text>

--- a/website/components/architecture-diagram.tsx
+++ b/website/components/architecture-diagram.tsx
@@ -1,279 +1,360 @@
-// Architecture layer diagram for the "How It Works" docs page.
-// Server component — no interactivity needed.
+// Architecture flow diagram — "How It Works" docs page.
+// Data sourced from apps/desktop/src/layouts/AppLayout.tsx (NAV_SECTIONS)
+// and apps/cli/src/index.ts. Keep in sync if sections change.
 
-const EyeIcon = () => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-    <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z" /><circle cx="12" cy="12" r="3" />
-  </svg>
-);
+const FONT = 'system-ui, -apple-system, sans-serif';
+const MONO = 'Menlo, Monaco, Consolas, monospace';
+const CYAN = '#22b1ec';
+const CYAN_DIM = 'rgba(34,177,236,0.25)';
+const CYAN_FAINT = 'rgba(34,177,236,0.08)';
+const SURFACE = '#0d1016';
+const SURFACE_MID = '#111827';
+const BORDER = 'rgba(255,255,255,0.08)';
+const TEXT = '#e4e7ec';
+const MUTED = '#8b919e';
+const SUBTLE = '#545b67';
 
-const GraphIcon = () => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-    <circle cx="18" cy="5" r="3" /><circle cx="6" cy="12" r="3" /><circle cx="18" cy="19" r="3" />
-    <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" /><line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
-  </svg>
-);
-
-const KanbanIcon = () => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-    <rect width="18" height="18" x="3" y="3" rx="2" />
-    <path d="M9 3v18M15 3v12" />
-  </svg>
-);
-
-const ChatIcon = () => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-    <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-  </svg>
-);
-
-const surfaces = [
-  { name: 'Observatory', desc: 'Session telemetry · tool call timeline · usage trends', icon: <EyeIcon /> },
-  { name: 'Memory', desc: 'Persistent knowledge graph across every tool and session', icon: <GraphIcon /> },
-  { name: 'Board', desc: 'AI-native Kanban — agents pick up cards, you review', icon: <KanbanIcon /> },
-  { name: 'AI Chat', desc: 'Terminal-style chat with Ollama support and 12 built-in tools', icon: <ChatIcon /> },
+// Groups come from NAV_SECTIONS in AppLayout.tsx
+const desktopGroups = [
+  { label: 'CORE', items: ['Harness', 'Marketplace'] },
+  { label: 'INSIGHTS', items: ['Observatory'] },
+  { label: 'SYSTEM', items: ['Security'] },
+  { label: 'WORKFLOWS', items: ['Board', 'Roadmap'] },
+  { label: 'OTHER', items: ['Agents', 'Comparator', 'Parity', 'AI Chat', 'Memory'] },
 ];
+
+const cliCommands = ['validate', 'compile', 'sync', 'check', 'detect', 'scan'];
 
 const pluginParts = [
-  { name: 'SKILL.md', desc: 'Workflow definition — what Claude reads at invocation', accent: true },
-  { name: 'agents/', desc: 'Specialist subagents — isolated workers with scoped tools' },
-  { name: 'hooks/', desc: 'Lifecycle events — Stop, PreTool, PostTool, etc.' },
-  { name: 'scripts/', desc: 'Shell automation bundled with the plugin' },
+  { name: 'SKILL.md', desc: 'workflow definition', highlight: true },
+  { name: 'agents/', desc: 'specialist subagents' },
+  { name: 'hooks/', desc: 'lifecycle events' },
+  { name: 'scripts/', desc: 'shell automation' },
 ];
 
-const cliOps = [
-  { cmd: 'validate', desc: 'Check harness.yaml against the schema' },
-  { cmd: 'compile', desc: 'Build native configs for Claude Code, Cursor, Copilot' },
-  { cmd: 'sync', desc: 'Pull latest plugin changes from the registry' },
-  { cmd: 'scan', desc: 'Security audit — flag unsafe skill content' },
+const aiTools = ['Claude Code', 'Cursor', 'Copilot', 'Windsurf', 'Zed'];
+
+const yamlLines = [
+  { key: 'plugins:', val: '- research@0.2.0  - board@0.1.0  - explain@0.2.0' },
+  { key: 'mcp-servers:', val: '- memory  - filesystem' },
+  { key: 'instructions:', val: '{ operational, behavioral, identity }' },
+  { key: 'permissions:', val: '{ tools, paths, network }' },
+  { key: 'env:', val: 'ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}' },
+  { key: 'extends:', val: '[ profiles/backend-engineer.yaml ]' },
 ];
 
-const aiTools = ['Claude Code', 'Cursor', 'GitHub Copilot', 'Windsurf', 'Zed'];
+/* ─── sub-components ─── */
 
-const layerLabelStyle: React.CSSProperties = {
-  fontSize: '9px',
-  fontWeight: 700,
-  letterSpacing: '0.1em',
-  textTransform: 'uppercase',
-  color: 'var(--fg-subtle, #6b7280)',
-  marginBottom: '10px',
-};
+function Label({ x, y, children }: { x: number; y: number; children: string }) {
+  return (
+    <text
+      x={x} y={y}
+      fontFamily={FONT} fontSize={8} fontWeight={700}
+      letterSpacing="0.1em" fill={SUBTLE}
+      textAnchor="middle"
+    >
+      {children}
+    </text>
+  );
+}
 
-const layerBoxBase: React.CSSProperties = {
-  borderRadius: '12px',
-  padding: '16px',
-};
+function Arrow({
+  x1, y1, x2, y2,
+  label, labelX, labelY,
+  dashed,
+}: {
+  x1: number; y1: number; x2: number; y2: number;
+  label?: string; labelX?: number; labelY?: number;
+  dashed?: boolean;
+}) {
+  return (
+    <>
+      <defs>
+        <marker id={`arr-${x1}-${y1}`} markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+          <polygon points="0 0,8 3,0 6" fill={dashed ? SUBTLE : CYAN} />
+        </marker>
+      </defs>
+      <line
+        x1={x1} y1={y1} x2={x2} y2={y2}
+        stroke={dashed ? SUBTLE : CYAN}
+        strokeWidth={dashed ? 1 : 1.5}
+        strokeDasharray={dashed ? '4 3' : undefined}
+        markerEnd={`url(#arr-${x1}-${y1})`}
+        opacity={dashed ? 0.4 : 0.7}
+      />
+      {label && (
+        <text
+          x={labelX ?? (x1 + x2) / 2}
+          y={labelY ?? (y1 + y2) / 2 - 5}
+          fontFamily={FONT} fontSize={9} fontWeight={600}
+          fill={dashed ? SUBTLE : CYAN}
+          textAnchor="middle"
+          opacity={dashed ? 0.6 : 0.9}
+        >
+          {label}
+        </text>
+      )}
+    </>
+  );
+}
 
-const accentLayer: React.CSSProperties = {
-  ...layerBoxBase,
-  border: '1px solid rgba(34,177,236,0.35)',
-  background: 'rgba(34,177,236,0.04)',
-};
-
-const mutedLayer: React.CSSProperties = {
-  ...layerBoxBase,
-  border: '1px solid var(--border-base, rgba(255,255,255,0.07))',
-  background: 'var(--bg-surface, #12151c)',
-};
-
-const connectorStyle: React.CSSProperties = {
-  display: 'flex',
-  justifyContent: 'center',
-  alignItems: 'center',
-  height: '28px',
-  gap: '6px',
-  color: 'rgba(34,177,236,0.5)',
-  fontSize: '11px',
-};
+/* ─── main diagram ─── */
 
 export function ArchitectureDiagram() {
+  // Layout constants
+  const W = 680;
+
+  // harness.yaml: top center
+  const HY = { x: 80, y: 24, w: 520, h: 116 };
+
+  // Desktop App: left column
+  const DA = { x: 24, y: 184, w: 236, h: 262 };
+
+  // CLI: right column (top)
+  const CL = { x: 424, y: 184, w: 232, h: 100 };
+
+  // Compiled configs: right column (below CLI)
+  const CC = { x: 424, y: 304, w: 232, h: 72 };
+
+  // Plugin System: bottom left
+  const PS = { x: 24, y: 490, w: 236, h: 90 };
+
+  // AI Tools: bottom center-right
+  const AT = { x: 280, y: 480, w: 240, h: 80 };
+
+  const totalH = 590;
+
   return (
-    <div className="not-prose my-8 space-y-0" style={{ fontFamily: 'var(--font-body, system-ui, sans-serif)' }}>
+    <div className="not-prose my-8">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox={`0 0 ${W} ${totalH}`}
+        style={{ width: '100%', display: 'block' }}
+        aria-label="harness-kit architecture diagram"
+      >
 
-      {/* ── Desktop App ── */}
-      <div style={accentLayer}>
-        <div style={layerLabelStyle}>Desktop App</div>
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))', gap: '8px' }}>
-          {surfaces.map((s) => (
-            <div
-              key={s.name}
-              style={{
-                borderRadius: '8px',
-                padding: '10px 12px',
-                background: 'rgba(13,16,22,0.8)',
-                border: '1px solid rgba(34,177,236,0.18)',
-              }}
-            >
-              <div style={{ display: 'flex', alignItems: 'center', gap: '7px', marginBottom: '5px', color: 'var(--accent, #22b1ec)' }}>
-                {s.icon}
-                <span style={{ fontSize: '12px', fontWeight: 600, color: 'var(--fg-base, #e8eaf0)' }}>{s.name}</span>
-              </div>
-              <p style={{ fontSize: '10px', lineHeight: 1.5, color: 'var(--fg-muted, #9aa0ad)', margin: 0 }}>{s.desc}</p>
-            </div>
-          ))}
-        </div>
-      </div>
+        {/* ── harness.yaml ── */}
+        <rect x={HY.x} y={HY.y} width={HY.w} height={HY.h} rx={10}
+          fill={SURFACE} stroke={CYAN} strokeWidth={1.5} />
 
-      {/* connector */}
-      <div style={connectorStyle}>
-        <svg width="1" height="20" viewBox="0 0 1 20" aria-hidden="true">
-          <line x1="0.5" y1="0" x2="0.5" y2="20" stroke="rgba(34,177,236,0.4)" strokeWidth="1.5" strokeDasharray="3 2" />
-        </svg>
-        <span style={{ color: 'rgba(34,177,236,0.5)', fontSize: '10px' }}>reads · writes · syncs</span>
-        <svg width="1" height="20" viewBox="0 0 1 20" aria-hidden="true">
-          <line x1="0.5" y1="0" x2="0.5" y2="20" stroke="rgba(34,177,236,0.4)" strokeWidth="1.5" strokeDasharray="3 2" />
-        </svg>
-      </div>
+        {/* header row */}
+        <text x={HY.x + HY.w / 2} y={HY.y + 22}
+          fontFamily={MONO} fontSize={14} fontWeight={700}
+          fill={CYAN} textAnchor="middle">
+          harness.yaml
+        </text>
+        <line x1={HY.x + 16} y1={HY.y + 30} x2={HY.x + HY.w - 16} y2={HY.y + 30}
+          stroke={CYAN_DIM} strokeWidth={1} />
 
-      {/* ── harness.yaml ── */}
-      <div style={{ ...accentLayer, border: '1.5px solid rgba(34,177,236,0.45)' }}>
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '12px' }}>
-          <div style={{ ...layerLabelStyle, marginBottom: 0 }}>Config Core</div>
-          <span style={{ fontSize: '13px', fontWeight: 700, color: 'var(--accent, #22b1ec)', fontFamily: 'var(--font-mono, monospace)' }}>harness.yaml</span>
-        </div>
-        <div
-          style={{
-            background: 'rgba(13,16,22,0.9)',
-            border: '1px solid rgba(255,255,255,0.06)',
-            borderRadius: '8px',
-            padding: '12px 16px',
-            fontFamily: 'var(--font-mono, Menlo, monospace)',
-            fontSize: '11px',
-            lineHeight: 1.8,
-            color: '#6b7280',
-          }}
+        {/* yaml fields — two columns */}
+        {yamlLines.map((line, i) => {
+          const col = i % 2;
+          const row = Math.floor(i / 2);
+          const cx = HY.x + 20 + col * 258;
+          const cy = HY.y + 47 + row * 24;
+          return (
+            <g key={i}>
+              <text x={cx} y={cy} fontFamily={MONO} fontSize={9} fontWeight={600} fill={MUTED}>{line.key}</text>
+              <text x={cx + 80} y={cy} fontFamily={MONO} fontSize={9} fill={SUBTLE}>{line.val}</text>
+            </g>
+          );
+        })}
+
+        {/* ── Arrows: harness.yaml → Desktop App & CLI ── */}
+        {/* harness.yaml → Desktop App */}
+        <Arrow
+          x1={HY.x + 90} y1={HY.y + HY.h}
+          x2={DA.x + DA.w / 2} y2={DA.y}
+          label="manages" labelX={160} labelY={HY.y + HY.h + 18}
+        />
+        {/* harness.yaml → CLI */}
+        <Arrow
+          x1={HY.x + HY.w - 90} y1={HY.y + HY.h}
+          x2={CL.x + CL.w / 2} y2={CL.y}
+          label="compile / validate" labelX={540} labelY={HY.y + HY.h + 18}
+        />
+
+        {/* ── Desktop App ── */}
+        <rect x={DA.x} y={DA.y} width={DA.w} height={DA.h} rx={10}
+          fill={SURFACE_MID} stroke={CYAN_DIM} strokeWidth={1} />
+
+        <Label x={DA.x + DA.w / 2} y={DA.y + 14}>DESKTOP APP</Label>
+
+        {desktopGroups.map((g, gi) => {
+          const gy = DA.y + 26 + gi * 47;
+          return (
+            <g key={g.label}>
+              {/* group label */}
+              <text x={DA.x + 12} y={gy + 10}
+                fontFamily={FONT} fontSize={7.5} fontWeight={700}
+                letterSpacing="0.09em" fill={SUBTLE}>
+                {g.label}
+              </text>
+              {/* chips */}
+              {g.items.map((item, ii) => {
+                const chipX = DA.x + 12 + ii * 66;
+                return (
+                  <g key={item}>
+                    <rect x={chipX} y={gy + 15} width={62} height={18} rx={4}
+                      fill={SURFACE} stroke={BORDER} />
+                    <text x={chipX + 31} y={gy + 27}
+                      fontFamily={FONT} fontSize={9} fill={MUTED}
+                      textAnchor="middle">
+                      {item}
+                    </text>
+                  </g>
+                );
+              })}
+            </g>
+          );
+        })}
+
+        {/* ── CLI ── */}
+        <rect x={CL.x} y={CL.y} width={CL.w} height={CL.h} rx={10}
+          fill={SURFACE_MID} stroke={BORDER} strokeWidth={1} />
+
+        <Label x={CL.x + CL.w / 2} y={CL.y + 14}>CLI — harness-kit</Label>
+
+        <text x={CL.x + CL.w / 2} y={CL.y + 32}
+          fontFamily={FONT} fontSize={9} fill={SUBTLE} textAnchor="middle">
+          standalone terminal tool
+        </text>
+
+        {/* command chips — two rows of 3 */}
+        {cliCommands.map((cmd, i) => {
+          const col = i % 3;
+          const row = Math.floor(i / 3);
+          const cx = CL.x + 12 + col * 74;
+          const cy = CL.y + 44 + row * 26;
+          return (
+            <g key={cmd}>
+              <rect x={cx} y={cy} width={68} height={18} rx={4}
+                fill={SURFACE} stroke={BORDER} />
+              <text x={cx + 34} y={cy + 12}
+                fontFamily={MONO} fontSize={9} fill={MUTED}
+                textAnchor="middle">
+                {cmd}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* ── Arrow: CLI → Native Configs ── */}
+        <Arrow
+          x1={CL.x + CL.w / 2} y1={CL.y + CL.h}
+          x2={CC.x + CC.w / 2} y2={CC.y}
+          label="compiles to" labelX={CL.x + CL.w / 2 + 8} labelY={CL.y + CL.h + 18}
+        />
+
+        {/* ── Native Configs ── */}
+        <rect x={CC.x} y={CC.y} width={CC.w} height={CC.h} rx={10}
+          fill={SURFACE} stroke={BORDER} strokeWidth={1} />
+
+        <Label x={CC.x + CC.w / 2} y={CC.y + 14}>NATIVE CONFIGS</Label>
+
+        {/* config targets */}
+        {['.claude/settings.json', '.cursor/rules', 'copilot config'].map((c, i) => (
+          <text key={c}
+            x={CC.x + CC.w / 2} y={CC.y + 32 + i * 14}
+            fontFamily={MONO} fontSize={9} fill={SUBTLE}
+            textAnchor="middle">
+            {c}
+          </text>
+        ))}
+
+        {/* ── Arrow: Native Configs → AI Tools ── */}
+        <Arrow
+          x1={CC.x + CC.w / 2 - 20} y1={CC.y + CC.h}
+          x2={AT.x + AT.w - 40} y2={AT.y}
+          label="loads into" labelX={520} labelY={CC.y + CC.h + 32}
+          dashed
+        />
+
+        {/* ── Plugin System ── */}
+        <rect x={PS.x} y={PS.y} width={PS.w} height={PS.h} rx={10}
+          fill={SURFACE_MID} stroke={BORDER} strokeWidth={1} />
+
+        <Label x={PS.x + PS.w / 2} y={PS.y + 14}>PLUGIN SYSTEM</Label>
+
+        {pluginParts.map((p, i) => {
+          const col = i % 2;
+          const row = Math.floor(i / 2);
+          const px = PS.x + 12 + col * 116;
+          const py = PS.y + 26 + row * 26;
+          return (
+            <g key={p.name}>
+              <rect x={px} y={py} width={110} height={20} rx={4}
+                fill={SURFACE}
+                stroke={p.highlight ? CYAN_DIM : BORDER} />
+              <text x={px + 6} y={py + 13}
+                fontFamily={MONO} fontSize={9}
+                fill={p.highlight ? CYAN : MUTED}>
+                {p.name}
+              </text>
+              <text x={px + 54} y={py + 13}
+                fontFamily={FONT} fontSize={8.5}
+                fill={SUBTLE}>
+                {p.desc}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* ── Arrow: Plugin System → AI Tools (installed via harness.yaml, runs in AI tool) ── */}
+        <Arrow
+          x1={PS.x + PS.w} y1={PS.y + PS.h / 2}
+          x2={AT.x} y2={AT.y + AT.h / 2}
+          label="runs in" labelX={(PS.x + PS.w + AT.x) / 2} labelY={AT.y + AT.h / 2 - 8}
+        />
+
+        {/* ── AI Tools ── */}
+        <rect x={AT.x} y={AT.y} width={AT.w} height={AT.h} rx={10}
+          fill={SURFACE_MID} stroke={BORDER} strokeWidth={1} />
+
+        <Label x={AT.x + AT.w / 2} y={AT.y + 14}>AI TOOLS</Label>
+
+        {aiTools.map((tool, i) => {
+          const tx = AT.x + 12 + (i % 3) * 76;
+          const ty = AT.y + 24 + Math.floor(i / 3) * 24;
+          return (
+            <g key={tool}>
+              <rect x={tx} y={ty} width={70} height={17} rx={4}
+                fill={SURFACE} stroke={BORDER} />
+              <text x={tx + 35} y={ty + 11.5}
+                fontFamily={FONT} fontSize={8.5} fill={MUTED}
+                textAnchor="middle">
+                {tool}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* ── Session data feedback arrow: AI Tools → Desktop App Observatory ── */}
+        {/* Path: left edge of AI Tools → go left → go up → right edge of Desktop App */}
+        <defs>
+          <marker id="arr-feedback" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+            <polygon points="0 0,8 3,0 6" fill={SUBTLE} opacity={0.5} />
+          </marker>
+        </defs>
+        <path
+          d={`M${AT.x},${AT.y + AT.h / 2} L${AT.x - 28},${AT.y + AT.h / 2} L${AT.x - 28},${DA.y + DA.h / 2} L${DA.x + DA.w},${DA.y + DA.h / 2}`}
+          fill="none"
+          stroke={SUBTLE}
+          strokeWidth={1}
+          strokeDasharray="4 3"
+          markerEnd="url(#arr-feedback)"
+          opacity={0.4}
+        />
+        <text
+          x={AT.x - 50} y={(AT.y + AT.h / 2 + DA.y + DA.h / 2) / 2}
+          fontFamily={FONT} fontSize={8.5} fill={SUBTLE}
+          textAnchor="middle" opacity={0.6}
+          transform={`rotate(-90, ${AT.x - 50}, ${(AT.y + AT.h / 2 + DA.y + DA.h / 2) / 2})`}
         >
-          <span style={{ color: '#9aa0ad' }}>sources:</span>{'\n'}
-          {'  '}<span style={{ color: '#5a6270' }}>- harnessprotocol/harness-kit</span>{'\n'}
-          <span style={{ color: '#9aa0ad' }}>plugins:</span>{'\n'}
-          {'  '}<span style={{ color: '#5a6270' }}>- research@0.2.0  # SKILL.md + scripts bundled</span>{'\n'}
-          {'  '}<span style={{ color: '#5a6270' }}>- board@0.1.0     # SKILL.md + MCP server</span>{'\n'}
-          <span style={{ color: '#9aa0ad' }}>mcp-servers:</span>{'\n'}
-          {'  '}<span style={{ color: '#5a6270' }}>- memory           # knowledge graph</span>{'\n'}
-          {'  '}<span style={{ color: '#5a6270' }}>- filesystem       # local file access</span>
-        </div>
-      </div>
+          session data
+        </text>
 
-      {/* connector */}
-      <div style={{ ...connectorStyle, justifyContent: 'space-around' }}>
-        <span style={{ color: 'rgba(34,177,236,0.4)', fontSize: '10px' }}>↙ installs &amp; manages</span>
-        <span style={{ color: 'rgba(34,177,236,0.4)', fontSize: '10px' }}>validates &amp; compiles ↘</span>
-      </div>
-
-      {/* ── Plugin System + CLI ── */}
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px' }}>
-
-        {/* Plugin System */}
-        <div style={mutedLayer}>
-          <div style={layerLabelStyle}>Plugin System</div>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
-            {pluginParts.map((p) => (
-              <div
-                key={p.name}
-                style={{
-                  display: 'flex',
-                  gap: '8px',
-                  alignItems: 'flex-start',
-                  padding: '6px 8px',
-                  borderRadius: '6px',
-                  background: 'rgba(13,16,22,0.5)',
-                  border: p.accent ? '1px solid rgba(34,177,236,0.25)' : '1px solid transparent',
-                }}
-              >
-                <code style={{
-                  fontSize: '10px',
-                  fontWeight: 600,
-                  whiteSpace: 'nowrap',
-                  color: p.accent ? 'var(--accent, #22b1ec)' : 'var(--fg-base, #e8eaf0)',
-                  background: 'none',
-                  padding: 0,
-                  minWidth: '68px',
-                }}>
-                  {p.name}
-                </code>
-                <span style={{ fontSize: '10px', color: 'var(--fg-muted, #9aa0ad)', lineHeight: 1.4 }}>{p.desc}</span>
-              </div>
-            ))}
-          </div>
-        </div>
-
-        {/* CLI */}
-        <div style={mutedLayer}>
-          <div style={layerLabelStyle}>CLI — harness-kit</div>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
-            {cliOps.map((op) => (
-              <div
-                key={op.cmd}
-                style={{
-                  display: 'flex',
-                  gap: '8px',
-                  alignItems: 'flex-start',
-                  padding: '6px 8px',
-                  borderRadius: '6px',
-                  background: 'rgba(13,16,22,0.5)',
-                  border: '1px solid transparent',
-                }}
-              >
-                <code style={{
-                  fontSize: '10px',
-                  fontWeight: 600,
-                  whiteSpace: 'nowrap',
-                  color: 'var(--fg-base, #e8eaf0)',
-                  background: 'none',
-                  padding: 0,
-                  minWidth: '60px',
-                }}>
-                  {op.cmd}
-                </code>
-                <span style={{ fontSize: '10px', color: 'var(--fg-muted, #9aa0ad)', lineHeight: 1.4 }}>{op.desc}</span>
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-
-      {/* connector */}
-      <div style={connectorStyle}>
-        <svg width="1" height="20" viewBox="0 0 1 20" aria-hidden="true">
-          <line x1="0.5" y1="0" x2="0.5" y2="20" stroke="rgba(100,100,120,0.4)" strokeWidth="1.5" strokeDasharray="3 2" />
-        </svg>
-        <span style={{ color: 'rgba(100,100,120,0.6)', fontSize: '10px' }}>runs in</span>
-        <svg width="1" height="20" viewBox="0 0 1 20" aria-hidden="true">
-          <line x1="0.5" y1="0" x2="0.5" y2="20" stroke="rgba(100,100,120,0.4)" strokeWidth="1.5" strokeDasharray="3 2" />
-        </svg>
-      </div>
-
-      {/* ── AI Tools ── */}
-      <div style={{ ...mutedLayer, border: '1px solid var(--border-base, rgba(255,255,255,0.07))' }}>
-        <div style={layerLabelStyle}>AI Tools</div>
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
-          {aiTools.map((tool) => (
-            <span
-              key={tool}
-              style={{
-                fontSize: '11px',
-                fontWeight: 500,
-                padding: '4px 10px',
-                borderRadius: '6px',
-                background: 'rgba(13,16,22,0.6)',
-                border: '1px solid rgba(255,255,255,0.08)',
-                color: 'var(--fg-muted, #9aa0ad)',
-              }}
-            >
-              {tool}
-            </span>
-          ))}
-          <span style={{
-            fontSize: '11px',
-            padding: '4px 10px',
-            borderRadius: '6px',
-            color: 'var(--fg-subtle, #6b7280)',
-          }}>
-            + any tool that reads markdown
-          </span>
-        </div>
-      </div>
-
+      </svg>
     </div>
   );
 }

--- a/website/components/architecture-diagram.tsx
+++ b/website/components/architecture-diagram.tsx
@@ -32,7 +32,8 @@ const pluginParts = [
   { name: 'scripts/',  desc: 'shell automation' },
 ];
 
-const aiTools = ['Claude Code', 'Cursor', 'Copilot', 'Windsurf', 'Zed'];
+// Harnesses sourced from cross-harness/ide-support.md support matrix
+const harnesses = ['Claude Code', 'Copilot', 'Cursor', 'Windsurf', 'Codex'];
 
 // 3 rows × 2 columns; values shortened to fit 286px value column
 const yamlFields = [
@@ -76,7 +77,7 @@ export function ArchitectureDiagram() {
         xmlns="http://www.w3.org/2000/svg"
         viewBox={`0 0 ${W} ${totalH}`}
         style={{ width: '100%', display: 'block' }}
-        aria-label="harness-kit architecture diagram"
+        aria-label="harness-kit architecture: harness.yaml → Desktop App and CLI → Native Configs → Harnesses; Plugin System runs in Harnesses"
       >
         <defs>
           {/* Reusable arrowheads — one per style to avoid duplicate IDs */}
@@ -349,11 +350,11 @@ export function ArchitectureDiagram() {
         <text x={AT.x + AT.w / 2} y={AT.y + 16}
           fontFamily={FONT} fontSize={8} fontWeight={700} letterSpacing="0.1em"
           fill={SUBTLE} textAnchor="middle">
-          AI TOOLS
+          HARNESSES
         </text>
 
         {/* 3+2 grid; chipW=98, gap=8; 3×98+2×8=310 in 340 */}
-        {aiTools.map((tool, i) => {
+        {harnesses.map((tool, i) => {
           const col = i % 3;
           const row = Math.floor(i / 3);
           const tx  = AT.x + 14 + col * 106;

--- a/website/components/architecture-diagram.tsx
+++ b/website/components/architecture-diagram.tsx
@@ -5,124 +5,70 @@
 const FONT = 'system-ui, -apple-system, sans-serif';
 const MONO = 'Menlo, Monaco, Consolas, monospace';
 const CYAN = '#22b1ec';
-const CYAN_DIM = 'rgba(34,177,236,0.25)';
-const CYAN_FAINT = 'rgba(34,177,236,0.08)';
+const CYAN_DIM = 'rgba(34,177,236,0.18)';
 const SURFACE = '#0d1016';
 const SURFACE_MID = '#111827';
-const BORDER = 'rgba(255,255,255,0.08)';
-const TEXT = '#e4e7ec';
+const BORDER = 'rgba(255,255,255,0.09)';
+const BORDER_MID = 'rgba(255,255,255,0.14)';
 const MUTED = '#8b919e';
-const SUBTLE = '#545b67';
+const SUBTLE = '#4a5060';
 
-// Groups come from NAV_SECTIONS in AppLayout.tsx
+// Groups sourced from NAV_SECTIONS in AppLayout.tsx
 const desktopGroups = [
-  { label: 'CORE', items: ['Harness', 'Marketplace'] },
-  { label: 'INSIGHTS', items: ['Observatory'] },
-  { label: 'SYSTEM', items: ['Security'] },
+  { label: 'CORE',      items: ['Harness', 'Marketplace'] },
+  { label: 'INSIGHTS',  items: ['Observatory'] },
+  { label: 'SYSTEM',    items: ['Security'] },
   { label: 'WORKFLOWS', items: ['Board', 'Roadmap'] },
-  { label: 'OTHER', items: ['Agents', 'Comparator', 'Parity', 'AI Chat', 'Memory'] },
+  { label: 'OTHER',     items: ['Agents', 'Comparator', 'Parity', 'AI Chat', 'Memory'] },
 ];
 
+// Commands sourced from apps/cli/src/index.ts
 const cliCommands = ['validate', 'compile', 'sync', 'check', 'detect', 'scan'];
 
 const pluginParts = [
   { name: 'SKILL.md', desc: 'workflow definition', highlight: true },
-  { name: 'agents/', desc: 'specialist subagents' },
-  { name: 'hooks/', desc: 'lifecycle events' },
-  { name: 'scripts/', desc: 'shell automation' },
+  { name: 'agents/',   desc: 'specialist subagents' },
+  { name: 'hooks/',    desc: 'lifecycle handlers' },
+  { name: 'scripts/',  desc: 'shell automation' },
 ];
 
 const aiTools = ['Claude Code', 'Cursor', 'Copilot', 'Windsurf', 'Zed'];
 
-const yamlLines = [
-  { key: 'plugins:', val: '- research@0.2.0  - board@0.1.0  - explain@0.2.0' },
-  { key: 'mcp-servers:', val: '- memory  - filesystem' },
-  { key: 'instructions:', val: '{ operational, behavioral, identity }' },
-  { key: 'permissions:', val: '{ tools, paths, network }' },
-  { key: 'env:', val: 'ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}' },
-  { key: 'extends:', val: '[ profiles/backend-engineer.yaml ]' },
+// 3 rows × 2 columns; values shortened to fit 286px value column
+const yamlFields = [
+  { key: 'plugins:',      val: 'research  board  explain' },
+  { key: 'mcp-servers:',  val: 'memory  filesystem' },
+  { key: 'instructions:', val: '{ operational, behavioral }' },
+  { key: 'permissions:',  val: '{ tools, paths, network }' },
+  { key: 'env:',          val: 'ANTHROPIC_API_KEY: ${...}' },
+  { key: 'extends:',      val: 'profiles/backend-engineer.yaml' },
 ];
 
-/* ─── sub-components ─── */
-
-function Label({ x, y, children }: { x: number; y: number; children: string }) {
-  return (
-    <text
-      x={x} y={y}
-      fontFamily={FONT} fontSize={8} fontWeight={700}
-      letterSpacing="0.1em" fill={SUBTLE}
-      textAnchor="middle"
-    >
-      {children}
-    </text>
-  );
-}
-
-function Arrow({
-  x1, y1, x2, y2,
-  label, labelX, labelY,
-  dashed,
-}: {
-  x1: number; y1: number; x2: number; y2: number;
-  label?: string; labelX?: number; labelY?: number;
-  dashed?: boolean;
-}) {
-  return (
-    <>
-      <defs>
-        <marker id={`arr-${x1}-${y1}`} markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-          <polygon points="0 0,8 3,0 6" fill={dashed ? SUBTLE : CYAN} />
-        </marker>
-      </defs>
-      <line
-        x1={x1} y1={y1} x2={x2} y2={y2}
-        stroke={dashed ? SUBTLE : CYAN}
-        strokeWidth={dashed ? 1 : 1.5}
-        strokeDasharray={dashed ? '4 3' : undefined}
-        markerEnd={`url(#arr-${x1}-${y1})`}
-        opacity={dashed ? 0.4 : 0.7}
-      />
-      {label && (
-        <text
-          x={labelX ?? (x1 + x2) / 2}
-          y={labelY ?? (y1 + y2) / 2 - 5}
-          fontFamily={FONT} fontSize={9} fontWeight={600}
-          fill={dashed ? SUBTLE : CYAN}
-          textAnchor="middle"
-          opacity={dashed ? 0.6 : 0.9}
-        >
-          {label}
-        </text>
-      )}
-    </>
-  );
-}
-
-/* ─── main diagram ─── */
-
 export function ArchitectureDiagram() {
-  // Layout constants
-  const W = 680;
+  // ── Layout constants ────────────────────────────────────────────────────────
+  const W = 780;
 
-  // harness.yaml: top center
-  const HY = { x: 80, y: 24, w: 520, h: 116 };
+  // harness.yaml — full width, top
+  const HY = { x: 20,  y: 20,  w: 740, h: 142 };
 
-  // Desktop App: left column
-  const DA = { x: 24, y: 184, w: 236, h: 262 };
+  // Left column
+  const DA = { x: 20,  y: 200, w: 340, h: 280 };  // Desktop App
 
-  // CLI: right column (top)
-  const CL = { x: 424, y: 184, w: 232, h: 100 };
+  // Right column
+  const CL = { x: 420, y: 200, w: 340, h: 112 };  // CLI
+  const CC = { x: 420, y: 342, w: 340, h: 86  };  // Native Configs
 
-  // Compiled configs: right column (below CLI)
-  const CC = { x: 424, y: 304, w: 232, h: 72 };
+  // Bottom row  (PS.y = DA.y + DA.h + 20 = 500; AT aligns with PS)
+  const PS = { x: 20,  y: 500, w: 340, h: 124 };  // Plugin System
+  const AT = { x: 420, y: 500, w: 340, h: 124 };  // AI Tools
 
-  // Plugin System: bottom left
-  const PS = { x: 24, y: 490, w: 236, h: 90 };
+  const totalH = 644;
 
-  // AI Tools: bottom center-right
-  const AT = { x: 280, y: 480, w: 240, h: 80 };
-
-  const totalH = 590;
+  // ── Derived midpoints used by arrows ────────────────────────────────────────
+  // Feedback path runs at x=390 — in the 60 px gap between DA/PS (right=360) and CL/AT (left=420)
+  const feedX    = 390;
+  const atMidY   = AT.y + AT.h / 2;   // 562
+  const daMidY   = DA.y + DA.h / 2;   // 340
 
   return (
     <div className="not-prose my-8">
@@ -132,107 +78,165 @@ export function ArchitectureDiagram() {
         style={{ width: '100%', display: 'block' }}
         aria-label="harness-kit architecture diagram"
       >
+        <defs>
+          {/* Reusable arrowheads — one per style to avoid duplicate IDs */}
+          <marker id="ad-arr-cyan" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+            <polygon points="0 0,8 3,0 6" fill={CYAN} />
+          </marker>
+          <marker id="ad-arr-subtle" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+            <polygon points="0 0,8 3,0 6" fill={SUBTLE} opacity="0.8" />
+          </marker>
+        </defs>
 
-        {/* ── harness.yaml ── */}
+        {/* ════════════════════════════════════════════════════════════════════
+            harness.yaml
+        ════════════════════════════════════════════════════════════════════ */}
         <rect x={HY.x} y={HY.y} width={HY.w} height={HY.h} rx={10}
           fill={SURFACE} stroke={CYAN} strokeWidth={1.5} />
 
-        {/* header row */}
-        <text x={HY.x + HY.w / 2} y={HY.y + 22}
+        <text x={HY.x + HY.w / 2} y={HY.y + 23}
           fontFamily={MONO} fontSize={14} fontWeight={700}
           fill={CYAN} textAnchor="middle">
           harness.yaml
         </text>
-        <line x1={HY.x + 16} y1={HY.y + 30} x2={HY.x + HY.w - 16} y2={HY.y + 30}
-          stroke={CYAN_DIM} strokeWidth={1} />
 
-        {/* yaml fields — two columns */}
-        {yamlLines.map((line, i) => {
+        <line
+          x1={HY.x + 16} y1={HY.y + 33}
+          x2={HY.x + HY.w - 16} y2={HY.y + 33}
+          stroke={CYAN_DIM} strokeWidth={1}
+        />
+
+        {/* YAML fields — 3 rows × 2 columns
+            Left col: x=44, Right col: x=418
+            Value offset: +86 px (clears longest key "instructions:") */}
+        {yamlFields.map((f, i) => {
           const col = i % 2;
           const row = Math.floor(i / 2);
-          const cx = HY.x + 20 + col * 258;
-          const cy = HY.y + 47 + row * 24;
+          const kx  = HY.x + 24 + col * 374;
+          const ky  = HY.y + 56 + row * 28;
           return (
-            <g key={i}>
-              <text x={cx} y={cy} fontFamily={MONO} fontSize={9} fontWeight={600} fill={MUTED}>{line.key}</text>
-              <text x={cx + 80} y={cy} fontFamily={MONO} fontSize={9} fill={SUBTLE}>{line.val}</text>
+            <g key={f.key}>
+              <text x={kx}      y={ky} fontFamily={MONO} fontSize={9} fontWeight={600} fill={MUTED}>{f.key}</text>
+              <text x={kx + 86} y={ky} fontFamily={MONO} fontSize={9}                  fill={SUBTLE}>{f.val}</text>
             </g>
           );
         })}
 
-        {/* ── Arrows: harness.yaml → Desktop App & CLI ── */}
-        {/* harness.yaml → Desktop App */}
-        <Arrow
-          x1={HY.x + 90} y1={HY.y + HY.h}
+        {/* ════════════════════════════════════════════════════════════════════
+            Arrows: harness.yaml → Desktop App and CLI
+        ════════════════════════════════════════════════════════════════════ */}
+        {/* → Desktop App */}
+        <line
+          x1={160} y1={HY.y + HY.h}
           x2={DA.x + DA.w / 2} y2={DA.y}
-          label="manages" labelX={160} labelY={HY.y + HY.h + 18}
+          stroke={CYAN} strokeWidth={1.5} markerEnd="url(#ad-arr-cyan)" opacity={0.7}
         />
-        {/* harness.yaml → CLI */}
-        <Arrow
-          x1={HY.x + HY.w - 90} y1={HY.y + HY.h}
-          x2={CL.x + CL.w / 2} y2={CL.y}
-          label="compile / validate" labelX={540} labelY={HY.y + HY.h + 18}
-        />
+        <text x={148} y={HY.y + HY.h + 16}
+          fontFamily={FONT} fontSize={9} fontWeight={600} fill={CYAN} textAnchor="middle" opacity={0.9}>
+          manages
+        </text>
 
-        {/* ── Desktop App ── */}
+        {/* → CLI */}
+        <line
+          x1={620} y1={HY.y + HY.h}
+          x2={CL.x + CL.w / 2} y2={CL.y}
+          stroke={CYAN} strokeWidth={1.5} markerEnd="url(#ad-arr-cyan)" opacity={0.7}
+        />
+        <text x={635} y={HY.y + HY.h + 16}
+          fontFamily={FONT} fontSize={9} fontWeight={600} fill={CYAN} textAnchor="middle" opacity={0.9}>
+          compile / validate
+        </text>
+
+        {/* ════════════════════════════════════════════════════════════════════
+            Desktop App
+        ════════════════════════════════════════════════════════════════════ */}
         <rect x={DA.x} y={DA.y} width={DA.w} height={DA.h} rx={10}
           fill={SURFACE_MID} stroke={CYAN_DIM} strokeWidth={1} />
 
-        <Label x={DA.x + DA.w / 2} y={DA.y + 14}>DESKTOP APP</Label>
+        <text x={DA.x + DA.w / 2} y={DA.y + 16}
+          fontFamily={FONT} fontSize={8} fontWeight={700} letterSpacing="0.1em"
+          fill={SUBTLE} textAnchor="middle">
+          DESKTOP APP
+        </text>
 
-        {desktopGroups.map((g, gi) => {
-          const gy = DA.y + 26 + gi * 47;
-          return (
-            <g key={g.label}>
-              {/* group label */}
-              <text x={DA.x + 12} y={gy + 10}
-                fontFamily={FONT} fontSize={7.5} fontWeight={700}
-                letterSpacing="0.09em" fill={SUBTLE}>
-                {g.label}
-              </text>
-              {/* chips */}
-              {g.items.map((item, ii) => {
-                const chipX = DA.x + 12 + ii * 66;
-                return (
-                  <g key={item}>
-                    <rect x={chipX} y={gy + 15} width={62} height={18} rx={4}
-                      fill={SURFACE} stroke={BORDER} />
-                    <text x={chipX + 31} y={gy + 27}
-                      fontFamily={FONT} fontSize={9} fill={MUTED}
-                      textAnchor="middle">
-                      {item}
-                    </text>
-                  </g>
-                );
-              })}
-            </g>
-          );
-        })}
+        {/* Groups — calculated at render time so gy advances correctly */}
+        {(() => {
+          let gy = DA.y + 26;
+          return desktopGroups.map((g) => {
+            const maxPerRow = g.label === 'OTHER' ? 3 : 2;
+            const chipW     = maxPerRow === 3 ? 100 : 152;
+            const chipH     = 18;
+            const gap       = 6;
+            const rows      = Math.ceil(g.items.length / maxPerRow);
 
-        {/* ── CLI ── */}
+            const groupStartY = gy;
+            // Advance: group label + chip rows + bottom gap
+            gy += 11 + rows * (chipH + 4) + 9;
+
+            return (
+              <g key={g.label}>
+                {/* Section label */}
+                <text
+                  x={DA.x + 14} y={groupStartY + 9}
+                  fontFamily={FONT} fontSize={7.5} fontWeight={700}
+                  letterSpacing="0.09em" fill={SUBTLE}
+                >
+                  {g.label}
+                </text>
+
+                {/* Chips */}
+                {g.items.map((item, ii) => {
+                  const col   = ii % maxPerRow;
+                  const row   = Math.floor(ii / maxPerRow);
+                  const chipX = DA.x + 14 + col * (chipW + gap);
+                  const chipY = groupStartY + 12 + row * (chipH + 4);
+                  return (
+                    <g key={item}>
+                      <rect x={chipX} y={chipY} width={chipW} height={chipH} rx={4}
+                        fill={SURFACE} stroke={BORDER_MID} />
+                      <text
+                        x={chipX + chipW / 2} y={chipY + 12}
+                        fontFamily={FONT} fontSize={9} fill={MUTED} textAnchor="middle"
+                      >
+                        {item}
+                      </text>
+                    </g>
+                  );
+                })}
+              </g>
+            );
+          });
+        })()}
+
+        {/* ════════════════════════════════════════════════════════════════════
+            CLI
+        ════════════════════════════════════════════════════════════════════ */}
         <rect x={CL.x} y={CL.y} width={CL.w} height={CL.h} rx={10}
           fill={SURFACE_MID} stroke={BORDER} strokeWidth={1} />
 
-        <Label x={CL.x + CL.w / 2} y={CL.y + 14}>CLI — harness-kit</Label>
-
-        <text x={CL.x + CL.w / 2} y={CL.y + 32}
-          fontFamily={FONT} fontSize={9} fill={SUBTLE} textAnchor="middle">
+        <text x={CL.x + CL.w / 2} y={CL.y + 16}
+          fontFamily={FONT} fontSize={8} fontWeight={700} letterSpacing="0.1em"
+          fill={SUBTLE} textAnchor="middle">
+          CLI — harness-kit
+        </text>
+        <text x={CL.x + CL.w / 2} y={CL.y + 30}
+          fontFamily={FONT} fontSize={8.5} fill={SUBTLE} textAnchor="middle">
           standalone terminal tool
         </text>
 
-        {/* command chips — two rows of 3 */}
+        {/* Command chips — 2 rows of 3
+            chipW=100, gap=8 → 3×100 + 2×8 = 316 px; start at CL.x+14=434 */}
         {cliCommands.map((cmd, i) => {
           const col = i % 3;
           const row = Math.floor(i / 3);
-          const cx = CL.x + 12 + col * 74;
-          const cy = CL.y + 44 + row * 26;
+          const cx  = CL.x + 14 + col * 108;
+          const cy  = CL.y + 42 + row * 28;
           return (
             <g key={cmd}>
-              <rect x={cx} y={cy} width={68} height={18} rx={4}
+              <rect x={cx} y={cy} width={100} height={20} rx={4}
                 fill={SURFACE} stroke={BORDER} />
-              <text x={cx + 34} y={cy + 12}
-                fontFamily={MONO} fontSize={9} fill={MUTED}
-                textAnchor="middle">
+              <text x={cx + 50} y={cy + 13.5}
+                fontFamily={MONO} fontSize={9} fill={MUTED} textAnchor="middle">
                 {cmd}
               </text>
             </g>
@@ -240,116 +244,157 @@ export function ArchitectureDiagram() {
         })}
 
         {/* ── Arrow: CLI → Native Configs ── */}
-        <Arrow
+        <line
           x1={CL.x + CL.w / 2} y1={CL.y + CL.h}
           x2={CC.x + CC.w / 2} y2={CC.y}
-          label="compiles to" labelX={CL.x + CL.w / 2 + 8} labelY={CL.y + CL.h + 18}
+          stroke={CYAN} strokeWidth={1.5} markerEnd="url(#ad-arr-cyan)" opacity={0.7}
         />
+        <text x={CL.x + CL.w / 2 + 62} y={(CL.y + CL.h + CC.y) / 2 + 4}
+          fontFamily={FONT} fontSize={9} fontWeight={600} fill={CYAN} textAnchor="middle" opacity={0.9}>
+          compiles to
+        </text>
 
-        {/* ── Native Configs ── */}
+        {/* ════════════════════════════════════════════════════════════════════
+            Native Configs
+        ════════════════════════════════════════════════════════════════════ */}
         <rect x={CC.x} y={CC.y} width={CC.w} height={CC.h} rx={10}
           fill={SURFACE} stroke={BORDER} strokeWidth={1} />
 
-        <Label x={CC.x + CC.w / 2} y={CC.y + 14}>NATIVE CONFIGS</Label>
+        <text x={CC.x + CC.w / 2} y={CC.y + 16}
+          fontFamily={FONT} fontSize={8} fontWeight={700} letterSpacing="0.1em"
+          fill={SUBTLE} textAnchor="middle">
+          NATIVE CONFIGS
+        </text>
 
-        {/* config targets */}
         {['.claude/settings.json', '.cursor/rules', 'copilot config'].map((c, i) => (
           <text key={c}
-            x={CC.x + CC.w / 2} y={CC.y + 32 + i * 14}
-            fontFamily={MONO} fontSize={9} fill={SUBTLE}
-            textAnchor="middle">
+            x={CC.x + CC.w / 2} y={CC.y + 34 + i * 16}
+            fontFamily={MONO} fontSize={9} fill={SUBTLE} textAnchor="middle">
             {c}
           </text>
         ))}
 
-        {/* ── Arrow: Native Configs → AI Tools ── */}
-        <Arrow
-          x1={CC.x + CC.w / 2 - 20} y1={CC.y + CC.h}
-          x2={AT.x + AT.w - 40} y2={AT.y}
-          label="loads into" labelX={520} labelY={CC.y + CC.h + 32}
-          dashed
+        {/* ── Arrow: Native Configs → AI Tools (dashed — loaded at session start) ── */}
+        <line
+          x1={CC.x + CC.w / 2} y1={CC.y + CC.h}
+          x2={AT.x + AT.w / 2} y2={AT.y}
+          stroke={SUBTLE} strokeWidth={1} strokeDasharray="4 3"
+          markerEnd="url(#ad-arr-subtle)" opacity={0.35}
         />
+        <text x={CC.x + CC.w / 2 + 58} y={(CC.y + CC.h + AT.y) / 2 + 4}
+          fontFamily={FONT} fontSize={9} fontWeight={600} fill={SUBTLE} textAnchor="middle" opacity={0.55}>
+          loads into
+        </text>
 
-        {/* ── Plugin System ── */}
+        {/* ════════════════════════════════════════════════════════════════════
+            Plugin System
+        ════════════════════════════════════════════════════════════════════ */}
         <rect x={PS.x} y={PS.y} width={PS.w} height={PS.h} rx={10}
           fill={SURFACE_MID} stroke={BORDER} strokeWidth={1} />
 
-        <Label x={PS.x + PS.w / 2} y={PS.y + 14}>PLUGIN SYSTEM</Label>
+        <text x={PS.x + PS.w / 2} y={PS.y + 16}
+          fontFamily={FONT} fontSize={8} fontWeight={700} letterSpacing="0.1em"
+          fill={SUBTLE} textAnchor="middle">
+          PLUGIN SYSTEM
+        </text>
 
+        {/* 2×2 grid of plugin parts; chip width=154, gap=8 → 2×154+8=316 in 340 */}
         {pluginParts.map((p, i) => {
-          const col = i % 2;
-          const row = Math.floor(i / 2);
-          const px = PS.x + 12 + col * 116;
-          const py = PS.y + 26 + row * 26;
+          const col  = i % 2;
+          const row  = Math.floor(i / 2);
+          const px   = PS.x + 14 + col * 162;
+          const py   = PS.y + 28 + row * 32;
           return (
             <g key={p.name}>
-              <rect x={px} y={py} width={110} height={20} rx={4}
+              <rect x={px} y={py} width={154} height={22} rx={4}
                 fill={SURFACE}
-                stroke={p.highlight ? CYAN_DIM : BORDER} />
-              <text x={px + 6} y={py + 13}
+                stroke={p.highlight ? CYAN_DIM : BORDER}
+                strokeWidth={1}
+              />
+              {/* name */}
+              <text x={px + 8} y={py + 14.5}
                 fontFamily={MONO} fontSize={9}
                 fill={p.highlight ? CYAN : MUTED}>
                 {p.name}
               </text>
-              <text x={px + 54} y={py + 13}
+              {/* description */}
+              <text x={px + 8 + (p.name.length * 5.6)} y={py + 14.5}
                 fontFamily={FONT} fontSize={8.5}
                 fill={SUBTLE}>
-                {p.desc}
+                {'  '}{p.desc}
               </text>
             </g>
           );
         })}
 
-        {/* ── Arrow: Plugin System → AI Tools (installed via harness.yaml, runs in AI tool) ── */}
-        <Arrow
+        {/* ── Arrow: Plugin System → AI Tools ── */}
+        <line
           x1={PS.x + PS.w} y1={PS.y + PS.h / 2}
-          x2={AT.x} y2={AT.y + AT.h / 2}
-          label="runs in" labelX={(PS.x + PS.w + AT.x) / 2} labelY={AT.y + AT.h / 2 - 8}
+          x2={AT.x}         y2={AT.y + AT.h / 2}
+          stroke={CYAN} strokeWidth={1.5} markerEnd="url(#ad-arr-cyan)" opacity={0.7}
         />
+        <text
+          x={(PS.x + PS.w + AT.x) / 2} y={PS.y + PS.h / 2 - 7}
+          fontFamily={FONT} fontSize={9} fontWeight={600}
+          fill={CYAN} textAnchor="middle" opacity={0.9}>
+          runs in
+        </text>
 
-        {/* ── AI Tools ── */}
+        {/* ════════════════════════════════════════════════════════════════════
+            AI Tools
+        ════════════════════════════════════════════════════════════════════ */}
         <rect x={AT.x} y={AT.y} width={AT.w} height={AT.h} rx={10}
           fill={SURFACE_MID} stroke={BORDER} strokeWidth={1} />
 
-        <Label x={AT.x + AT.w / 2} y={AT.y + 14}>AI TOOLS</Label>
+        <text x={AT.x + AT.w / 2} y={AT.y + 16}
+          fontFamily={FONT} fontSize={8} fontWeight={700} letterSpacing="0.1em"
+          fill={SUBTLE} textAnchor="middle">
+          AI TOOLS
+        </text>
 
+        {/* 3+2 grid; chipW=98, gap=8; 3×98+2×8=310 in 340 */}
         {aiTools.map((tool, i) => {
-          const tx = AT.x + 12 + (i % 3) * 76;
-          const ty = AT.y + 24 + Math.floor(i / 3) * 24;
+          const col = i % 3;
+          const row = Math.floor(i / 3);
+          const tx  = AT.x + 14 + col * 106;
+          const ty  = AT.y + 26 + row * 30;
           return (
             <g key={tool}>
-              <rect x={tx} y={ty} width={70} height={17} rx={4}
-                fill={SURFACE} stroke={BORDER} />
-              <text x={tx + 35} y={ty + 11.5}
-                fontFamily={FONT} fontSize={8.5} fill={MUTED}
-                textAnchor="middle">
+              <rect x={tx} y={ty} width={98} height={20} rx={4}
+                fill={SURFACE} stroke={BORDER_MID} />
+              <text x={tx + 49} y={ty + 13.5}
+                fontFamily={FONT} fontSize={9} fill={MUTED} textAnchor="middle">
                 {tool}
               </text>
             </g>
           );
         })}
 
-        {/* ── Session data feedback arrow: AI Tools → Desktop App Observatory ── */}
-        {/* Path: left edge of AI Tools → go left → go up → right edge of Desktop App */}
+        {/* ════════════════════════════════════════════════════════════════════
+            Session data feedback: AI Tools Observatory → Desktop App
+            Path runs at x=390 — the 60 px gap between the two columns.
+            DA right edge = 360, AT left edge = 420. No box overlap.
+        ════════════════════════════════════════════════════════════════════ */}
         <defs>
-          <marker id="arr-feedback" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-            <polygon points="0 0,8 3,0 6" fill={SUBTLE} opacity={0.5} />
+          <marker id="ad-arr-feedback" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+            <polygon points="0 0,8 3,0 6" fill={SUBTLE} opacity="0.5" />
           </marker>
         </defs>
         <path
-          d={`M${AT.x},${AT.y + AT.h / 2} L${AT.x - 28},${AT.y + AT.h / 2} L${AT.x - 28},${DA.y + DA.h / 2} L${DA.x + DA.w},${DA.y + DA.h / 2}`}
+          d={`M${AT.x},${atMidY} L${feedX},${atMidY} L${feedX},${daMidY} L${DA.x + DA.w},${daMidY}`}
           fill="none"
           stroke={SUBTLE}
           strokeWidth={1}
           strokeDasharray="4 3"
-          markerEnd="url(#arr-feedback)"
-          opacity={0.4}
+          markerEnd="url(#ad-arr-feedback)"
+          opacity={0.35}
         />
         <text
-          x={AT.x - 50} y={(AT.y + AT.h / 2 + DA.y + DA.h / 2) / 2}
-          fontFamily={FONT} fontSize={8.5} fill={SUBTLE}
-          textAnchor="middle" opacity={0.6}
-          transform={`rotate(-90, ${AT.x - 50}, ${(AT.y + AT.h / 2 + DA.y + DA.h / 2) / 2})`}
+          x={feedX - 10}
+          y={(atMidY + daMidY) / 2}
+          fontFamily={FONT} fontSize={8} fill={SUBTLE}
+          textAnchor="middle" opacity={0.5}
+          transform={`rotate(-90, ${feedX - 10}, ${(atMidY + daMidY) / 2})`}
         >
           session data
         </text>

--- a/website/components/architecture-diagram.tsx
+++ b/website/components/architecture-diagram.tsx
@@ -1,0 +1,279 @@
+// Architecture layer diagram for the "How It Works" docs page.
+// Server component — no interactivity needed.
+
+const EyeIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z" /><circle cx="12" cy="12" r="3" />
+  </svg>
+);
+
+const GraphIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <circle cx="18" cy="5" r="3" /><circle cx="6" cy="12" r="3" /><circle cx="18" cy="19" r="3" />
+    <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" /><line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+  </svg>
+);
+
+const KanbanIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <rect width="18" height="18" x="3" y="3" rx="2" />
+    <path d="M9 3v18M15 3v12" />
+  </svg>
+);
+
+const ChatIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+  </svg>
+);
+
+const surfaces = [
+  { name: 'Observatory', desc: 'Session telemetry · tool call timeline · usage trends', icon: <EyeIcon /> },
+  { name: 'Memory', desc: 'Persistent knowledge graph across every tool and session', icon: <GraphIcon /> },
+  { name: 'Board', desc: 'AI-native Kanban — agents pick up cards, you review', icon: <KanbanIcon /> },
+  { name: 'AI Chat', desc: 'Terminal-style chat with Ollama support and 12 built-in tools', icon: <ChatIcon /> },
+];
+
+const pluginParts = [
+  { name: 'SKILL.md', desc: 'Workflow definition — what Claude reads at invocation', accent: true },
+  { name: 'agents/', desc: 'Specialist subagents — isolated workers with scoped tools' },
+  { name: 'hooks/', desc: 'Lifecycle events — Stop, PreTool, PostTool, etc.' },
+  { name: 'scripts/', desc: 'Shell automation bundled with the plugin' },
+];
+
+const cliOps = [
+  { cmd: 'validate', desc: 'Check harness.yaml against the schema' },
+  { cmd: 'compile', desc: 'Build native configs for Claude Code, Cursor, Copilot' },
+  { cmd: 'sync', desc: 'Pull latest plugin changes from the registry' },
+  { cmd: 'scan', desc: 'Security audit — flag unsafe skill content' },
+];
+
+const aiTools = ['Claude Code', 'Cursor', 'GitHub Copilot', 'Windsurf', 'Zed'];
+
+const layerLabelStyle: React.CSSProperties = {
+  fontSize: '9px',
+  fontWeight: 700,
+  letterSpacing: '0.1em',
+  textTransform: 'uppercase',
+  color: 'var(--fg-subtle, #6b7280)',
+  marginBottom: '10px',
+};
+
+const layerBoxBase: React.CSSProperties = {
+  borderRadius: '12px',
+  padding: '16px',
+};
+
+const accentLayer: React.CSSProperties = {
+  ...layerBoxBase,
+  border: '1px solid rgba(34,177,236,0.35)',
+  background: 'rgba(34,177,236,0.04)',
+};
+
+const mutedLayer: React.CSSProperties = {
+  ...layerBoxBase,
+  border: '1px solid var(--border-base, rgba(255,255,255,0.07))',
+  background: 'var(--bg-surface, #12151c)',
+};
+
+const connectorStyle: React.CSSProperties = {
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  height: '28px',
+  gap: '6px',
+  color: 'rgba(34,177,236,0.5)',
+  fontSize: '11px',
+};
+
+export function ArchitectureDiagram() {
+  return (
+    <div className="not-prose my-8 space-y-0" style={{ fontFamily: 'var(--font-body, system-ui, sans-serif)' }}>
+
+      {/* ── Desktop App ── */}
+      <div style={accentLayer}>
+        <div style={layerLabelStyle}>Desktop App</div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))', gap: '8px' }}>
+          {surfaces.map((s) => (
+            <div
+              key={s.name}
+              style={{
+                borderRadius: '8px',
+                padding: '10px 12px',
+                background: 'rgba(13,16,22,0.8)',
+                border: '1px solid rgba(34,177,236,0.18)',
+              }}
+            >
+              <div style={{ display: 'flex', alignItems: 'center', gap: '7px', marginBottom: '5px', color: 'var(--accent, #22b1ec)' }}>
+                {s.icon}
+                <span style={{ fontSize: '12px', fontWeight: 600, color: 'var(--fg-base, #e8eaf0)' }}>{s.name}</span>
+              </div>
+              <p style={{ fontSize: '10px', lineHeight: 1.5, color: 'var(--fg-muted, #9aa0ad)', margin: 0 }}>{s.desc}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* connector */}
+      <div style={connectorStyle}>
+        <svg width="1" height="20" viewBox="0 0 1 20" aria-hidden="true">
+          <line x1="0.5" y1="0" x2="0.5" y2="20" stroke="rgba(34,177,236,0.4)" strokeWidth="1.5" strokeDasharray="3 2" />
+        </svg>
+        <span style={{ color: 'rgba(34,177,236,0.5)', fontSize: '10px' }}>reads · writes · syncs</span>
+        <svg width="1" height="20" viewBox="0 0 1 20" aria-hidden="true">
+          <line x1="0.5" y1="0" x2="0.5" y2="20" stroke="rgba(34,177,236,0.4)" strokeWidth="1.5" strokeDasharray="3 2" />
+        </svg>
+      </div>
+
+      {/* ── harness.yaml ── */}
+      <div style={{ ...accentLayer, border: '1.5px solid rgba(34,177,236,0.45)' }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '12px' }}>
+          <div style={{ ...layerLabelStyle, marginBottom: 0 }}>Config Core</div>
+          <span style={{ fontSize: '13px', fontWeight: 700, color: 'var(--accent, #22b1ec)', fontFamily: 'var(--font-mono, monospace)' }}>harness.yaml</span>
+        </div>
+        <div
+          style={{
+            background: 'rgba(13,16,22,0.9)',
+            border: '1px solid rgba(255,255,255,0.06)',
+            borderRadius: '8px',
+            padding: '12px 16px',
+            fontFamily: 'var(--font-mono, Menlo, monospace)',
+            fontSize: '11px',
+            lineHeight: 1.8,
+            color: '#6b7280',
+          }}
+        >
+          <span style={{ color: '#9aa0ad' }}>sources:</span>{'\n'}
+          {'  '}<span style={{ color: '#5a6270' }}>- harnessprotocol/harness-kit</span>{'\n'}
+          <span style={{ color: '#9aa0ad' }}>plugins:</span>{'\n'}
+          {'  '}<span style={{ color: '#5a6270' }}>- research@0.2.0  # SKILL.md + scripts bundled</span>{'\n'}
+          {'  '}<span style={{ color: '#5a6270' }}>- board@0.1.0     # SKILL.md + MCP server</span>{'\n'}
+          <span style={{ color: '#9aa0ad' }}>mcp-servers:</span>{'\n'}
+          {'  '}<span style={{ color: '#5a6270' }}>- memory           # knowledge graph</span>{'\n'}
+          {'  '}<span style={{ color: '#5a6270' }}>- filesystem       # local file access</span>
+        </div>
+      </div>
+
+      {/* connector */}
+      <div style={{ ...connectorStyle, justifyContent: 'space-around' }}>
+        <span style={{ color: 'rgba(34,177,236,0.4)', fontSize: '10px' }}>↙ installs &amp; manages</span>
+        <span style={{ color: 'rgba(34,177,236,0.4)', fontSize: '10px' }}>validates &amp; compiles ↘</span>
+      </div>
+
+      {/* ── Plugin System + CLI ── */}
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px' }}>
+
+        {/* Plugin System */}
+        <div style={mutedLayer}>
+          <div style={layerLabelStyle}>Plugin System</div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+            {pluginParts.map((p) => (
+              <div
+                key={p.name}
+                style={{
+                  display: 'flex',
+                  gap: '8px',
+                  alignItems: 'flex-start',
+                  padding: '6px 8px',
+                  borderRadius: '6px',
+                  background: 'rgba(13,16,22,0.5)',
+                  border: p.accent ? '1px solid rgba(34,177,236,0.25)' : '1px solid transparent',
+                }}
+              >
+                <code style={{
+                  fontSize: '10px',
+                  fontWeight: 600,
+                  whiteSpace: 'nowrap',
+                  color: p.accent ? 'var(--accent, #22b1ec)' : 'var(--fg-base, #e8eaf0)',
+                  background: 'none',
+                  padding: 0,
+                  minWidth: '68px',
+                }}>
+                  {p.name}
+                </code>
+                <span style={{ fontSize: '10px', color: 'var(--fg-muted, #9aa0ad)', lineHeight: 1.4 }}>{p.desc}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* CLI */}
+        <div style={mutedLayer}>
+          <div style={layerLabelStyle}>CLI — harness-kit</div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+            {cliOps.map((op) => (
+              <div
+                key={op.cmd}
+                style={{
+                  display: 'flex',
+                  gap: '8px',
+                  alignItems: 'flex-start',
+                  padding: '6px 8px',
+                  borderRadius: '6px',
+                  background: 'rgba(13,16,22,0.5)',
+                  border: '1px solid transparent',
+                }}
+              >
+                <code style={{
+                  fontSize: '10px',
+                  fontWeight: 600,
+                  whiteSpace: 'nowrap',
+                  color: 'var(--fg-base, #e8eaf0)',
+                  background: 'none',
+                  padding: 0,
+                  minWidth: '60px',
+                }}>
+                  {op.cmd}
+                </code>
+                <span style={{ fontSize: '10px', color: 'var(--fg-muted, #9aa0ad)', lineHeight: 1.4 }}>{op.desc}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* connector */}
+      <div style={connectorStyle}>
+        <svg width="1" height="20" viewBox="0 0 1 20" aria-hidden="true">
+          <line x1="0.5" y1="0" x2="0.5" y2="20" stroke="rgba(100,100,120,0.4)" strokeWidth="1.5" strokeDasharray="3 2" />
+        </svg>
+        <span style={{ color: 'rgba(100,100,120,0.6)', fontSize: '10px' }}>runs in</span>
+        <svg width="1" height="20" viewBox="0 0 1 20" aria-hidden="true">
+          <line x1="0.5" y1="0" x2="0.5" y2="20" stroke="rgba(100,100,120,0.4)" strokeWidth="1.5" strokeDasharray="3 2" />
+        </svg>
+      </div>
+
+      {/* ── AI Tools ── */}
+      <div style={{ ...mutedLayer, border: '1px solid var(--border-base, rgba(255,255,255,0.07))' }}>
+        <div style={layerLabelStyle}>AI Tools</div>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
+          {aiTools.map((tool) => (
+            <span
+              key={tool}
+              style={{
+                fontSize: '11px',
+                fontWeight: 500,
+                padding: '4px 10px',
+                borderRadius: '6px',
+                background: 'rgba(13,16,22,0.6)',
+                border: '1px solid rgba(255,255,255,0.08)',
+                color: 'var(--fg-muted, #9aa0ad)',
+              }}
+            >
+              {tool}
+            </span>
+          ))}
+          <span style={{
+            fontSize: '11px',
+            padding: '4px 10px',
+            borderRadius: '6px',
+            color: 'var(--fg-subtle, #6b7280)',
+          }}>
+            + any tool that reads markdown
+          </span>
+        </div>
+      </div>
+
+    </div>
+  );
+}

--- a/website/components/install-method-cards.tsx
+++ b/website/components/install-method-cards.tsx
@@ -1,0 +1,113 @@
+import Link from 'next/link';
+
+const MonitorIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <rect width="20" height="14" x="2" y="3" rx="2" />
+    <path d="M8 21h8M12 17v4" />
+  </svg>
+);
+
+const PuzzleIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <path d="M19.439 7.85c-.049.322.059.648.289.878l1.568 1.568c.47.47.706 1.087.706 1.704s-.235 1.233-.706 1.704l-1.611 1.611a.98.98 0 0 1-.837.276c-.47-.07-.802-.48-.968-.925a2.501 2.501 0 1 0-3.214 3.214c.446.166.855.497.925.968a.979.979 0 0 1-.276.837l-1.61 1.61a2.404 2.404 0 0 1-3.408 0l-1.569-1.568c-.23-.23-.556-.338-.878-.29-.493.074-.84.504-1.02.968a2.5 2.5 0 1 1-3.237-3.237c.464-.18.894-.527.967-1.02.049-.322-.059-.648-.289-.878L4.14 9.171a2.403 2.403 0 0 1 0-3.408l1.568-1.568c.23-.23.338-.556.29-.878-.075-.493-.504-.84-.968-1.02a2.5 2.5 0 1 1 3.237-3.237c.18.464.527.894 1.02.967.322.049.648-.059.878-.289l1.568-1.568a2.403 2.403 0 0 1 3.408 0l1.568 1.568c.23.23.556.338.879.29.493-.074.84-.504 1.019-.968a2.5 2.5 0 1 1 3.237 3.237c-.464.18-.894.527-.968 1.02Z" />
+  </svg>
+);
+
+const TerminalIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <polyline points="4 17 10 11 4 5" />
+    <line x1="12" x2="20" y1="19" y2="19" />
+  </svg>
+);
+
+const methods = [
+  {
+    id: 'desktop-app',
+    icon: <MonitorIcon />,
+    title: 'Desktop App',
+    description: 'Observatory, Memory, Board, and AI Chat — all in one native app. The best way to see and manage your harness.',
+    tags: ['Homebrew Cask', 'DMG'],
+    href: '#desktop-app',
+    featured: true,
+  },
+  {
+    id: 'skills',
+    icon: <PuzzleIcon />,
+    title: 'Skills & Plugins',
+    description: 'Slash commands for Claude Code. Add the marketplace, install any plugin by name.',
+    tags: ['Plugin Marketplace', 'Install Script'],
+    href: '#skills--plugins',
+    featured: false,
+  },
+  {
+    id: 'cli',
+    icon: <TerminalIcon />,
+    title: 'CLI',
+    description: 'Compile harness.yaml, sync plugins, detect drift — from the terminal.',
+    tags: ['Homebrew', 'npm', 'Binary'],
+    href: '#cli',
+    featured: false,
+  },
+];
+
+export function InstallMethodCards() {
+  return (
+    <div className="not-prose my-6 grid gap-3 sm:grid-cols-3">
+      {methods.map((m) => (
+        <Link
+          key={m.id}
+          href={m.href}
+          className="group relative flex flex-col gap-3 rounded-xl p-5 no-underline transition-all duration-200"
+          style={{
+            background: m.featured
+              ? 'linear-gradient(135deg, rgba(34,177,236,0.10) 0%, rgba(34,177,236,0.04) 100%)'
+              : 'var(--bg-surface)',
+            border: m.featured
+              ? '1px solid rgba(34,177,236,0.25)'
+              : '1px solid var(--border-base)',
+          }}
+        >
+          {m.featured && (
+            <span
+              className="absolute right-4 top-4 rounded-full px-2 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wide"
+              style={{ background: 'rgba(34,177,236,0.15)', color: 'var(--accent)' }}
+            >
+              Start here
+            </span>
+          )}
+          <div
+            className="flex size-9 items-center justify-center rounded-lg"
+            style={{
+              background: m.featured ? 'rgba(34,177,236,0.15)' : 'var(--bg-elevated)',
+              color: m.featured ? 'var(--accent)' : 'var(--fg-muted)',
+            }}
+          >
+            {m.icon}
+          </div>
+          <div>
+            <p
+              className="mb-1 text-sm font-semibold"
+              style={{ color: m.featured ? 'var(--accent)' : 'var(--fg-base)' }}
+            >
+              {m.title}
+            </p>
+            <p className="text-xs leading-relaxed" style={{ color: 'var(--fg-muted)' }}>
+              {m.description}
+            </p>
+          </div>
+          <div className="mt-auto flex flex-wrap gap-1.5">
+            {m.tags.map((tag) => (
+              <span
+                key={tag}
+                className="rounded-md px-1.5 py-0.5 text-[0.65rem] font-medium"
+                style={{ background: 'var(--bg-elevated)', color: 'var(--fg-subtle)' }}
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/website/components/site/SiteNav.tsx
+++ b/website/components/site/SiteNav.tsx
@@ -53,6 +53,21 @@ export function SiteNav() {
               </Link>
             );
           })}
+          <button
+            aria-label="Toggle Theme"
+            data-theme-toggle=""
+            className="flex size-8 cursor-pointer items-center justify-center rounded-md text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
+          >
+            {/* Sun — shown in dark mode */}
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="size-4 dark:block hidden" aria-hidden="true">
+              <circle cx="12" cy="12" r="4" />
+              <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
+            </svg>
+            {/* Moon — shown in light mode */}
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="size-4 dark:hidden block" aria-hidden="true">
+              <path d="M20.985 12.486a9 9 0 1 1-9.473-9.472c.405-.022.617.46.402.803a6 6 0 0 0 8.268 8.268c.344-.215.825-.004.803.401" />
+            </svg>
+          </button>
         </div>
       </div>
     </nav>

--- a/website/content/docs/cross-harness/ide-support.md
+++ b/website/content/docs/cross-harness/ide-support.md
@@ -25,26 +25,26 @@ Quick reference for feature support by editor — useful when deciding where to 
 
 ## harness-kit Plugin Portability
 
-| Plugin | Claude Code | Copilot CLI | VS Code (Copilot) | Cursor | Windsurf |
-|---|---|---|---|---|---|
-| explain | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
-| review | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
-| docgen | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
-| research | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
-| lineage | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
-| orient | ✅ native | ✅ native | 🔄 MCP required | 🔄 MCP required | ❌ no MCP |
-| capture | ✅ native | ✅ native | 🔄 MCP required | 🔄 MCP required | ❌ no MCP |
-| membrain | ✅ native | ✅ native | 🔄 MCP required | 🔄 MCP required | ❌ no MCP |
-| open-pr | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
-| merge-pr | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
-| pr-sweep | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
-| harness-share | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
-| stats | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
-| board | ✅ native | 🔄 MCP required | 🔄 MCP required | 🔄 MCP required | ❌ no MCP |
-| iterm-notify | ✅ native | ❌ hooks only | ❌ hooks only | ❌ hooks only | ❌ hooks only |
-| frontend-design | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
+| Plugin | Claude Code | Copilot CLI | VS Code (Copilot) | Cursor | Windsurf | Codex |
+|---|---|---|---|---|---|---|
+| explain | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
+| review | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
+| docgen | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
+| research | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
+| lineage | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
+| orient | ✅ native | ✅ native | 🔄 MCP required | 🔄 MCP required | ❌ no MCP | 🔄 MCP required |
+| capture | ✅ native | ✅ native | 🔄 MCP required | 🔄 MCP required | ❌ no MCP | 🔄 MCP required |
+| membrain | ✅ native | ✅ native | 🔄 MCP required | 🔄 MCP required | ❌ no MCP | 🔄 MCP required |
+| open-pr | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
+| merge-pr | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
+| pr-sweep | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
+| harness-share | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
+| stats | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
+| board | ✅ native | 🔄 MCP required | 🔄 MCP required | 🔄 MCP required | ❌ no MCP | 🔄 MCP required |
+| iterm-notify | ✅ native | ❌ hooks only | ❌ hooks only | ❌ hooks only | ❌ hooks only | ❌ hooks only |
+| frontend-design | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
 
-> MCP-required plugins work in tools that support MCP servers.
+> MCP-required plugins work in tools that support MCP servers. Codex supports MCP via `--mcp` flag.
 
 ## MCP as Universal Fallback
 
@@ -52,4 +52,4 @@ MCP has the broadest cross-tool support of any harness-kit feature. The `orient`
 
 ## Last Updated
 
-Last updated: 2026-04-06
+Last updated: 2026-04-17

--- a/website/content/docs/cross-harness/ide-support.md
+++ b/website/content/docs/cross-harness/ide-support.md
@@ -25,24 +25,24 @@ Quick reference for feature support by editor — useful when deciding where to 
 
 ## harness-kit Plugin Portability
 
-| Plugin | Claude Code | Copilot CLI | VS Code (Copilot) | Cursor | Windsurf | Codex |
-|---|---|---|---|---|---|---|
-| explain | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
-| review | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
-| docgen | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
-| research | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
-| lineage | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
-| orient | ✅ native | ✅ native | 🔄 MCP required | 🔄 MCP required | ❌ no MCP | 🔄 MCP required |
-| capture | ✅ native | ✅ native | 🔄 MCP required | 🔄 MCP required | ❌ no MCP | 🔄 MCP required |
-| membrain | ✅ native | ✅ native | 🔄 MCP required | 🔄 MCP required | ❌ no MCP | 🔄 MCP required |
-| open-pr | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
-| merge-pr | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
-| pr-sweep | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
-| harness-share | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
-| stats | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
-| board | ✅ native | 🔄 MCP required | 🔄 MCP required | 🔄 MCP required | ❌ no MCP | 🔄 MCP required |
-| iterm-notify | ✅ native | ❌ hooks only | ❌ hooks only | ❌ hooks only | ❌ hooks only | ❌ hooks only |
-| frontend-design | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
+| Plugin | Claude Code | Copilot CLI | VS Code (Copilot) | Cursor | Codex |
+|---|---|---|---|---|---|
+| explain | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
+| review | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
+| docgen | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
+| research | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
+| lineage | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
+| orient | ✅ native | ✅ native | 🔄 MCP required | 🔄 MCP required | 🔄 MCP required |
+| capture | ✅ native | ✅ native | 🔄 MCP required | 🔄 MCP required | 🔄 MCP required |
+| membrain | ✅ native | ✅ native | 🔄 MCP required | 🔄 MCP required | 🔄 MCP required |
+| open-pr | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
+| merge-pr | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
+| pr-sweep | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
+| harness-share | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
+| stats | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
+| board | ✅ native | 🔄 MCP required | 🔄 MCP required | 🔄 MCP required | 🔄 MCP required |
+| iterm-notify | ✅ native | ❌ hooks only | ❌ hooks only | ❌ hooks only | ❌ hooks only |
+| frontend-design | ✅ native | ✅ native | ✅ copy SKILL.md | ✅ copy SKILL.md | ✅ copy SKILL.md |
 
 > MCP-required plugins work in tools that support MCP servers. Codex supports MCP via `--mcp` flag.
 

--- a/website/content/docs/cross-harness/setup-guide.mdx
+++ b/website/content/docs/cross-harness/setup-guide.mdx
@@ -63,10 +63,6 @@ globs: "src/**/*.ts"
 [SKILL.md content here]
 ```
 
-## Windsurf
-
-Copy the `SKILL.md` content into `.windsurfrules`, or paste it through Windsurf's project rules UI. No frontmatter needed — Windsurf applies rules project-wide.
-
 ## Codex
 
 Copy a plugin's `SKILL.md` into your `AGENTS.md` file, or place it in a project-level `AGENTS.md` at the repo root. Codex reads `AGENTS.md` as its persistent instruction context — the same role `CLAUDE.md` plays for Claude Code.
@@ -97,10 +93,10 @@ Plugins that depend on MCP (like `orient` and `capture`) work in any of these to
 
 ## What You Lose
 
-| Feature | Claude Code | Copilot CLI | Cursor | Windsurf | Codex |
-|---------|-------------|-------------|--------|----------|-------|
-| Marketplace install/update | ✅ One command | ✅ One command | ❌ Manual | ❌ Manual | ❌ Manual |
-| Hooks | ✅ Auto-triggered | ❌ | ❌ | ❌ | ❌ |
-| Auto-execution scripts | ✅ Bundled | ❌ Run manually | ❌ Run manually | ❌ Run manually | ❌ Run manually |
-| SKILL.md workflows | ✅ | ✅ | ✅ | ✅ | ✅ |
-| MCP server support | ✅ | ✅ | ✅ | ❌ | ✅ |
+| Feature | Claude Code | Copilot CLI | Cursor | Codex |
+|---------|-------------|-------------|--------|-------|
+| Marketplace install/update | ✅ One command | ✅ One command | ❌ Manual | ❌ Manual |
+| Hooks | ✅ Auto-triggered | ❌ | ❌ | ❌ |
+| Auto-execution scripts | ✅ Bundled | ❌ Run manually | ❌ Run manually | ❌ Run manually |
+| SKILL.md workflows | ✅ | ✅ | ✅ | ✅ |
+| MCP server support | ✅ | ✅ | ✅ | ✅ |

--- a/website/content/docs/cross-harness/setup-guide.mdx
+++ b/website/content/docs/cross-harness/setup-guide.mdx
@@ -67,6 +67,22 @@ globs: "src/**/*.ts"
 
 Copy the `SKILL.md` content into `.windsurfrules`, or paste it through Windsurf's project rules UI. No frontmatter needed — Windsurf applies rules project-wide.
 
+## Codex
+
+Copy a plugin's `SKILL.md` into your `AGENTS.md` file, or place it in a project-level `AGENTS.md` at the repo root. Codex reads `AGENTS.md` as its persistent instruction context — the same role `CLAUDE.md` plays for Claude Code.
+
+```bash
+cat plugins/research/skills/research/SKILL.md >> AGENTS.md
+```
+
+**MCP servers:** Codex supports MCP via the `--mcp` flag. Pass your `.mcp.json` at startup:
+
+```bash
+codex --mcp .mcp.json
+```
+
+Plugins that depend on MCP (`orient`, `capture`, `membrain`) work with Codex once the server is wired up this way.
+
 ## MCP Servers
 
 MCP has 100% cross-platform support — it's the only harness-kit feature that works identically everywhere. The wiring location varies by tool:
@@ -81,10 +97,10 @@ Plugins that depend on MCP (like `orient` and `capture`) work in any of these to
 
 ## What You Lose
 
-| Feature | Claude Code | Other Tools |
-|---------|-------------|-------------|
-| Marketplace install/update | ✅ One command | ✅ Copilot CLI / ❌ Cursor, Windsurf |
-| Hooks | ✅ Auto-triggered | ❌ Harness-specific |
-| Auto-execution scripts | ✅ Bundled | ❌ Run manually |
-| SKILL.md workflows | ✅ | ✅ |
-| MCP server support | ✅ | ✅ (varies by tool) |
+| Feature | Claude Code | Copilot CLI | Cursor | Windsurf | Codex |
+|---------|-------------|-------------|--------|----------|-------|
+| Marketplace install/update | ✅ One command | ✅ One command | ❌ Manual | ❌ Manual | ❌ Manual |
+| Hooks | ✅ Auto-triggered | ❌ | ❌ | ❌ | ❌ |
+| Auto-execution scripts | ✅ Bundled | ❌ Run manually | ❌ Run manually | ❌ Run manually | ❌ Run manually |
+| SKILL.md workflows | ✅ | ✅ | ✅ | ✅ | ✅ |
+| MCP server support | ✅ | ✅ | ✅ | ❌ | ✅ |

--- a/website/content/docs/getting-started/architecture.mdx
+++ b/website/content/docs/getting-started/architecture.mdx
@@ -1,70 +1,164 @@
 ---
 title: How It Works
+description: The full harness-kit stack — desktop app, harness.yaml, plugin system, and CLI.
 ---
 
-# How harness-kit Works
+harness-kit is four layers that work together: a desktop app for observation and management, a `harness.yaml` config file at the center, a plugin system that delivers skills and agents to your AI tools, and a CLI that compiles and validates it all.
 
-harness-kit packages proven AI workflows as portable plugins. This page explains the pieces and how they fit together.
+<ArchitectureDiagram />
 
-## The Stack
+---
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 560 310" style={{width: '100%', maxWidth: '560px', display: 'block', margin: '2rem auto'}}>
-  <defs>
-    <marker id="ap" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#22b1ec" />
-    </marker>
-    <marker id="am" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto" markerUnits="userSpaceOnUse">
-      <polygon points="0 0, 8 3, 0 6" fill="#555" />
-    </marker>
-  </defs>
-  <rect x="16" y="28" width="72" height="34" rx="6" fill="#1a1a24" stroke="#22b1ec" strokeWidth="1.5" />
-  <text x="52" y="50" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="13" fontWeight="600" fill="#e0e0e0">You</text>
-  <line x1="88" y1="45" x2="122" y2="45" markerEnd="url(#ap)" stroke="#22b1ec" strokeWidth="1.5" />
-  <text x="105" y="37" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="10" fill="#22b1ec">install</text>
-  <rect x="132" y="28" width="126" height="34" rx="6" fill="#1a1a24" stroke="#22b1ec" strokeWidth="1.5" />
-  <text x="195" y="50" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="13" fontWeight="600" fill="#e0e0e0">Your Harness</text>
-  <line x1="258" y1="45" x2="312" y2="45" markerEnd="url(#ap)" stroke="#22b1ec" strokeWidth="1.5" />
-  <text x="285" y="37" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="10" fill="#22b1ec">fetch</text>
-  <rect x="322" y="28" width="108" height="34" rx="6" fill="#1a1a24" stroke="#22b1ec" strokeWidth="1.5" />
-  <text x="376" y="50" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="13" fontWeight="600" fill="#e0e0e0">Registry</text>
-  <line x1="376" y1="62" x2="287" y2="100" markerEnd="url(#ap)" stroke="#22b1ec" strokeWidth="1.5" />
-  <text x="362" y="83" textAnchor="start" fontFamily="system-ui, sans-serif" fontSize="10" fill="#22b1ec">downloads</text>
-  <rect x="200" y="108" width="150" height="34" rx="6" fill="#1a1a24" stroke="#22b1ec" strokeWidth="1.5" />
-  <text x="275" y="130" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="13" fontWeight="600" fill="#e0e0e0">Plugin Directory</text>
-  <line x1="275" y1="142" x2="72" y2="188" markerEnd="url(#am)" stroke="#555" strokeWidth="1.5" />
-  <line x1="275" y1="142" x2="196" y2="188" markerEnd="url(#am)" stroke="#555" strokeWidth="1.5" />
-  <line x1="275" y1="142" x2="318" y2="188" markerEnd="url(#am)" stroke="#555" strokeWidth="1.5" />
-  <line x1="275" y1="142" x2="444" y2="188" markerEnd="url(#am)" stroke="#555" strokeWidth="1.5" />
-  <rect x="26" y="196" width="92" height="28" rx="6" fill="#1a1a24" stroke="#22b1ec" strokeWidth="1.5" />
-  <text x="72" y="215" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="12" fontWeight="600" fill="#e0e0e0">SKILL.md</text>
-  <rect x="152" y="196" width="88" height="28" rx="6" fill="#1a1a24" stroke="#555" strokeWidth="1.5" />
-  <text x="196" y="215" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="12" fill="#888">scripts/</text>
-  <rect x="278" y="196" width="80" height="28" rx="6" fill="#1a1a24" stroke="#555" strokeWidth="1.5" />
-  <text x="318" y="215" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="12" fill="#888">hooks/</text>
-  <rect x="404" y="196" width="80" height="28" rx="6" fill="#1a1a24" stroke="#555" strokeWidth="1.5" />
-  <text x="444" y="215" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="12" fill="#888">agents/</text>
-  <line x1="72" y1="224" x2="72" y2="256" markerEnd="url(#ap)" stroke="#22b1ec" strokeWidth="1.5" />
-  <text x="86" y="244" textAnchor="start" fontFamily="system-ui, sans-serif" fontSize="10" fill="#22b1ec">/command</text>
-  <rect x="26" y="264" width="92" height="28" rx="6" fill="#1a1a24" stroke="#22b1ec" strokeWidth="1.5" />
-  <text x="72" y="283" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="12" fontWeight="600" fill="#e0e0e0">Workflow</text>
-  <text x="18" y="14" fontFamily="system-ui, sans-serif" fontSize="9" fill="#666" letterSpacing="0.08em">LOCAL</text>
-  <text x="322" y="14" fontFamily="system-ui, sans-serif" fontSize="9" fill="#666" letterSpacing="0.08em">REMOTE</text>
-  <rect x="310" y="18" width="142" height="54" rx="8" fill="none" stroke="#555" strokeWidth="1" strokeDasharray="4 3" />
-</svg>
+## harness.yaml — The Config Core
 
-## Plugin Lifecycle
+Everything in harness-kit flows through `harness.yaml`. It is the portable declaration of your entire AI coding setup: which plugins are installed, which MCP servers are running, what sources they come from, and which versions you're pinned to.
 
-1. **Source** — You register harness-kit as a plugin source in your AI tool. This points to the collection — not individual plugins.
-2. **Install** — You install a plugin by name. Your harness downloads the plugin directory and makes it available locally.
-3. **Discovery** — At session start, your harness scans installed plugins and registers any skills it finds.
-4. **Invocation** — You invoke a command (e.g. `/research`). Your harness loads the matching `SKILL.md` into context as the workflow definition.
-5. **Execution** — The AI follows the steps in the SKILL.md, using available tools (file I/O, web fetch, shell commands, MCP servers).
+```yaml
+sources:
+  - harnessprotocol/harness-kit
 
-> **Distribution today:** harness-kit distributes through Claude Code's plugin marketplace. SKILL.md files are plain markdown — any tool that reads prompt templates can use them directly. See [Using with Other Tools](/docs/cross-harness/setup-guide).
+plugins:
+  - research@0.2.0
+  - explain@0.2.0
+  - board@0.1.0
+  - review@0.2.0
 
-## Starting Fresh on a New Machine
+mcp-servers:
+  - memory
+  - filesystem
 
-Your harness setup is fully reproducible. Config files live in version control; plugins reinstall from the registry with the same commands you used the first time.
+env:
+  ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+```
+
+`harness.yaml` follows the [Harness Protocol](https://harnessprotocol.io) — an open, vendor-neutral specification. Any tool that validates against the schema can consume it. harness-kit is the reference implementation.
+
+---
+
+## Desktop App
+
+The desktop app is the visual management layer. It reads your harness configuration, shows you what your AI tools are doing, and gives you direct control over the pieces that are hard to manage from a terminal.
+
+Four surfaces ship with the app:
+
+**Observatory** — Session telemetry in detail: every session, every tool call, token usage, and trends over time. When someone asks "is this thing working?", Observatory is the answer.
+
+**Memory** — A knowledge graph that persists across every tool and every session. Add teammates, decisions, and conventions once; every agent can orient itself using them. Backed by the [membrain MCP server](/docs/plugins/research-knowledge/membrain).
+
+**Board** — An AI-native Kanban board with real-time two-way sync. Agents pick up cards, draft commits, flag for review. You approve. See [board plugin docs](/docs/plugins/productivity/board) for the full MCP tool surface.
+
+**AI Chat** — A keyboard-first chat window tied to your harness. Terminal UX, Ollama support, and 12 built-in tools including file piping, web search, and memory queries. Every conversation is stored.
+
+---
+
+## Plugin System
+
+### Lifecycle
+
+<Steps>
+<Step>
+**Source** — You register harness-kit as a plugin source in your AI tool. This points to the collection, not individual plugins.
+</Step>
+<Step>
+**Install** — You install a plugin by name. Your harness downloads the plugin directory locally.
+
+```
+/plugin install research@harness-kit
+```
+</Step>
+<Step>
+**Discovery** — At session start, your harness scans installed plugins and registers all skills it finds.
+</Step>
+<Step>
+**Invocation** — You invoke a slash command. The matching `SKILL.md` is loaded into context as the workflow definition.
+
+```
+/research
+```
+</Step>
+<Step>
+**Execution** — The AI follows the steps in `SKILL.md`, using available tools: file I/O, web fetch, shell commands, MCP servers.
+</Step>
+</Steps>
+
+### Plugin Anatomy
+
+Every plugin follows the same directory layout:
+
+```
+plugins/<name>/
+├── .claude-plugin/
+│   └── plugin.json         # name, version, description
+├── skills/
+│   └── <name>/
+│       ├── SKILL.md        # the workflow (what Claude reads)
+│       └── README.md       # human docs
+├── scripts/                # optional: bundled automation
+├── hooks/                  # optional: lifecycle event handlers
+└── agents/                 # optional: specialist subagents
+```
+
+| Component | Role | When it runs |
+|-----------|------|-------------|
+| `plugin.json` | Metadata — name, version, description | At install and update |
+| `SKILL.md` | Workflow definition — steps Claude follows at invocation | At slash command invocation |
+| `README.md` | Human-facing docs | Never (reference only) |
+| `scripts/` | Shell scripts called by skills or hooks | On demand |
+| `hooks/` | Stop, PreTool, PostTool event handlers | On harness lifecycle events |
+| `agents/` | Isolated specialist workers with scoped tools and permissions | When a skill delegates to a named agent |
+
+### What Makes a SKILL.md Different from a Prompt
+
+A `SKILL.md` is a **complete workflow specification**, not a prompt template:
+
+- **Mandatory step ordering** — steps execute in sequence, no skipping
+- **Input parsing rules** — how to interpret arguments and flags
+- **Tool usage patterns** — which tools to call when, and how
+- **Output structure** — exact format for results
+- **Error handling** — explicit recovery steps when things fail
+- **Common mistakes table** — known failure modes and fixes
+
+This structure makes skills repeatable across sessions and transferable across users. The same `/research` invocation produces the same workflow regardless of who runs it or when.
+
+---
+
+## CLI
+
+The `harness-kit` CLI operates on `harness.yaml` from the terminal. It's useful for CI pipelines, pre-commit hooks, and machines where the desktop app isn't running.
+
+<Tabs items={["Homebrew", "npm", "Binary"]}>
+<Tab value="Homebrew">
+```bash
+brew tap harnessprotocol/tap
+brew install harness-kit
+```
+</Tab>
+<Tab value="npm">
+```bash
+npm install -g @harness-kit/cli
+```
+</Tab>
+<Tab value="Binary">
+Download from [GitHub Releases](https://github.com/harnessprotocol/harness-kit/releases).
+</Tab>
+</Tabs>
+
+**Core commands:**
+
+```bash
+harness-kit validate          # check harness.yaml against the schema
+harness-kit compile           # emit native configs for Claude Code, Cursor, Copilot
+harness-kit sync              # pull latest plugin changes from the registry
+harness-kit scan              # audit installed skills for unsafe directives
+```
+
+---
+
+## Portability
+
+### New Machine
+
+Your harness is fully reproducible. Config files live in version control; plugins reinstall from the registry with the same commands you used the first time.
 
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 560 210" style={{width: '100%', maxWidth: '560px', display: 'block', margin: '2rem auto'}}>
   <defs>
@@ -116,166 +210,25 @@ Your harness setup is fully reproducible. Config files live in version control; 
   <text x="504" y="185" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="11" fill="#888">review ...</text>
 </svg>
 
-## Sharing Your Setup
+### Sharing with Teammates
 
-Your entire harness — plugins, versions, sources — serializes into a single `harness.yaml`. Export it, hand it to a teammate, and they selectively import what they need.
+Your entire harness serializes into a single `harness.yaml`. Export it, commit it, share it — your teammate runs one command to selectively import what they want.
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 340" style={{width: '100%', maxWidth: '680px', display: 'block', margin: '2rem auto'}}>
-  <defs>
-    <marker id="ex" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#22b1ec" />
-    </marker>
-    <marker id="gx" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#555" />
-    </marker>
-  </defs>
-
-  {/* — YOUR SETUP — */}
-  <text x="90" y="18" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="11" fontWeight="600" fill="#e0e0e0">Your Setup</text>
-  <rect x="8" y="26" width="164" height="186" rx="8" fill="#1a1a24" stroke="#555" strokeWidth="1.5" />
-
-  <text x="90" y="46" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="9" fill="#666" letterSpacing="0.06em">CONFIG</text>
-  <rect x="18" y="52" width="68" height="22" rx="5" fill="#12121a" stroke="#22b1ec" strokeWidth="1.2" />
-  <text x="52" y="67" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="10" fontWeight="600" fill="#e0e0e0">CLAUDE.md</text>
-  <rect x="94" y="52" width="68" height="22" rx="5" fill="#12121a" stroke="#22b1ec" strokeWidth="1.2" />
-  <text x="128" y="67" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="10" fontWeight="600" fill="#e0e0e0">AGENT.md</text>
-
-  <text x="90" y="94" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="9" fill="#666" letterSpacing="0.06em">PLUGINS</text>
-  <rect x="18" y="100" width="60" height="20" rx="4" fill="#12121a" stroke="#555" strokeWidth="1.2" />
-  <text x="48" y="114" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="10" fill="#888">research</text>
-  <rect x="84" y="100" width="52" height="20" rx="4" fill="#12121a" stroke="#555" strokeWidth="1.2" />
-  <text x="110" y="114" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="10" fill="#888">explain</text>
-  <rect x="18" y="126" width="74" height="20" rx="4" fill="#12121a" stroke="#555" strokeWidth="1.2" />
-  <text x="55" y="140" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="10" fill="#888">lineage</text>
-  <rect x="98" y="126" width="52" height="20" rx="4" fill="#12121a" stroke="#555" strokeWidth="1.2" />
-  <text x="124" y="140" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="10" fill="#888">review</text>
-
-  <text x="90" y="168" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="9" fill="#666" letterSpacing="0.06em">MCP SERVERS</text>
-  <rect x="18" y="174" width="60" height="20" rx="4" fill="#12121a" stroke="#555" strokeWidth="1.2" />
-  <text x="48" y="188" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="10" fill="#888">memory</text>
-  <rect x="84" y="174" width="74" height="20" rx="4" fill="#12121a" stroke="#555" strokeWidth="1.2" />
-  <text x="121" y="188" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="10" fill="#888">filesystem</text>
-
-  {/* — EXPORT ARROW — */}
-  <line x1="172" y1="120" x2="218" y2="120" markerEnd="url(#ex)" stroke="#22b1ec" strokeWidth="1.5" />
-  <text x="195" y="112" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="9" fontWeight="600" fill="#22b1ec">/export</text>
-
-  {/* — HARNESS.YAML — */}
-  <rect x="228" y="42" width="224" height="196" rx="10" fill="#12121a" stroke="#22b1ec" strokeWidth="2" />
-  <text x="340" y="66" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="14" fontWeight="700" fill="#22b1ec">harness.yaml</text>
-  <line x1="248" y1="76" x2="432" y2="76" stroke="#333" strokeWidth="1" />
-
-  <text x="258" y="96" fontFamily="monospace, Menlo, Consolas" fontSize="10" fill="#888">sources:</text>
-  <text x="268" y="112" fontFamily="monospace, Menlo, Consolas" fontSize="10" fill="#666">- harnessprotocol/harness-kit</text>
-  <text x="258" y="132" fontFamily="monospace, Menlo, Consolas" fontSize="10" fill="#888">plugins:</text>
-  <text x="268" y="148" fontFamily="monospace, Menlo, Consolas" fontSize="10" fill="#666">- research@0.2.0</text>
-  <text x="268" y="162" fontFamily="monospace, Menlo, Consolas" fontSize="10" fill="#666">- explain@0.2.0</text>
-  <text x="268" y="176" fontFamily="monospace, Menlo, Consolas" fontSize="10" fill="#666">- lineage@0.3.0</text>
-  <text x="268" y="190" fontFamily="monospace, Menlo, Consolas" fontSize="10" fill="#666">- review@0.2.0</text>
-  <text x="258" y="210" fontFamily="monospace, Menlo, Consolas" fontSize="10" fill="#888">mcp-servers:</text>
-  <text x="268" y="226" fontFamily="monospace, Menlo, Consolas" fontSize="10" fill="#666">- memory, filesystem</text>
-
-  {/* — SHARE METHODS — */}
-  <text x="340" y="260" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="9" fill="#666" letterSpacing="0.06em">SHARE VIA</text>
-  <rect x="252" y="268" width="40" height="18" rx="4" fill="#1a1a24" stroke="#555" strokeWidth="1" />
-  <text x="272" y="281" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="9" fill="#888">git</text>
-  <rect x="300" y="268" width="44" height="18" rx="4" fill="#1a1a24" stroke="#555" strokeWidth="1" />
-  <text x="322" y="281" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="9" fill="#888">slack</text>
-  <rect x="352" y="268" width="46" height="18" rx="4" fill="#1a1a24" stroke="#555" strokeWidth="1" />
-  <text x="375" y="281" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="9" fill="#888">email</text>
-  <rect x="406" y="268" width="40" height="18" rx="4" fill="#1a1a24" stroke="#555" strokeWidth="1" />
-  <text x="426" y="281" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="9" fill="#888">URL</text>
-
-  {/* — IMPORT ARROW — */}
-  <line x1="452" y1="120" x2="498" y2="120" markerEnd="url(#ex)" stroke="#22b1ec" strokeWidth="1.5" />
-  <text x="475" y="112" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="9" fontWeight="600" fill="#22b1ec">/import</text>
-
-  {/* — TEAMMATE'S SETUP — */}
-  <text x="590" y="18" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="11" fontWeight="600" fill="#e0e0e0">Teammate</text>
-  <rect x="508" y="26" width="164" height="186" rx="8" fill="#1a1a24" stroke="#555" strokeWidth="1.5" />
-
-  <text x="590" y="46" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="9" fill="#666" letterSpacing="0.06em">INTERACTIVE PICKER</text>
-
-  {/* Checkboxes — selected */}
-  <rect x="522" y="54" width="14" height="14" rx="3" fill="#22b1ec" stroke="#22b1ec" strokeWidth="1" />
-  <text x="520" y="66" fontFamily="system-ui, sans-serif" fontSize="11" fill="#fff" dx="3" dy="-1">✓</text>
-  <text x="544" y="66" fontFamily="system-ui, sans-serif" fontSize="11" fill="#e0e0e0">research@0.2.0</text>
-
-  <rect x="522" y="76" width="14" height="14" rx="3" fill="#22b1ec" stroke="#22b1ec" strokeWidth="1" />
-  <text x="520" y="88" fontFamily="system-ui, sans-serif" fontSize="11" fill="#fff" dx="3" dy="-1">✓</text>
-  <text x="544" y="88" fontFamily="system-ui, sans-serif" fontSize="11" fill="#e0e0e0">explain@0.2.0</text>
-
-  {/* Checkboxes — skipped */}
-  <rect x="522" y="98" width="14" height="14" rx="3" fill="none" stroke="#555" strokeWidth="1.2" />
-  <text x="544" y="110" fontFamily="system-ui, sans-serif" fontSize="11" fill="#666">lineage@0.3.0</text>
-
-  <rect x="522" y="120" width="14" height="14" rx="3" fill="#22b1ec" stroke="#22b1ec" strokeWidth="1" />
-  <text x="520" y="132" fontFamily="system-ui, sans-serif" fontSize="11" fill="#fff" dx="3" dy="-1">✓</text>
-  <text x="544" y="132" fontFamily="system-ui, sans-serif" fontSize="11" fill="#e0e0e0">review@0.2.0</text>
-
-  <line x1="522" y1="148" x2="656" y2="148" stroke="#333" strokeWidth="1" />
-
-  <text x="590" y="166" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="9" fill="#666" letterSpacing="0.06em">RESULT</text>
-  <rect x="522" y="174" width="60" height="20" rx="4" fill="#12121a" stroke="#22b1ec" strokeWidth="1.2" />
-  <text x="552" y="188" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="10" fill="#e0e0e0">research</text>
-  <rect x="588" y="174" width="52" height="20" rx="4" fill="#12121a" stroke="#22b1ec" strokeWidth="1.2" />
-  <text x="614" y="188" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="10" fill="#e0e0e0">explain</text>
-  <rect x="522" y="198" width="52" height="20" rx="4" fill="#12121a" stroke="#22b1ec" strokeWidth="1.2" />
-  <text x="548" y="212" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="10" fill="#e0e0e0">review</text>
-
-  {/* — Bottom note — */}
-  <text x="340" y="328" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="10" fill="#666">Your setup is a starting point — teammates pick what they want, not an all-or-nothing clone.</text>
-</svg>
-
-The flow:
-
-1. **Export** — `/harness-export` captures your installed plugins, their versions, and sources into a `harness.yaml` file.
-2. **Share** — Commit it to a repo, drop it in Slack, include it in onboarding docs — it's one file.
-3. **Import** — `/harness-import harness.yaml` presents an interactive list. Your teammate picks what they want and skips the rest.
-
-The harness.yaml is a manifest, not a dump. It records *what* you have and *where it came from*, so the import side can fetch the same versions from the same sources. Your configuration becomes a sharable artifact instead of tribal knowledge.
-
-## Plugin Anatomy
-
-Every plugin follows the same directory structure:
-
-```
-plugins/<name>/
-├── .claude-plugin/
-│   └── plugin.json         # name, version, description
-├── skills/
-│   └── <name>/
-│       ├── SKILL.md        # the workflow (what Claude reads)
-│       └── README.md       # human documentation
-└── scripts/                # optional: automation scripts
-    hooks/                  # optional: event hooks
-    agents/                 # optional: agent configurations
+```bash
+/harness-export          # captures plugins, versions, and sources
+/harness-import harness.yaml  # interactive picker: they choose what to install
 ```
 
-| Component | Role | When it runs |
-|-----------|------|-------------|
-| `plugin.json` | Metadata — name, version, description | At install and update |
-| `SKILL.md` | Workflow definition — the actual instructions Claude follows | At slash command invocation |
-| `README.md` | Human-facing docs — usage examples, notes | Never (reference only) |
-| `scripts/` | Shell scripts for automation | Called by SKILL.md or hooks |
-| `hooks/` | Event handlers (e.g., Stop hook) | On harness lifecycle events |
-| `agents/` | Subagent definitions — isolated workers with their own context, tools, and permissions | When a skill or user delegates to a named agent |
+<Callout type="info" title="A manifest, not a clone">
+  harness.yaml records <em>what</em> you have and <em>where it came from</em>. The import side fetches the same versions from the same sources. Your setup becomes a shareable artifact, not tribal knowledge.
+</Callout>
 
-## What Makes a Skill Different from a Prompt
-
-A SKILL.md is more than a prompt — it's a **complete workflow specification**:
-
-- **Mandatory step ordering** — steps must execute in sequence, no skipping
-- **Input parsing rules** — how to interpret arguments
-- **Tool usage patterns** — which tools to use when and how
-- **Output structure** — exact format for results
-- **Error handling** — what to do when things fail
-- **Common mistakes table** — known failure modes and fixes
-
-This structure makes skills repeatable across sessions and transferable across users. The same `/research` invocation produces the same workflow regardless of who runs it.
+---
 
 ## Design Philosophy
 
-harness-kit is a framework without a runtime. No SDK, no build step, no execution layer to depend on. The framework is the config format and the portability it creates — uninstall a plugin and nothing breaks, because nothing was ever coupled to it. Skills are plain markdown, readable and editable by anyone.
+harness-kit is a framework without a runtime. No SDK, no build step, no execution layer to depend on. The framework is the config format and the portability it creates.
 
-The SKILL.md is the portable unit. Plugins add distribution, versioning, and optional automation on top — but the workflow itself is just text that any AI tool can read.
+The `SKILL.md` is the portable unit. Plugins add distribution, versioning, and automation on top — but the workflow itself is plain text that any AI tool can read. Uninstall a plugin and nothing breaks, because nothing was ever coupled to it.
+
+> Skills are plain markdown, readable and editable by anyone. The spec is [open](https://harnessprotocol.io). The format travels.

--- a/website/content/docs/getting-started/architecture.mdx
+++ b/website/content/docs/getting-started/architecture.mdx
@@ -1,53 +1,100 @@
 ---
 title: How It Works
-description: The full harness-kit stack — desktop app, harness.yaml, plugin system, and CLI.
+description: harness-kit is three things — a config format, a desktop management console, and a CLI — plus a plugin system that delivers skills and agents to your AI coding tools.
 ---
 
-harness-kit is four layers that work together: a desktop app for observation and management, a `harness.yaml` config file at the center, a plugin system that delivers skills and agents to your AI tools, and a CLI that compiles and validates it all.
+harness-kit has three main components and a plugin system. `harness.yaml` is the config format at the center of everything. The desktop app is a multi-section management console for it. The `harness-kit` CLI is a standalone terminal tool that compiles it. Plugins — SKILL.md files, agents, hooks, scripts — run inside your AI tools.
 
 <ArchitectureDiagram />
 
 ---
 
-## harness.yaml — The Config Core
+## harness.yaml
 
-Everything in harness-kit flows through `harness.yaml`. It is the portable declaration of your entire AI coding setup: which plugins are installed, which MCP servers are running, what sources they come from, and which versions you're pinned to.
+`harness.yaml` is the single declaration of your entire AI coding setup. It follows the [Harness Protocol](https://harnessprotocol.io) — an open, vendor-neutral specification.
 
 ```yaml
-sources:
-  - harnessprotocol/harness-kit
-
 plugins:
   - research@0.2.0
-  - explain@0.2.0
   - board@0.1.0
-  - review@0.2.0
+  - explain@0.2.0
 
 mcp-servers:
-  - memory
-  - filesystem
+  - name: memory
+  - name: filesystem
+
+instructions:
+  operational: "Always create a feature branch. Never commit to main."
+  behavioral: "Direct, concise. Lead with the answer."
+
+permissions:
+  tools:
+    allow: ["Bash", "Edit", "Read"]
+    deny: ["WebFetch"]
+  network:
+    allow: ["api.anthropic.com"]
 
 env:
   ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+
+extends:
+  - profiles/backend-engineer.yaml
 ```
 
-`harness.yaml` follows the [Harness Protocol](https://harnessprotocol.io) — an open, vendor-neutral specification. Any tool that validates against the schema can consume it. harness-kit is the reference implementation.
+The full schema supports `version`, `kind`, `metadata`, `plugins`, `mcp-servers`, `instructions`, `permissions`, `env`, and `extends`. [Harness Protocol spec →](https://harnessprotocol.io)
 
 ---
 
 ## Desktop App
 
-The desktop app is the visual management layer. It reads your harness configuration, shows you what your AI tools are doing, and gives you direct control over the pieces that are hard to manage from a terminal.
+The desktop app is a management console organized into named sections. It reads your harness configuration, provides observability into what your AI tools are doing, and gives you direct control over the pieces that are hard to manage from a terminal.
 
-Four surfaces ship with the app:
+**CORE**
 
-**Observatory** — Session telemetry in detail: every session, every tool call, token usage, and trends over time. When someone asks "is this thing working?", Observatory is the answer.
+- **Harness** — view and edit your harness.yaml, CLAUDE.md, plugins, MCP servers, and hooks in a structured UI
+- **Marketplace** — browse and install plugins from the registry
 
-**Memory** — A knowledge graph that persists across every tool and every session. Add teammates, decisions, and conventions once; every agent can orient itself using them. Backed by the [membrain MCP server](/docs/plugins/research-knowledge/membrain).
+**INSIGHTS**
 
-**Board** — An AI-native Kanban board with real-time two-way sync. Agents pick up cards, draft commits, flag for review. You approve. See [board plugin docs](/docs/plugins/productivity/board) for the full MCP tool surface.
+- **Observatory** — session telemetry: every session, every tool call, token usage, timeline, trends
 
-**AI Chat** — A keyboard-first chat window tied to your harness. Terminal UX, Ollama support, and 12 built-in tools including file piping, web search, and memory queries. Every conversation is stored.
+**SYSTEM**
+
+- **Security** — permissions, secrets management, audit log
+
+**WORKFLOWS**
+
+- **Board** — AI-native Kanban board with real-time two-way sync; agents pick up cards, flag for review
+- **Roadmap** — AI-generated quarterly roadmaps and competitor analysis tied to your board
+
+**Standalone sections**
+
+- **Agents** — monitor and manage specialist subagents running across your harness
+- **Comparator** — run the same prompt across Claude Code, Cursor, and Copilot side by side
+- **Parity** — track which plugins, MCP servers, and skills are loaded in each connected AI tool
+- **AI Chat** — keyboard-first chat window with Ollama support and integrated tools
+- **Memory** — browse, search, and manage the knowledge graph your agents orient themselves in
+
+---
+
+## CLI
+
+The `harness-kit` CLI is a standalone terminal tool. You run it from your shell; it is not a plugin and does not run inside an AI tool's session.
+
+```bash
+harness-kit validate          # check harness.yaml against the schema
+harness-kit compile           # compile harness.yaml into native per-tool configs
+harness-kit sync              # fetch plugins into local cache, write harness.lock
+harness-kit check             # detect drift between compiled output and harness.yaml
+harness-kit detect            # show which AI platforms are present in the working directory
+harness-kit scan              # security audit of installed plugin skill files
+```
+
+**`compile` output** — `harness-kit compile` writes native configuration files for each detected AI tool: `.claude/settings.json` for Claude Code, `.cursor/rules` for Cursor, and so on. Each AI tool then loads those files at session start. This is how harness.yaml becomes active in your AI tools — it is compiled, not interpreted at runtime.
+
+<Callout type="info" title="Installation">
+  See [Installation](/docs/getting-started/installation) for Homebrew, npm, and binary options.
+</Callout>
 
 ---
 
@@ -57,108 +104,71 @@ Four surfaces ship with the app:
 
 <Steps>
 <Step>
-**Source** — You register harness-kit as a plugin source in your AI tool. This points to the collection, not individual plugins.
+**Source** — you register harness-kit as a plugin source in your AI tool. This points to the collection, not individual plugins.
 </Step>
 <Step>
-**Install** — You install a plugin by name. Your harness downloads the plugin directory locally.
+**Install** — you install a plugin by name. The plugin directory is downloaded locally.
 
 ```
 /plugin install research@harness-kit
 ```
 </Step>
 <Step>
-**Discovery** — At session start, your harness scans installed plugins and registers all skills it finds.
+**Discovery** — at session start, your AI tool scans installed plugins and registers any skills it finds.
 </Step>
 <Step>
-**Invocation** — You invoke a slash command. The matching `SKILL.md` is loaded into context as the workflow definition.
+**Invocation** — you run a slash command. The matching `SKILL.md` is loaded into context as the workflow definition.
 
 ```
-/research
+/research https://github.com/anthropics/claude-code
 ```
 </Step>
 <Step>
-**Execution** — The AI follows the steps in `SKILL.md`, using available tools: file I/O, web fetch, shell commands, MCP servers.
+**Execution** — the AI follows the steps in `SKILL.md`, using available tools: file I/O, web fetch, shell commands, MCP servers.
 </Step>
 </Steps>
 
 ### Plugin Anatomy
 
-Every plugin follows the same directory layout:
-
 ```
 plugins/<name>/
 ├── .claude-plugin/
-│   └── plugin.json         # name, version, description
+│   └── plugin.json       # name, version, description
 ├── skills/
 │   └── <name>/
-│       ├── SKILL.md        # the workflow (what Claude reads)
-│       └── README.md       # human docs
-├── scripts/                # optional: bundled automation
-├── hooks/                  # optional: lifecycle event handlers
-└── agents/                 # optional: specialist subagents
+│       ├── SKILL.md      # the workflow (what the AI reads at invocation)
+│       └── README.md     # human docs
+├── scripts/              # optional: shell automation
+├── hooks/                # optional: Stop, PreTool, PostTool handlers
+└── agents/               # optional: isolated specialist subagents
 ```
 
 | Component | Role | When it runs |
 |-----------|------|-------------|
 | `plugin.json` | Metadata — name, version, description | At install and update |
-| `SKILL.md` | Workflow definition — steps Claude follows at invocation | At slash command invocation |
-| `README.md` | Human-facing docs | Never (reference only) |
+| `SKILL.md` | Workflow definition | At slash command invocation |
 | `scripts/` | Shell scripts called by skills or hooks | On demand |
-| `hooks/` | Stop, PreTool, PostTool event handlers | On harness lifecycle events |
-| `agents/` | Isolated specialist workers with scoped tools and permissions | When a skill delegates to a named agent |
+| `hooks/` | Lifecycle event handlers | On harness lifecycle events |
+| `agents/` | Isolated workers with scoped tools and a fresh context window | When a skill delegates to a named agent |
 
-### What Makes a SKILL.md Different from a Prompt
+### SKILL.md vs. a prompt
 
 A `SKILL.md` is a **complete workflow specification**, not a prompt template:
 
 - **Mandatory step ordering** — steps execute in sequence, no skipping
 - **Input parsing rules** — how to interpret arguments and flags
-- **Tool usage patterns** — which tools to call when, and how
+- **Tool usage patterns** — which tools to call, when, and how
 - **Output structure** — exact format for results
 - **Error handling** — explicit recovery steps when things fail
 - **Common mistakes table** — known failure modes and fixes
 
-This structure makes skills repeatable across sessions and transferable across users. The same `/research` invocation produces the same workflow regardless of who runs it or when.
-
----
-
-## CLI
-
-The `harness-kit` CLI operates on `harness.yaml` from the terminal. It's useful for CI pipelines, pre-commit hooks, and machines where the desktop app isn't running.
-
-<Tabs items={["Homebrew", "npm", "Binary"]}>
-<Tab value="Homebrew">
-```bash
-brew tap harnessprotocol/tap
-brew install harness-kit
-```
-</Tab>
-<Tab value="npm">
-```bash
-npm install -g @harness-kit/cli
-```
-</Tab>
-<Tab value="Binary">
-Download from [GitHub Releases](https://github.com/harnessprotocol/harness-kit/releases).
-</Tab>
-</Tabs>
-
-**Core commands:**
-
-```bash
-harness-kit validate          # check harness.yaml against the schema
-harness-kit compile           # emit native configs for Claude Code, Cursor, Copilot
-harness-kit sync              # pull latest plugin changes from the registry
-harness-kit scan              # audit installed skills for unsafe directives
-```
+This structure makes skills repeatable across sessions and transferable across users. The same `/research` invocation produces the same workflow regardless of who runs it.
 
 ---
 
 ## Portability
 
-### New Machine
-
-Your harness is fully reproducible. Config files live in version control; plugins reinstall from the registry with the same commands you used the first time.
+Your harness is fully reproducible. Config files live in version control; plugins reinstall from the registry with the same commands.
 
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 560 210" style={{width: '100%', maxWidth: '560px', display: 'block', margin: '2rem auto'}}>
   <defs>
@@ -210,18 +220,12 @@ Your harness is fully reproducible. Config files live in version control; plugin
   <text x="504" y="185" textAnchor="middle" fontFamily="system-ui, sans-serif" fontSize="11" fill="#888">review ...</text>
 </svg>
 
-### Sharing with Teammates
-
-Your entire harness serializes into a single `harness.yaml`. Export it, commit it, share it — your teammate runs one command to selectively import what they want.
+Your harness.yaml serializes your whole setup. Share it, import it, or use it to bootstrap the same configuration on any machine.
 
 ```bash
-/harness-export          # captures plugins, versions, and sources
-/harness-import harness.yaml  # interactive picker: they choose what to install
+/harness-export                       # capture plugins, versions, sources → harness.yaml
+/harness-import harness.yaml          # interactive picker: teammate chooses what to install
 ```
-
-<Callout type="info" title="A manifest, not a clone">
-  harness.yaml records <em>what</em> you have and <em>where it came from</em>. The import side fetches the same versions from the same sources. Your setup becomes a shareable artifact, not tribal knowledge.
-</Callout>
 
 ---
 
@@ -231,4 +235,4 @@ harness-kit is a framework without a runtime. No SDK, no build step, no executio
 
 The `SKILL.md` is the portable unit. Plugins add distribution, versioning, and automation on top — but the workflow itself is plain text that any AI tool can read. Uninstall a plugin and nothing breaks, because nothing was ever coupled to it.
 
-> Skills are plain markdown, readable and editable by anyone. The spec is [open](https://harnessprotocol.io). The format travels.
+The spec is [open](https://harnessprotocol.io). The format travels.

--- a/website/content/docs/getting-started/installation.mdx
+++ b/website/content/docs/getting-started/installation.mdx
@@ -1,91 +1,137 @@
 ---
 sidebar_position: 1
 title: Installation
+description: Three ways to install harness-kit — pick what fits your workflow.
 ---
 
-# Installation
+<InstallMethodCards />
 
-Two commands. The first adds the Harness Kit marketplace to Claude Code. The second installs your first plugin by name. That's the whole install.
+## Desktop App
 
-harness-kit ships three installable artifacts — choose what you need:
+The full harness-kit experience. Observatory, Memory, Board, and AI Chat — all in one native app with a visual interface for managing your AI tool configurations.
 
-| Artifact | What it does | How to install |
-|----------|-------------|----------------|
-| **Skills & Plugins** | Adds slash commands to Claude Code | Plugin marketplace or install script |
-| **CLI** (`harness-kit`) | Compiles and validates `harness.yaml` from the terminal | Homebrew, npm, or direct download |
-| **Desktop App** | Visual interface for managing your AI tool configurations | Homebrew Cask or DMG |
+<Tabs items={["Homebrew", "DMG"]}>
+<Tab value="Homebrew">
+<Steps>
+<Step>
+**Tap the Harness Kit Homebrew cask**
 
-Most users start with skills. The CLI and desktop app are for teams managing shared `harness.yaml` configs.
+```bash
+brew tap harnessprotocol/tap
+brew install --cask harness-kit
+```
+</Step>
+<Step>
+**Clear the quarantine flag**
+
+The app is not yet notarized. Run this before first launch:
+
+```bash
+xattr -cr "/Applications/Harness Kit.app"
+```
+
+Or right-click the app in Finder → **Open** → confirm.
+</Step>
+<Step>
+**Launch from Applications or Spotlight**
+
+Search `Harness Kit` or open from `/Applications/Harness Kit.app`.
+</Step>
+</Steps>
+</Tab>
+
+<Tab value="DMG">
+<Steps>
+<Step>
+**Download the DMG**
+
+Get `HarnessKit-vX.Y.Z-darwin-arm64.dmg` from [GitHub Releases](https://github.com/harnessprotocol/harness-kit/releases).
+</Step>
+<Step>
+**Drag to Applications**
+
+Open the `.dmg` and drag **Harness Kit** to your Applications folder.
+</Step>
+<Step>
+**Clear the quarantine flag**
+
+```bash
+xattr -cr "/Applications/Harness Kit.app"
+```
+</Step>
+<Step>
+**Launch from Applications or Spotlight**
+</Step>
+</Steps>
+</Tab>
+</Tabs>
+
+<Callout type="info" title="System requirements">
+  macOS 14 (Sonoma) or later, Apple Silicon (arm64). Intel builds are planned.
+</Callout>
 
 ---
 
 ## Skills & Plugins
 
+Slash commands for Claude Code. Add the marketplace once, install any plugin by name.
+
 <Tabs items={["Plugin Marketplace", "Install Script"]}>
 <Tab value="Plugin Marketplace">
-Add the marketplace once, then install any plugin by name:
+<Steps>
+<Step>
+**Add the marketplace**
 
 ```
 /plugin marketplace add harnessprotocol/harness-kit
+```
+</Step>
+<Step>
+**Install plugins by name**
+
+```
 /plugin install research@harness-kit
-```
-
-Repeat for any plugin you want:
-
-```
 /plugin install explain@harness-kit
-/plugin install lineage@harness-kit
 /plugin install orient@harness-kit
-/plugin install capture@harness-kit
-/plugin install review@harness-kit
-/plugin install docgen@harness-kit
 ```
+</Step>
+</Steps>
 </Tab>
 
 <Tab value="Install Script">
-If your Claude Code build doesn't support the plugin marketplace yet:
+No plugin marketplace access? Use the install script:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/harnessprotocol/harness-kit/main/install.sh | bash
 ```
 
-This downloads skill files to `~/.claude/skills/` over HTTPS. It installs **only the skill files** — bundled scripts (like the research index rebuilder) require the full marketplace install.
+This copies skill files to `~/.claude/skills/` over HTTPS. Bundled scripts (like the research index rebuilder) require the full marketplace install.
 </Tab>
 </Tabs>
 
-### Verify
-
-After installing, invoke any skill to confirm it loaded:
+**Verify:** invoke any skill after installing:
 
 ```
 /research
 /explain src/main.ts
 ```
 
-<Callout type="success" title="Ready to go">
-  If the skill responds with its workflow, you're set.
+<Callout type="info" title="Using with other tools">
+  SKILL.md files are plain markdown — copy them into any tool's instruction system. See [Using with Other Tools](/docs/cross-harness/setup-guide) for Copilot, Cursor, and Windsurf setup.
 </Callout>
-
-### Using with other tools
-
-SKILL.md files are plain markdown — copy them into any tool's instruction system. VS Code Copilot reads `CLAUDE.md` natively via the `chat.useClaudeMdFile` setting, so the [conventions guide](/docs/guides/conventions) works without modification.
-
-For per-tool setup instructions (Copilot, Cursor, Windsurf, MCP wiring), see [Using with Other Tools](/docs/cross-harness/setup-guide).
 
 ---
 
 ## CLI
 
-The `harness-kit` CLI validates and compiles `harness.yaml` into native config files for Claude Code, Cursor, and Copilot. It also handles plugin sync, drift detection, and security scanning.
+Compile `harness.yaml`, sync plugins, detect drift — from the terminal.
 
-<Tabs items={["Homebrew", "npm", "Direct download"]}>
+<Tabs items={["Homebrew", "npm", "Binary"]}>
 <Tab value="Homebrew">
 ```bash
 brew tap harnessprotocol/tap
 brew install harness-kit
 ```
-
-Homebrew manages updates automatically — `brew upgrade harness-kit` to update.
 </Tab>
 
 <Tab value="npm">
@@ -93,34 +139,30 @@ Homebrew manages updates automatically — `brew upgrade harness-kit` to update.
 npm install -g @harness-kit/cli
 ```
 
-Requires Node.js 22 or later. The package is published as `@harness-kit/cli` on npm.
+Requires Node.js 22 or later.
 </Tab>
 
-<Tab value="Direct download">
-Download the standalone binary (no Node.js required) from [GitHub Releases](https://github.com/harnessprotocol/harness-kit/releases).
+<Tab value="Binary">
+Download the standalone binary (no Node.js required) from [GitHub Releases](https://github.com/harnessprotocol/harness-kit/releases):
 
-**macOS (Apple Silicon):**
 ```bash
 tar -xzf harness-kit-vX.Y.Z-darwin-arm64.tar.gz
 chmod +x harness-kit
 sudo mv harness-kit /usr/local/bin/
 ```
-
-Replace `X.Y.Z` with the version you downloaded.
 </Tab>
 </Tabs>
 
-### Verify
+**Verify:**
 
 ```bash
 harness-kit --version
-harness-kit validate        # validates harness.yaml in the current directory
-harness-kit compile --help  # see compile options
+harness-kit validate
 ```
 
 ---
 
-## Desktop App
+## Plugin Requirements
 
 The Harness Kit desktop app provides a visual interface for managing configs, running evals, comparing AI tools, and monitoring your setup.
 
@@ -156,14 +198,17 @@ macOS 14 (Sonoma) or later, Apple Silicon (arm64) required. Intel Mac builds are
 
 ---
 
-## Requirements per Plugin
+## Plugin Requirements
+
+<Accordions>
+<Accordion title="View requirements by plugin">
 
 | Plugin | Requirements |
 |--------|-------------|
-| research | `gh` CLI (GitHub sources only), Python 3.10+ (index rebuild) |
+| research | `gh` CLI (GitHub sources), Python 3.10+ (index rebuild) |
 | explain | None |
 | lineage | None |
-| orient | None (optional: [MCP Memory Server](https://github.com/anthropics/claude-code-memory)) |
+| orient | None (optional: MCP Memory Server) |
 | capture | None |
 | review | `gh` CLI (PR review only) |
 | docgen | None |
@@ -177,6 +222,9 @@ macOS 14 (Sonoma) or later, Apple Silicon (arm64) required. Intel Mac builds are
 | membrain | Go 1.25+, membrain MCP server |
 | frontend-design | None |
 
+</Accordion>
+</Accordions>
+
 <Callout type="warn" title="Environment variables">
-  Some plugins require environment variables for optional features. See the [Secrets Management guide](/docs/guides/secrets-management) for how to configure them.
+  Some plugins use optional env vars. See [Secrets Management](/docs/guides/secrets-management) for how to configure them.
 </Callout>


### PR DESCRIPTION
## Summary

Adds `npx skills add` support to the harness-kit docs — a single command installs the full docs as a Claude Code skill. Also ships a complete redesign of the architecture ("How It Works") page, an installation page overhaul, and brings the cross-harness support matrix up to date with Codex added and Windsurf removed.

## Changes

- **`skills/harness-docs/`** — new skill with 5 curated reference files (getting-started, plugin-catalog, creating-plugins, cross-harness, concepts-and-faq). Agent-optimized markdown, no JSX/MDX dependencies.
- **`AgentSkillBanner`** — banner on every docs page with `npx skills add` install command and copy button.
- **Architecture diagram** — full SVG rebuild: wider boxes (340 px/column), accurate Desktop App sections (all 11 from NAV_SECTIONS), CLI described as standalone terminal tool, feedback arrow routes through the column gap without crossing any box.
- **Installation page** — `InstallMethodCards` component wired in, duplicate heading removed, clean structure.
- **Explore page** — 5 broken links fixed (Observatory, Agents, Board, Roadmap, Memory all pointed to non-existent paths).
- **Docs sidebar logo** — fixed from purple (#8b7aff) to cyan (#4ec7f2) to match homepage.
- **Cross-harness matrix** — Codex added (AGENTS.md + `--mcp` flag), Windsurf removed; `ide-support.md`, `setup-guide.mdx`, and `skills/harness-docs/references/cross-harness.md` all consistent.

## Test Plan

- [x] `pnpm --filter harness-kit-docs build` passes (static export, 43 pages)
- [x] All 5 previously broken explore page links verified against static output
- [x] Architecture diagram rendered via Playwright — no overflow, no clipped text, all sections visible
- [x] Windsurf references scrubbed from all files (diagram, docs, skill references)
- [ ] CI checks (not configured for this branch)

## Notes

- No Windsurf section in setup-guide or support matrix. Can be re-added if market share warrants it later.
- Codex MCP support documented as `--mcp` flag — verify against latest Codex CLI release before merging if timing is sensitive.
- `harness-docs` skill is `user-invocable: false` — background knowledge skill, not a slash command.