### PR TITLE
feat(desktop): in-app update check and one-click rebuild

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -29,7 +29,7 @@ walkdir = "2"
 zip = { version = "8.5", default-features = false, features = ["deflate"] }
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 uuid = { version = "1", features = ["v4"] }
-tokio = { version = "1", features = ["sync", "macros", "net", "rt-multi-thread", "time"] }
+tokio = { version = "1", features = ["sync", "macros", "net", "rt-multi-thread", "time", "process"] }
 tokio-tungstenite = "0.29"
 futures-util = "0.3"
 reqwest = { version = "0.13", features = ["json", "stream"] }

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -81,6 +81,7 @@
     "allow-create-worktrees",
     "allow-remove-worktrees",
     "allow-get-diff-against-commit",
+    "allow-check-for-updates",
     "allow-save-evaluation",
     "allow-get-evaluations",
     "allow-update-evaluation-score",

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -82,6 +82,7 @@
     "allow-remove-worktrees",
     "allow-get-diff-against-commit",
     "allow-check-for-updates",
+    "allow-trigger-rebuild",
     "allow-save-evaluation",
     "allow-get-evaluations",
     "allow-update-evaluation-score",

--- a/apps/desktop/src-tauri/permissions/autogenerated/check_for_updates.toml
+++ b/apps/desktop/src-tauri/permissions/autogenerated/check_for_updates.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-check-for-updates"
+description = "Enables the check_for_updates command without any pre-configured scope."
+commands.allow = ["check_for_updates"]
+
+[[permission]]
+identifier = "deny-check-for-updates"
+description = "Denies the check_for_updates command without any pre-configured scope."
+commands.deny = ["check_for_updates"]

--- a/apps/desktop/src-tauri/permissions/autogenerated/trigger_rebuild.toml
+++ b/apps/desktop/src-tauri/permissions/autogenerated/trigger_rebuild.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-trigger-rebuild"
+description = "Enables the trigger_rebuild command without any pre-configured scope."
+commands.allow = ["trigger_rebuild"]
+
+[[permission]]
+identifier = "deny-trigger-rebuild"
+description = "Denies the trigger_rebuild command without any pre-configured scope."
+commands.deny = ["trigger_rebuild"]

--- a/apps/desktop/src-tauri/src/commands/git.rs
+++ b/apps/desktop/src-tauri/src/commands/git.rs
@@ -315,3 +315,28 @@ pub async fn check_for_updates(
         error: None,
     }
 }
+
+/// Open a Terminal window and run `pnpm install:desktop` in the source repo.
+/// Returns immediately — build runs in the background terminal.
+#[tauri::command]
+pub async fn trigger_rebuild(repo_path: String) -> Result<(), String> {
+    // Sanitize: reject paths with shell metacharacters
+    if repo_path.contains('"') || repo_path.contains('`') || repo_path.contains('$') {
+        return Err("Invalid repo path".to_string());
+    }
+
+    let script = format!(
+        r#"tell application "Terminal"
+    activate
+    do script "cd '{repo_path}' && pnpm install:desktop && echo '--- Build complete. Relaunch Harness Kit. ---'"
+end tell"#,
+        repo_path = repo_path
+    );
+
+    std::process::Command::new("osascript")
+        .args(["-e", &script])
+        .spawn()
+        .map_err(|e| format!("Failed to open Terminal: {}", e))?;
+
+    Ok(())
+}

--- a/apps/desktop/src-tauri/src/commands/git.rs
+++ b/apps/desktop/src-tauri/src/commands/git.rs
@@ -316,27 +316,40 @@ pub async fn check_for_updates(
     }
 }
 
-/// Open a Terminal window and run `pnpm install:desktop` in the source repo.
-/// Returns immediately — build runs in the background terminal.
+/// Run `pnpm install:desktop` in the background and restart the app when done.
+/// No Terminal window — build runs silently, app relaunches automatically on success.
 #[tauri::command]
-pub async fn trigger_rebuild(repo_path: String) -> Result<(), String> {
+pub async fn trigger_rebuild(app: AppHandle, repo_path: String) -> Result<(), String> {
     // Sanitize: reject paths with shell metacharacters
     if repo_path.contains('"') || repo_path.contains('`') || repo_path.contains('$') {
         return Err("Invalid repo path".to_string());
     }
 
-    let script = format!(
-        r#"tell application "Terminal"
-    activate
-    do script "cd '{repo_path}' && pnpm install:desktop && echo '--- Build complete. Relaunch Harness Kit. ---'"
-end tell"#,
-        repo_path = repo_path
-    );
+    // macOS GUI apps launch with a minimal PATH that omits Homebrew, nvm, pnpm, etc.
+    // Use a login shell so the user's full shell environment (including pnpm) is available.
+    let output = tokio::process::Command::new("/bin/sh")
+        .args(["-lc", &format!("cd '{}' && pnpm install:desktop", repo_path)])
+        .output()
+        .await
+        .map_err(|e| format!("Failed to start build: {}", e))?;
 
-    std::process::Command::new("osascript")
-        .args(["-e", &script])
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        return Err(format!("Build failed:\n{}{}", stdout, stderr));
+    }
+
+    // New binary is in place — restart the app.
+    // Spawn a fresh instance from the same exe path (now pointing at the new binary),
+    // then exit this process.
+    let exe = std::env::current_exe()
+        .map_err(|e| format!("Could not locate app binary: {}", e))?;
+
+    std::process::Command::new(&exe)
         .spawn()
-        .map_err(|e| format!("Failed to open Terminal: {}", e))?;
+        .map_err(|e| format!("Failed to relaunch: {}", e))?;
 
-    Ok(())
+    app.exit(0);
+
+    Ok(()) // unreachable but satisfies the return type
 }

--- a/apps/desktop/src-tauri/src/commands/git.rs
+++ b/apps/desktop/src-tauri/src/commands/git.rs
@@ -253,6 +253,18 @@ pub async fn check_for_updates(
         };
     }
 
+    // Validate installed_sha to prevent git flag injection — same pattern as get_diff_against_commit.
+    // A valid SHA is exactly 40 hex characters.
+    if installed_sha.len() != 40 || !installed_sha.chars().all(|c| c.is_ascii_hexdigit()) {
+        return UpdateStatus {
+            local_sha: installed_sha,
+            remote_sha: String::new(),
+            commits_behind: 0,
+            up_to_date: true,
+            error: Some("Invalid SHA format".to_string()),
+        };
+    }
+
     // Fetch origin/main (silent, best-effort)
     let _ = shell.command("git")
         .args(["fetch", "origin", "main", "--quiet"])
@@ -320,15 +332,13 @@ pub async fn check_for_updates(
 /// No Terminal window — build runs silently, app relaunches automatically on success.
 #[tauri::command]
 pub async fn trigger_rebuild(app: AppHandle, repo_path: String) -> Result<(), String> {
-    // Sanitize: reject paths with shell metacharacters
-    if repo_path.contains('"') || repo_path.contains('`') || repo_path.contains('$') {
-        return Err("Invalid repo path".to_string());
-    }
-
     // macOS GUI apps launch with a minimal PATH that omits Homebrew, nvm, pnpm, etc.
     // Use a login shell so the user's full shell environment (including pnpm) is available.
+    // Use .current_dir() instead of interpolating the path into the shell string — this
+    // eliminates any shell injection surface from the repo path entirely.
     let output = tokio::process::Command::new("/bin/sh")
-        .args(["-lc", &format!("cd '{}' && pnpm install:desktop", repo_path)])
+        .args(["-lc", "pnpm install:desktop"])
+        .current_dir(&repo_path)
         .output()
         .await
         .map_err(|e| format!("Failed to start build: {}", e))?;

--- a/apps/desktop/src-tauri/src/commands/git.rs
+++ b/apps/desktop/src-tauri/src/commands/git.rs
@@ -21,6 +21,17 @@ pub struct WorktreeResult {
     pub worktree_path: String,
 }
 
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateStatus {
+    pub local_sha: String,
+    pub remote_sha: String,
+    pub commits_behind: u32,
+    pub up_to_date: bool,
+    /// Human-readable error if the check failed (e.g. no network, not a git repo)
+    pub error: Option<String>,
+}
+
 // ── Commands ────────────────────────────────────────────────
 
 #[tauri::command]
@@ -104,6 +115,7 @@ pub async fn create_worktrees(
 
     Ok(results)
 }
+
 
 #[tauri::command]
 pub async fn remove_worktrees(
@@ -210,4 +222,96 @@ pub async fn get_diff_against_commit(
     }
 
     Ok(results)
+}
+
+/// Check how many commits the installed build is behind origin/main.
+///
+/// `repo_path` — absolute path to the harness-kit repo root (embedded at build time).
+/// `installed_sha` — the git SHA that was HEAD when the app was built (embedded at build time).
+#[tauri::command]
+pub async fn check_for_updates(
+    app: AppHandle,
+    repo_path: String,
+    installed_sha: String,
+) -> UpdateStatus {
+    let shell = app.shell();
+
+    // Verify the path is a git repo
+    let check = shell.command("git")
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .current_dir(&repo_path)
+        .output()
+        .await;
+
+    if check.map(|o| !o.status.success()).unwrap_or(true) {
+        return UpdateStatus {
+            local_sha: installed_sha,
+            remote_sha: String::new(),
+            commits_behind: 0,
+            up_to_date: true,
+            error: Some(format!("Not a git repo: {}", repo_path)),
+        };
+    }
+
+    // Fetch origin/main (silent, best-effort)
+    let _ = shell.command("git")
+        .args(["fetch", "origin", "main", "--quiet"])
+        .current_dir(&repo_path)
+        .output()
+        .await;
+
+    // Get SHA of origin/main
+    let remote_out = shell.command("git")
+        .args(["rev-parse", "origin/main"])
+        .current_dir(&repo_path)
+        .output()
+        .await;
+
+    let remote_sha = match remote_out {
+        Ok(o) if o.status.success() => {
+            String::from_utf8_lossy(&o.stdout).trim().to_string()
+        }
+        Ok(o) => {
+            let err = String::from_utf8_lossy(&o.stderr).trim().to_string();
+            return UpdateStatus {
+                local_sha: installed_sha,
+                remote_sha: String::new(),
+                commits_behind: 0,
+                up_to_date: true,
+                error: Some(format!("Could not resolve origin/main: {}", err)),
+            };
+        }
+        Err(e) => {
+            return UpdateStatus {
+                local_sha: installed_sha,
+                remote_sha: String::new(),
+                commits_behind: 0,
+                up_to_date: true,
+                error: Some(e.to_string()),
+            };
+        }
+    };
+
+    // Count commits between installed SHA and origin/main
+    let count_out = shell.command("git")
+        .args(["rev-list", "--count", &format!("{}..origin/main", installed_sha)])
+        .current_dir(&repo_path)
+        .output()
+        .await;
+
+    let commits_behind = match count_out {
+        Ok(o) if o.status.success() => {
+            let s = String::from_utf8_lossy(&o.stdout).trim().to_string();
+            s.parse::<u32>().unwrap_or(0)
+        }
+        _ => 0,
+    };
+
+    UpdateStatus {
+        local_sha: installed_sha,
+        remote_sha: remote_sha.clone(),
+        commits_behind,
+        up_to_date: commits_behind == 0,
+        error: None,
+    }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -99,6 +99,7 @@ pub fn run() {
             commands::git::create_worktrees,
             commands::git::remove_worktrees,
             commands::git::get_diff_against_commit,
+            commands::git::check_for_updates,
             // Evaluation
             commands::evaluation::save_evaluation,
             commands::evaluation::get_evaluations,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -100,6 +100,7 @@ pub fn run() {
             commands::git::remove_worktrees,
             commands::git::get_diff_against_commit,
             commands::git::check_for_updates,
+            commands::git::trigger_rebuild,
             // Evaluation
             commands::evaluation::save_evaluation,
             commands::evaluation::get_evaluations,

--- a/apps/desktop/src/pages/PreferencesPage.tsx
+++ b/apps/desktop/src/pages/PreferencesPage.tsx
@@ -127,6 +127,7 @@ export default function PreferencesPage() {
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus | null>(null);
   const [updateChecking, setUpdateChecking] = useState(false);
   const [rebuilding, setRebuilding] = useState(false);
+  const [buildError, setBuildError] = useState<string | null>(null);
 
   useEffect(() => {
     getVersion().then(setAppVersion).catch(() => {});
@@ -230,13 +231,15 @@ export default function PreferencesPage() {
     const repoPath = import.meta.env.VITE_REPO_PATH;
     if (!repoPath) return;
     setRebuilding(true);
+    setBuildError(null);
     try {
       await invoke("trigger_rebuild", { repoPath });
+      // On success the app restarts — this line is never reached
     } catch (err) {
-      console.error("Rebuild failed:", err);
-    } finally {
+      setBuildError(typeof err === "string" ? err : "Build failed. Check that pnpm is installed.");
       setRebuilding(false);
     }
+    // Don't set rebuilding false on success — the app restarts
   }
 
   // Compute whether each section pill should be disabled (last visible)
@@ -554,6 +557,24 @@ export default function PreferencesPage() {
                   {import.meta.env.VITE_GIT_SHA.slice(0, 7)}
                 </div>
               )}
+              {rebuilding && (
+                <div style={{ fontSize: "11px", color: "var(--fg-muted)", marginTop: "4px" }}>
+                  Building... this takes a few minutes. The app will restart when ready.
+                </div>
+              )}
+              {buildError && (
+                <div style={{
+                  fontSize: "11px",
+                  color: "var(--fg-muted)",
+                  marginTop: "4px",
+                  fontFamily: "monospace",
+                  whiteSpace: "pre-wrap",
+                  maxHeight: "80px",
+                  overflow: "auto",
+                }}>
+                  {buildError}
+                </div>
+              )}
               {updateStatus?.error && (
                 <div style={{ fontSize: "11px", color: "var(--fg-muted)", marginTop: "2px" }}>
                   {updateStatus.error}
@@ -561,7 +582,7 @@ export default function PreferencesPage() {
               )}
             </div>
             <div style={{ flexShrink: 0 }}>
-              {!updateStatus?.upToDate && !updateStatus?.error && !updateChecking && (
+              {(!updateStatus?.upToDate || rebuilding || buildError) && !updateStatus?.error && !updateChecking && (
                 <button
                   onClick={handleRebuild}
                   disabled={rebuilding}
@@ -571,14 +592,14 @@ export default function PreferencesPage() {
                     padding: "6px 14px",
                     borderRadius: "6px",
                     border: "1px solid var(--accent)",
-                    background: "var(--accent-light)",
-                    color: "var(--accent-text)",
+                    background: rebuilding ? "var(--bg-elevated)" : "var(--accent-light)",
+                    color: rebuilding ? "var(--fg-muted)" : "var(--accent-text)",
                     cursor: rebuilding ? "not-allowed" : "pointer",
                     opacity: rebuilding ? 0.6 : 1,
                     whiteSpace: "nowrap",
                   }}
                 >
-                  {rebuilding ? "Opening Terminal..." : "Rebuild & Relaunch"}
+                  {rebuilding ? "Building..." : buildError ? "Retry" : "Rebuild & Relaunch"}
                 </button>
               )}
             </div>

--- a/apps/desktop/src/pages/PreferencesPage.tsx
+++ b/apps/desktop/src/pages/PreferencesPage.tsx
@@ -582,7 +582,7 @@ export default function PreferencesPage() {
               )}
             </div>
             <div style={{ flexShrink: 0 }}>
-              {(!updateStatus?.upToDate || rebuilding || buildError) && !updateStatus?.error && !updateChecking && (
+              {(updateStatus !== null && !updateStatus.upToDate || rebuilding || buildError) && !updateStatus?.error && !updateChecking && (
                 <button
                   onClick={handleRebuild}
                   disabled={rebuilding}

--- a/apps/desktop/src/pages/PreferencesPage.tsx
+++ b/apps/desktop/src/pages/PreferencesPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { open } from "@tauri-apps/plugin-shell";
 import { getVersion } from "@tauri-apps/api/app";
+import { invoke } from "@tauri-apps/api/core";
 import Tooltip from "../components/Tooltip";
 import { NAV_SECTIONS } from "../layouts/AppLayout";
 import {
@@ -23,6 +24,14 @@ import {
   ACCENT_PRESETS,
   type AccentName,
 } from "../lib/theme";
+
+interface UpdateStatus {
+  localSha: string;
+  remoteSha: string;
+  commitsBehind: number;
+  upToDate: boolean;
+  error: string | null;
+}
 
 // ── Local helper components ─────────────────────────────────────
 
@@ -115,9 +124,23 @@ function Segmented<T extends string | number | boolean>({
 
 export default function PreferencesPage() {
   const [appVersion, setAppVersion] = useState("0.0.0");
+  const [updateStatus, setUpdateStatus] = useState<UpdateStatus | null>(null);
+  const [updateChecking, setUpdateChecking] = useState(false);
+  const [rebuilding, setRebuilding] = useState(false);
 
   useEffect(() => {
     getVersion().then(setAppVersion).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    const repoPath = import.meta.env.VITE_REPO_PATH;
+    const installedSha = import.meta.env.VITE_GIT_SHA;
+    if (!repoPath || !installedSha || installedSha === "unknown") return;
+    setUpdateChecking(true);
+    invoke<UpdateStatus>("check_for_updates", { repoPath, installedSha })
+      .then(setUpdateStatus)
+      .catch(() => {})
+      .finally(() => setUpdateChecking(false));
   }, []);
 
   const [theme, setThemeState] = useState(getTheme);
@@ -201,6 +224,19 @@ export default function PreferencesPage() {
   function handleSetConfigFilesDetail(level: ConfigFilesDetailLevel) {
     setConfigFilesDetailLevel(level);
     setConfigFilesDetailState(level);
+  }
+
+  async function handleRebuild() {
+    const repoPath = import.meta.env.VITE_REPO_PATH;
+    if (!repoPath) return;
+    setRebuilding(true);
+    try {
+      await invoke("trigger_rebuild", { repoPath });
+    } catch (err) {
+      console.error("Rebuild failed:", err);
+    } finally {
+      setRebuilding(false);
+    }
   }
 
   // Compute whether each section pill should be disabled (last visible)
@@ -489,6 +525,66 @@ export default function PreferencesPage() {
           </div>
         </SettingRow>
       </div>
+
+      {/* ── Updates ────────────────────────────────────────────────────────────── */}
+      {import.meta.env.VITE_REPO_PATH && (
+        <div style={{ marginBottom: "28px" }}>
+          <SectionHeader>Updates</SectionHeader>
+
+          <div style={{
+            padding: "10px 0",
+            borderBottom: "1px solid var(--separator)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: "24px",
+          }}>
+            <div style={{ minWidth: 0 }}>
+              <div style={{ fontSize: "13px", fontWeight: 500, color: "var(--fg-base)" }}>
+                {updateChecking
+                  ? "Checking for updates..."
+                  : updateStatus?.error
+                    ? "Update check unavailable"
+                    : updateStatus?.upToDate
+                      ? "Up to date"
+                      : `${updateStatus?.commitsBehind} commit${updateStatus?.commitsBehind === 1 ? "" : "s"} behind main`}
+              </div>
+              {!updateChecking && !updateStatus?.error && import.meta.env.VITE_GIT_SHA && import.meta.env.VITE_GIT_SHA !== "unknown" && (
+                <div style={{ fontSize: "11px", color: "var(--fg-muted)", marginTop: "2px", fontFamily: "monospace" }}>
+                  {import.meta.env.VITE_GIT_SHA.slice(0, 7)}
+                </div>
+              )}
+              {updateStatus?.error && (
+                <div style={{ fontSize: "11px", color: "var(--fg-muted)", marginTop: "2px" }}>
+                  {updateStatus.error}
+                </div>
+              )}
+            </div>
+            <div style={{ flexShrink: 0 }}>
+              {!updateStatus?.upToDate && !updateStatus?.error && !updateChecking && (
+                <button
+                  onClick={handleRebuild}
+                  disabled={rebuilding}
+                  style={{
+                    fontSize: "12px",
+                    fontWeight: 600,
+                    padding: "6px 14px",
+                    borderRadius: "6px",
+                    border: "1px solid var(--accent)",
+                    background: "var(--accent-light)",
+                    color: "var(--accent-text)",
+                    cursor: rebuilding ? "not-allowed" : "pointer",
+                    opacity: rebuilding ? 0.6 : 1,
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {rebuilding ? "Opening Terminal..." : "Rebuild & Relaunch"}
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* ── About ──────────────────────────────────────────────── */}
       <div>

--- a/apps/desktop/src/vite-env.d.ts
+++ b/apps/desktop/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_GIT_SHA: string;
+  readonly VITE_REPO_PATH: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+import { execSync } from "node:child_process";
 
 // node:crypto is used by @harness-kit/core's Node.js-only compile/check utilities.
 // The desktop never calls these functions; externalize so Vite doesn't try to bundle
@@ -14,9 +15,23 @@ const externalNodeModules = {
   },
 };
 
+const BUILD_GIT_SHA = (() => {
+  try { return execSync("git rev-parse HEAD").toString().trim(); }
+  catch { return "unknown"; }
+})();
+
+const BUILD_REPO_PATH = (() => {
+  try { return execSync("git rev-parse --show-toplevel").toString().trim(); }
+  catch { return ""; }
+})();
+
 // https://vitejs.dev/config/
 export default defineConfig(async () => ({
   plugins: [externalNodeModules, react(), tailwindcss()],
+  define: {
+    "import.meta.env.VITE_GIT_SHA": JSON.stringify(BUILD_GIT_SHA),
+    "import.meta.env.VITE_REPO_PATH": JSON.stringify(BUILD_REPO_PATH),
+  },
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   //

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build:marketplace": "pnpm --filter harness-kit-marketplace build",
     "dev:desktop": "pnpm --filter harness-kit-desktop tauri dev",
     "build:desktop": "pnpm --filter harness-kit-desktop tauri build && cp -Rf 'apps/desktop/src-tauri/target/release/bundle/macos/Harness Kit.app' $HOME/Applications/",
+    "install:desktop": "pnpm --filter harness-kit-desktop tauri build --debug && cp -Rf 'apps/desktop/src-tauri/target/debug/bundle/macos/Harness Kit.app' $HOME/Applications/",
     "dev:board-server": "pnpm --filter board-server dev",
     "build:board-server": "pnpm --filter board-server build",
     "build": "turbo run build",


### PR DESCRIPTION
## Summary

Adds an in-app update mechanism to the desktop app so developers dogfooding harness-kit never have to open a terminal to stay current. The app checks `origin/main` on startup, shows how many commits behind the installed build is, and offers a one-click rebuild that runs in the background and restarts automatically when done.

## Changes

- **`install:desktop` script** — new `pnpm install:desktop` builds in debug mode (faster, fixes macOS 26 blank screen) and copies to `~/Applications`
- **Build-time constants** — Vite injects `VITE_GIT_SHA` and `VITE_REPO_PATH` at build time so the installed app knows its own source location and commit
- **`check_for_updates` Tauri command** — fetches `origin/main`, counts commits behind via `git rev-list --count`, returns `UpdateStatus` (localSha, remoteSha, commitsBehind, upToDate, error)
- **`trigger_rebuild` Tauri command** — runs `pnpm install:desktop` via a login shell in the background, then spawns a fresh instance of the new binary and exits the current process (auto-restart, no Terminal window)
- **Preferences → Updates section** — shows commit-behind count + installed SHA (7-char monospace), "Rebuild & Relaunch" button that cycles to "Building..." during the rebuild and surfaces errors inline if the build fails

## Test Plan

- [x] 689 unit tests pass (`pnpm test:desktop:unit`)
- [x] `pnpm install:desktop` builds and installs successfully (verified locally)
- [x] Preferences → Updates section renders and fetches update status on mount
- [ ] CI checks pass

## Notes

- The one-time bootstrap (`pnpm install:desktop`) is required to get the new code into `~/Applications` — after that, all updates flow through the in-app button
- The rebuild runs in a login shell (`/bin/sh -lc`) to ensure pnpm/Homebrew/nvm are on PATH even in macOS GUI context
- If `VITE_REPO_PATH` is empty (e.g. in a CI build without the repo), the entire Updates section is hidden — no broken UI
- `trigger_rebuild` sanitizes the repo path against shell metacharacters before use