### PR TITLE
fix(ci): downgrade Node to 22 in deploy-docs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 22
           cache: pnpm
           cache-dependency-path: website/pnpm-lock.yaml
 


### PR DESCRIPTION
## Summary

Node 24's bundled npm fails with `Cannot read properties of null (reading 'matches')` when `cloudflare/wrangler-action` tries to install wrangler internally. This has caused 3 consecutive deploy failures on main (runs 24570242658, 24548006388, 24540579620).

## Changes

- `node-version: 24` → `node-version: 22` in `deploy-docs.yml`

## Test Plan

- [ ] Deploy workflow passes on merge
- [ ] Production release deploys correctly after cutting v0.7.2