### PR TITLE
fix(ci): replace wrangler-action with pnpm dlx wrangler

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -45,18 +45,16 @@ jobs:
 
       - name: Deploy preview
         if: github.event_name == 'push'
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          packageManager: npm
-          command: pages deploy website/out --project-name=harness-kit-docs --branch=preview
+        working-directory: website
+        run: pnpm dlx wrangler@latest pages deploy out --project-name=harness-kit-docs --branch=preview
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Deploy production
         if: github.event_name == 'release'
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          packageManager: npm
-          command: pages deploy website/out --project-name=harness-kit-docs --branch=main
+        working-directory: website
+        run: pnpm dlx wrangler@latest pages deploy out --project-name=harness-kit-docs --branch=main
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary
- `wrangler-action@v3` fails on both Node 22 and Node 24 with `npm error Cannot read properties of null (reading 'matches')` when installing `wrangler@3.90.0`
- Root cause is in the action itself, not the Node version
- Fix: bypass `wrangler-action` entirely and invoke `pnpm dlx wrangler@latest` directly

## Changes
- Replace both `cloudflare/wrangler-action@v3` steps (preview + production) with `pnpm dlx wrangler@latest pages deploy ...`
- Credentials passed via env vars (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`) — same as wrangler expects natively

## Test Plan
- [ ] Push to main with website changes triggers preview deploy via pnpm dlx
- [ ] Release event triggers production deploy via pnpm dlx
- [ ] CI passes