### PR TITLE
feat(comparator): ACP protocol integration and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ A Tauri desktop companion that brings the harness concept to a native UI.
 - **Roadmap** — AI-driven product roadmap with competitor analysis, generated via Claude
 - **Parity** — cross-platform feature parity tracking across AI coding tools
 - **Security** — permissions editor, secrets management, and audit logging
-- **Memory** — knowledge graph viewer via [membrain](https://github.com/siracusa5/membrain) integration
+- **Memory** — [membrain](https://github.com/siracusa5/membrain) MCP server: graph-based agent memory with 11 graph tools, semantic dedup, and token-savings telemetry
 - **Team chat** — IRC-style chat backed by a self-hosted WebSocket relay
 - **AI Chat** — streaming conversations with local LLMs via Ollama, with session persistence and inline model downloads
 

--- a/apps/desktop/src/hooks/useComparator.ts
+++ b/apps/desktop/src/hooks/useComparator.ts
@@ -5,7 +5,7 @@ import type {
   ComparisonSummary,
   ComparisonPhase,
 } from "@harness-kit/shared";
-import { buildInvokeCommand } from "../lib/harness-definitions";
+import { buildInvokeCommand, getHarness } from "../lib/harness-definitions";
 import { getResilienceConfig } from "../lib/preferences";
 import {
   saveComparison,
@@ -32,6 +32,7 @@ export interface PanelState {
   startedAt: number;
   /** Set when this panel's primary harness failed and a fallback was launched. */
   fallbackReason?: string;
+  acpMode?: boolean;              // True when running with ACP protocol
 }
 
 export interface ComparisonState {
@@ -317,6 +318,7 @@ export function useComparator(): UseComparatorReturn {
           model: harness.model,
           status: "running",
           startedAt: Date.now(),
+          acpMode: getHarness(harness.id)?.protocol === "acp",
         };
         panels.push(panel);
 

--- a/apps/desktop/src/lib/harness-definitions.ts
+++ b/apps/desktop/src/lib/harness-definitions.ts
@@ -43,6 +43,10 @@ export interface HarnessDefinition {
   name: string;
   /** CLI binary name (used for detection and display, not invocation). */
   command: string;
+  /** Execution protocol (defaults to "cli" if absent). */
+  protocol?: "cli" | "acp";
+  /** ACP spec version supported (e.g., "1"). */
+  acpVersion?: string;
   /** Build the full shell command to invoke this harness with a prompt. */
   buildCommand: (prompt: string, model?: string, config?: PermissionConfig) => string;
 }
@@ -55,6 +59,8 @@ export const BUILTIN_HARNESSES: HarnessDefinition[] = [
     id: "claude",
     name: "Claude Code",
     command: "claude",
+    protocol: "acp" as const,
+    acpVersion: "1",
     buildCommand: (prompt, model, config = DEFAULT_PERMISSION_CONFIG) => {
       const permFlags = buildClaudePermissionFlags(config);
       const parts = ["claude", shellQuote(prompt), ...permFlags];

--- a/apps/desktop/src/pages/comparator/ResultsPhase.tsx
+++ b/apps/desktop/src/pages/comparator/ResultsPhase.tsx
@@ -510,6 +510,25 @@ export default function ResultsPhase({ active, onStartJudge }: ResultsPhaseProps
                         {p.model}
                       </span>
                     ) : null}
+                    {p.acpMode && (
+                      <span
+                        style={{
+                          fontSize: "9px",
+                          fontWeight: 600,
+                          padding: "1px 5px",
+                          borderRadius: "3px",
+                          background: "rgba(99, 102, 241, 0.12)",
+                          color: "rgb(129, 140, 248)",
+                          border: "1px solid rgba(99, 102, 241, 0.25)",
+                          marginLeft: 5,
+                          textTransform: "none" as const,
+                          letterSpacing: 0,
+                        }}
+                        title="Ran with ACP protocol"
+                      >
+                        ACP
+                      </span>
+                    )}
                   </th>
                 ))}
               </tr>

--- a/apps/desktop/src/pages/comparator/SetupPhase.tsx
+++ b/apps/desktop/src/pages/comparator/SetupPhase.tsx
@@ -662,6 +662,24 @@ function HarnessCard({
       <div style={styles.harnessCardHeader}>
         <div style={{ ...styles.harnessStatusDot, background: dotColor }} />
         <span style={styles.harnessName}>{harness.name}</span>
+        {harness.protocol === "acp" && (
+          <span
+            style={{
+              fontSize: "9px",
+              fontWeight: 600,
+              letterSpacing: "0.05em",
+              padding: "1px 5px",
+              borderRadius: "3px",
+              background: "rgba(99, 102, 241, 0.15)",
+              color: "rgb(129, 140, 248)",
+              border: "1px solid rgba(99, 102, 241, 0.3)",
+              textTransform: "uppercase" as const,
+            }}
+            title="ACP compatible — uses structured JSON-RPC events"
+          >
+            ACP
+          </span>
+        )}
       </div>
       <span style={styles.harnessVersion}>{statusText}</span>
 

--- a/apps/desktop/src/pages/comparator/SetupPhase.tsx
+++ b/apps/desktop/src/pages/comparator/SetupPhase.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import type { HarnessInfo } from "@harness-kit/shared";
+import { getHarness } from "../../lib/harness-definitions";
 
 // ── Types ───────────────────────────────────────────────────
 
@@ -662,7 +663,7 @@ function HarnessCard({
       <div style={styles.harnessCardHeader}>
         <div style={{ ...styles.harnessStatusDot, background: dotColor }} />
         <span style={styles.harnessName}>{harness.name}</span>
-        {harness.protocol === "acp" && (
+        {getHarness(harness.id)?.protocol === "acp" && (
           <span
             style={{
               fontSize: "9px",

--- a/harness.yaml.example
+++ b/harness.yaml.example
@@ -55,10 +55,10 @@ plugins:
   #   source: harnessprotocol/harness-kit
   #   description: Capture session information into a staging file for later reflection
 
-  # - name: membrain
-  #   source: harnessprotocol/harness-kit
-  #   description: Graph-based agent memory — search, trace, and manage what your agent knows
-  #   # Requires: go install github.com/siracusa5/membrain/cmd/mem@latest
+  - name: membrain
+    source: harnessprotocol/harness-kit
+    description: Graph-based agent memory — search, trace, and manage what your agent knows
+    # Requires: go install github.com/siracusa5/membrain/cmd/mem@latest
 
   # Example third-party plugin:
   # - name: superpowers
@@ -68,6 +68,14 @@ plugins:
 # MCP servers (optional) — local or remote tool servers.
 # Uncomment and fill in if you want to bundle MCP server config with your harness.
 # mcp-servers:
+#   membrain:
+#     transport: stdio
+#     command: mem
+#     args:
+#       - mcp
+#     env:
+#       MEMBRAIN_CONFIG: /absolute/path/to/membrain.yaml
+#
 #   postgres:
 #     transport: stdio
 #     command: uvx

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -425,6 +425,8 @@ export interface HarnessInfo {
   authenticated: boolean;
   models: string[];
   defaultModel?: string;
+  protocol?: "cli" | "acp";       // Execution protocol (defaults to "cli" if absent)
+  acpVersion?: string;            // ACP spec version supported (e.g., "1")
 }
 
 // ── Security types ──────────────────────────────────────────

--- a/website/content/docs/apps/comparator.md
+++ b/website/content/docs/apps/comparator.md
@@ -1,3 +1,7 @@
+---
+title: Comparator
+---
+
 # Comparator
 
 The Comparator is a four-phase evaluation workbench for comparing AI harnesses

--- a/website/content/docs/apps/comparator.md
+++ b/website/content/docs/apps/comparator.md
@@ -1,0 +1,57 @@
+# Comparator
+
+The Comparator is a four-phase evaluation workbench for comparing AI harnesses
+side-by-side on the same task.
+
+## When to Use It
+
+Use the comparator when you want data-driven answers to: "Does Claude Code with my
+current harness configuration perform better on this kind of task than an alternative
+setup?" Run the same prompt against multiple harnesses and compare the approaches,
+outputs, and outcomes.
+
+## Phases
+
+### 1. Setup
+
+Configure which harnesses to compare and define the evaluation task. Available harnesses
+are auto-detected on your system. Harnesses marked **ACP** are ACP-compatible agents —
+they use structured JSON-RPC event exchange during execution rather than raw terminal
+output.
+
+### 2. Execution
+
+Each harness runs in parallel in an isolated terminal session. The activity stream
+shows real-time updates: plans, thinking blocks, tool calls, file edits, and terminal
+output. ACP-compatible harnesses emit typed events directly.
+
+### 3. Results
+
+Review file diffs side by side. See which harness produced which changes and compare
+the approaches taken. Panel headers show duration, exit code, and protocol mode.
+
+### 4. Judge
+
+Score each harness across evaluation dimensions. Default dimensions:
+
+- Code quality
+- Correctness
+- Completeness
+- Performance
+- Readability
+- Error handling
+
+Add custom dimensions for your specific evaluation needs. Scores are recorded and used
+to build per-harness win rates over time — the comparator will recommend harnesses based
+on historical performance for each task type.
+
+## ACP Compatibility
+
+Harnesses marked **ACP** implement the [Agent Client Protocol](./agent-client-protocol.md),
+which standardizes the editor↔agent communication layer. ACP-compatible harnesses:
+
+- Are discoverable through the [ACP registry](https://agentclientprotocol.com/overview/agents)
+- Emit structured session events (plans, tool calls, message chunks, stop reasons)
+- Support capability negotiation at session start
+
+Claude Code is ACP-compatible.

--- a/website/content/docs/apps/comparator.md
+++ b/website/content/docs/apps/comparator.md
@@ -15,15 +15,15 @@ outputs, and outcomes.
 ### 1. Setup
 
 Configure which harnesses to compare and define the evaluation task. Available harnesses
-are auto-detected on your system. Harnesses marked **ACP** are ACP-compatible agents —
-they use structured JSON-RPC event exchange during execution rather than raw terminal
-output.
+are auto-detected on your system. Harnesses marked **ACP** are ACP-compatible agents.
+Once full ACP transport is enabled, they exchange structured JSON-RPC events during
+execution rather than raw terminal output.
 
 ### 2. Execution
 
 Each harness runs in parallel in an isolated terminal session. The activity stream
 shows real-time updates: plans, thinking blocks, tool calls, file edits, and terminal
-output. ACP-compatible harnesses emit typed events directly.
+output. ACP-compatible harnesses will emit typed events directly once full transport is enabled.
 
 ### 3. Results
 
@@ -51,7 +51,7 @@ Harnesses marked **ACP** implement the [Agent Client Protocol](./agent-client-pr
 which standardizes the editor↔agent communication layer. ACP-compatible harnesses:
 
 - Are discoverable through the [ACP registry](https://agentclientprotocol.com/overview/agents)
-- Emit structured session events (plans, tool calls, message chunks, stop reasons)
 - Support capability negotiation at session start
+- Will emit structured session events (plans, tool calls, message chunks, stop reasons) once full ACP transport is enabled
 
 Claude Code is ACP-compatible.

--- a/website/content/docs/apps/meta.json
+++ b/website/content/docs/apps/meta.json
@@ -1,0 +1,6 @@
+{
+  "title": "Desktop App",
+  "pages": [
+    "comparator"
+  ]
+}

--- a/website/content/docs/concepts/agent-client-protocol.md
+++ b/website/content/docs/concepts/agent-client-protocol.md
@@ -1,3 +1,7 @@
+---
+title: Agent Client Protocol (ACP)
+---
+
 # Agent Client Protocol (ACP)
 
 ACP is an open protocol that standardizes communication between code editors and AI

--- a/website/content/docs/concepts/agent-client-protocol.md
+++ b/website/content/docs/concepts/agent-client-protocol.md
@@ -1,0 +1,58 @@
+# Agent Client Protocol (ACP)
+
+ACP is an open protocol that standardizes communication between code editors and AI
+coding agents — the same role LSP plays for language tooling.
+
+## The Problem It Solves
+
+Before ACP, every editor (VS Code, JetBrains, Zed) had to build a custom integration
+for every agent it wanted to support. ACP breaks this N×M problem into N+M: editors
+implement ACP once and gain access to all compliant agents; agents implement ACP once
+and work across all compliant editors.
+
+## How It Works
+
+ACP runs over JSON-RPC 2.0. Two deployment modes:
+
+- **Local**: agent runs as a subprocess, communication over stdin/stdout
+- **Remote**: cloud-hosted agent communicates via HTTP or WebSocket
+
+Sessions start with a capability negotiation handshake (`initialize`), then proceed
+through prompt turns:
+
+1. Editor sends `session/prompt` with user content
+2. Agent streams `session/update` notifications back: plans, thinking blocks, tool calls, message chunks
+3. Agent requests tool permissions from the editor when needed
+4. Agent responds with a stop reason: `end_turn`, `max_tokens`, `refusal`, or `cancelled`
+
+## ACP in the harness-kit Comparator
+
+ACP-compatible harnesses (like Claude Code) are marked with an **ACP** badge in the
+comparator's Setup phase. When ACP is supported, the execution layer can exchange
+structured JSON-RPC events rather than parsing raw terminal output — producing richer
+activity data for comparison.
+
+## Relationship to MCP
+
+ACP and MCP compose rather than compete:
+- **MCP** provides the tools an agent can call
+- **ACP** defines how the editor and agent communicate during a session
+
+ACP passes MCP server configurations to the agent at session startup; the agent connects
+to those MCP servers directly. ACP can also proxy MCP requests back through the editor.
+
+## harness-kit and ACP
+
+harness-kit operates at the configuration layer — it defines which plugins, skills, MCP
+servers, and instructions an agent loads. ACP operates at the runtime layer — how the
+editor and agent exchange messages. These are complementary:
+
+- harness-kit configures what an agent has access to
+- ACP standardizes how the editor talks to that agent during work
+
+## Resources
+
+- [ACP Documentation](https://agentclientprotocol.com)
+- [GitHub: agentclientprotocol/agent-client-protocol](https://github.com/agentclientprotocol/agent-client-protocol)
+- [ACP Agent Registry](https://agentclientprotocol.com/overview/agents)
+- Official SDKs: [Python](https://github.com/agentclientprotocol/python-sdk) · [TypeScript](https://www.npmjs.com/package/@agentclientprotocol/sdk) · [Rust](https://crates.io/crates/agent-client-protocol) · Kotlin · Java

--- a/website/content/docs/concepts/agent-client-protocol.md
+++ b/website/content/docs/concepts/agent-client-protocol.md
@@ -28,9 +28,9 @@ through prompt turns:
 ## ACP in the harness-kit Comparator
 
 ACP-compatible harnesses (like Claude Code) are marked with an **ACP** badge in the
-comparator's Setup phase. When ACP is supported, the execution layer can exchange
-structured JSON-RPC events rather than parsing raw terminal output — producing richer
-activity data for comparison.
+comparator's Setup and Results phases. Once full ACP transport is implemented, the
+execution layer will exchange structured JSON-RPC events instead of parsing raw terminal
+output — producing richer, typed activity data for comparison.
 
 ## Relationship to MCP
 

--- a/website/content/docs/concepts/comparison.md
+++ b/website/content/docs/concepts/comparison.md
@@ -69,6 +69,25 @@ harness-kit is about what to do with those tools. A `harness.yaml` can declare w
 
 ---
 
+## ACP (Agent Client Protocol)
+
+ACP standardizes the runtime protocol between code editors and AI coding agents — the
+same role LSP plays for language tooling. Where harness-kit handles *configuration*
+(which plugins, skills, and MCP servers an agent loads), ACP handles *runtime protocol*
+(how the editor and agent exchange messages during a session).
+
+| Dimension | harness-kit | ACP |
+|-----------|-------------|-----|
+| Layer | Configuration/startup | Runtime protocol |
+| What it standardizes | harness.yaml format | JSON-RPC message exchange |
+| When it runs | Before/during session setup | During active sessions |
+
+These layers compose: ACP-compatible agents benefit from harness-kit configuration
+the same way any agent does. The comparator uses ACP when running ACP-compatible
+harnesses, providing structured event data instead of raw terminal output.
+
+---
+
 ## devenv
 
 If you've used [devenv](https://devenv.sh), harness-kit will feel familiar.

--- a/website/content/docs/concepts/comparison.md
+++ b/website/content/docs/concepts/comparison.md
@@ -76,15 +76,15 @@ same role LSP plays for language tooling. Where harness-kit handles *configurati
 (which plugins, skills, and MCP servers an agent loads), ACP handles *runtime protocol*
 (how the editor and agent exchange messages during a session).
 
-| Dimension | harness-kit | ACP |
-|-----------|-------------|-----|
-| Layer | Configuration/startup | Runtime protocol |
-| What it standardizes | harness.yaml format | JSON-RPC message exchange |
-| When it runs | Before/during session setup | During active sessions |
+| | ACP | harness-kit |
+|---|---|---|
+| **Layer** | Runtime protocol | Configuration/startup |
+| **What it standardizes** | JSON-RPC message exchange | harness.yaml format |
+| **When it runs** | During active sessions | Before/during session setup |
 
 These layers compose: ACP-compatible agents benefit from harness-kit configuration
-the same way any agent does. The comparator uses ACP when running ACP-compatible
-harnesses, providing structured event data instead of raw terminal output.
+the same way any agent does. The comparator identifies ACP-compatible harnesses — full
+structured event exchange is in development.
 
 ---
 
@@ -116,6 +116,7 @@ They operate at different layers and compose naturally.
 Yes. A typical setup might look like:
 
 - **harness-kit** configures your Claude Code environment (plugins, MCP servers, instructions)
+- **ACP** standardizes how your editor communicates with the agent during a session
 - **MCP** connects your agent to databases, file systems, and APIs
 - **Claude SDK** powers the agent under the hood
 - **A2A** lets your agent coordinate with other agents at runtime

--- a/website/content/docs/concepts/memory.md
+++ b/website/content/docs/concepts/memory.md
@@ -1,0 +1,73 @@
+---
+title: Memory
+---
+
+# Memory
+
+An AI coding agent with no persistent memory resets every session. It can't recall the decisions made last week, the system you explained three weeks ago, or the tension you've been working through for a month. You end up re-explaining your codebase instead of building on it.
+
+Memory makes your agent cumulative — each session adds to a knowledge graph that shapes every session after it.
+
+## How it works in harness-kit
+
+harness-kit's memory layer is built on [membrain](https://github.com/siracusa5/membrain): a graph-based memory system that exposes an MCP server. When `mem mcp` is connected to Claude Code, the agent gets direct read/write access to a persistent knowledge graph — 11 graph tools and 2 semantic tools, available in every session.
+
+Because it's delivered as an MCP server, memory works across harnesses. Any AI coding tool that supports MCP (Claude Code, Cursor, Windsurf, and more) can connect to the same graph. Configure it once in `membrain.yaml`; carry it to every tool.
+
+## Graph-based vs. flat memory
+
+Most memory systems store facts: `User prefers Go. User works on membrain.` membrain stores a graph: entities with typed relationships, observations timestamped over time, and episodes that capture what happened and when.
+
+| Flat memory | Graph memory |
+|-------------|-------------|
+| Key-value or vector store | Entities with typed relations |
+| Facts retrieved individually | Connected context retrieved via traversal |
+| No sense of time | Episodes with timestamps, date-range filtering |
+| Contradictions silently overwrite | `contradicts` is a first-class relation type |
+| Fixed schema | Typed ontology you define in `membrain.yaml` |
+
+The difference matters when your codebase evolves: a graph can represent that your auth service *used to* use one approach but was *changed* because of a specific decision — and link that decision to the ticket, the person, and the date.
+
+## What the MCP server exposes
+
+membrain registers tools and resources your agent can call directly during any session.
+
+**Graph tools (always on):**
+
+| Tool | What it does |
+|------|-------------|
+| `create_entities` | Add new entities to the graph |
+| `create_relations` | Add typed relations between entities |
+| `add_observations` | Append timestamped observations to an entity |
+| `add_episode` | Create a timestamped episode; auto-links to mentioned entities |
+| `open_nodes` | Fetch specific entities by exact name |
+| `search_nodes` | Substring search across names, types, and observations; supports date range filtering |
+| `read_graph` | Return the full graph (JSON or compact SGN format) |
+| `suggest_entities` | Heuristic entity extraction from raw text — suggests, doesn't create |
+| `delete_entities` | Remove entities and cascade-delete their relations |
+| `delete_observations` | Remove specific observations from an entity |
+| `delete_relations` | Remove specific relations |
+
+**Semantic tools (require vector config):**
+
+| Tool | What it does |
+|------|-------------|
+| `search_research` | Semantic search over indexed knowledge files via embeddings |
+| `suggest_merges` | Find near-duplicate entities by name similarity — surfaces dedup candidates |
+
+**Resources (always on):**
+
+| Resource | What it provides |
+|----------|----------------|
+| `membrain://profile` | Mission, directives, disposition, and named context profiles from `membrain.yaml` |
+| `membrain://recent` | The 10 most recently modified entities |
+
+## Token efficiency
+
+A naive memory implementation dumps the entire graph into every context window. membrain's `search_nodes` and `open_nodes` return a `_membrain.retrievalStats` block alongside results — showing exactly how many tokens were retrieved vs. what a full dump would have cost and the percentage saved. On a mature graph this typically saves 80–95% of context overhead per query.
+
+## Getting started
+
+See the [membrain plugin page](/docs/plugins/research-knowledge/membrain) for install instructions, setup, and the `/memory` skill reference.
+
+See the [membrain repository](https://github.com/siracusa5/membrain) for `membrain.yaml` configuration, schema design, vector setup, and internals.

--- a/website/content/docs/concepts/meta.json
+++ b/website/content/docs/concepts/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "plugins-vs-skills",
     "agents",
+    "memory",
     "secrets-management",
     "cross-harness-portability",
     "comparison",

--- a/website/content/docs/concepts/meta.json
+++ b/website/content/docs/concepts/meta.json
@@ -6,6 +6,7 @@
     "secrets-management",
     "cross-harness-portability",
     "comparison",
+    "agent-client-protocol",
     "harness-protocol"
   ]
 }

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -29,4 +29,5 @@ Configure once. Observe what your AI actually does. Share your setup with a team
   <Card title="Architecture" description="How skills, plugins, and the registry fit together." href="/docs/getting-started/architecture" />
   <Card title="Create a Plugin" description="Build your own plugin in minutes." href="/docs/guides/creating-plugins" />
   <Card title="Cross-Harness" description="Use with Copilot, Cursor, Windsurf, and more." href="/docs/cross-harness/setup-guide" />
+  <Card title="Memory" description="Persistent knowledge graph via membrain MCP — cumulative context across every session." href="/docs/concepts/memory" />
 </Cards>

--- a/website/content/docs/meta.json
+++ b/website/content/docs/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "concepts",
     "getting-started",
+    "apps",
     "plugins",
     "evals",
     "guides",

--- a/website/content/docs/plugins/research-knowledge/membrain.mdx
+++ b/website/content/docs/plugins/research-knowledge/membrain.mdx
@@ -95,12 +95,16 @@ Once connected, Claude Code has direct access to these tools — no skill invoca
 **Token-savings telemetry.** Every `search_nodes` and `open_nodes` response includes a `_membrain` stats block showing retrieved tokens vs. full-graph baseline and the percentage saved. On a mature graph this typically saves 80–95% of context overhead per query.
 
 ```json
-"_membrain": {
-  "retrieved_entities": 4,
-  "total_entities": 312,
-  "retrieved_tokens": 180,
-  "baseline_tokens": 14200,
-  "savings_pct": 98.7
+{
+  "entities": [...],
+  "relations": [...],
+  "_membrain": {
+    "retrieved_entities": 4,
+    "total_entities": 312,
+    "retrieved_tokens": 180,
+    "baseline_tokens": 14200,
+    "savings_pct": 98.7
+  }
 }
 ```
 

--- a/website/content/docs/plugins/research-knowledge/membrain.mdx
+++ b/website/content/docs/plugins/research-knowledge/membrain.mdx
@@ -1,13 +1,17 @@
 ---
 title: membrain
-description: Graph-based agent memory — search, trace, and manage a persistent knowledge graph from Claude Code via MCP.
+description: Graph-based agent memory — persistent knowledge graph via MCP, with token-savings telemetry, semantic dedup, and a typed ontology.
 ---
 
 > **[View in Marketplace →](https://marketplace.harnessprotocol.io/plugins/membrain)** for install tracking, related plugins, and profiles.
 
 # membrain
 
-Search, trace, and manage your [membrain](https://github.com/siracusa5/membrain) knowledge graph from Claude Code. membrain is a graph-based memory system that persists entities, relations, and timestamped episodes across sessions. This plugin connects Claude to it via MCP.
+[membrain](https://github.com/siracusa5/membrain) is a graph-based memory system that runs as an MCP server. It gives Claude Code persistent read/write access to a knowledge graph across every session — entities, typed relations, timestamped episodes, and semantic search — without flooding your context window.
+
+This plugin adds the `/memory` skill, which is a thin command interface over the MCP surface. The real power is in the 11 graph tools and 2 semantic tools membrain registers directly as MCP tools.
+
+See the [Memory concept page](/docs/concepts/memory) for the full picture of how graph-based memory works in harness-kit.
 
 ## Requirements
 
@@ -26,22 +30,114 @@ go install github.com/siracusa5/membrain/cmd/mem@latest
 
 ## Setup
 
-After install, add the membrain MCP server to your Claude Code settings:
+Initialize a graph directory and add the MCP server to Claude Code:
+
+```bash
+mem init ~/my-agent-memory
+```
+
+Add to `~/.claude/settings.json`:
 
 ```json
 {
   "mcpServers": {
     "membrain": {
       "command": "mem",
-      "args": ["mcp"]
+      "args": ["mcp"],
+      "env": {
+        "MEMBRAIN_CONFIG": "/absolute/path/to/membrain.yaml"
+      }
     }
   }
 }
 ```
 
-Restart Claude Code. The `/memory` skill activates automatically once the MCP tools are connected.
+Use an absolute path for `MEMBRAIN_CONFIG` — relative paths break when Claude Code spawns the subprocess from a different working directory.
 
-## Usage
+Restart Claude Code. The `/memory` skill activates automatically once the MCP tools are connected. Run `/mcp` to confirm `membrain` is listed.
+
+## MCP tools reference
+
+Once connected, Claude Code has direct access to these tools — no skill invocation needed.
+
+**Graph tools (always on):**
+
+| Tool | What it does |
+|------|-------------|
+| `create_entities` | Add new entities to the graph |
+| `create_relations` | Add typed relations between entities |
+| `add_observations` | Append observations to an existing entity |
+| `add_episode` | Create a timestamped episode; auto-links to mentioned entities |
+| `open_nodes` | Fetch specific entities by exact name |
+| `search_nodes` | Substring search across names, types, and observations; supports `date_from`/`date_to` filtering |
+| `read_graph` | Return the full graph in JSON or compact SGN format |
+| `suggest_entities` | Heuristic entity extraction from raw text — suggests but does not create |
+| `delete_entities` | Remove entities and cascade-delete their relations |
+| `delete_observations` | Remove specific observations from an entity |
+| `delete_relations` | Remove specific relations |
+
+**Semantic tools (require [vector config](#optional-semantic-search)):**
+
+| Tool | What it does |
+|------|-------------|
+| `search_research` | Semantic search over indexed knowledge files using embeddings |
+| `suggest_merges` | Find near-duplicate entities by name similarity (default threshold: 0.85) |
+
+**Resources (always on):**
+
+| Resource | What it provides |
+|----------|----------------|
+| `membrain://profile` | Mission, directives, disposition, and context profile names from `membrain.yaml` |
+| `membrain://recent` | The 10 most recently modified entities |
+
+## What makes it different
+
+**Token-savings telemetry.** Every `search_nodes` and `open_nodes` response includes a `_membrain` stats block showing retrieved tokens vs. full-graph baseline and the percentage saved. On a mature graph this typically saves 80–95% of context overhead per query.
+
+```json
+"_membrain": {
+  "retrieved_entities": 4,
+  "total_entities": 312,
+  "retrieved_tokens": 180,
+  "baseline_tokens": 14200,
+  "savings_pct": 98.7
+}
+```
+
+**Compact SGN output.** Call `read_graph` with `format: sgn` to get Symbolic Graph Notation — a token-efficient text format instead of JSON. Useful when you need the full graph but want to minimize context cost.
+
+**Episode auto-linking.** `add_episode` creates a timestamped Episode entity and automatically creates `mentions` relations to any entities you name in `mentioned_entities`. Sessions become first-class graph nodes.
+
+**Semantic dedup.** `suggest_merges` computes embedding similarity across all entity names and returns candidate duplicate pairs — before they accumulate into a polluted graph.
+
+**Typed ontology.** membrain supports a typed entity system (Identity, Goal, Desire, Tension, Evidence, Reflection, Episode) with `contradicts` as a first-class relation type. You define your schema in `membrain.yaml`.
+
+**Federated store.** membrain merges NDJSON and Markdown files with priority-based conflict resolution. Your knowledge can live in both structured graph data and human-readable markdown, unified in one store.
+
+## Optional: semantic search
+
+Add a `vector:` section to `membrain.yaml` to unlock `search_research` and `suggest_merges`:
+
+```yaml
+vector:
+  enabled: true
+  provider: ollama        # or: openai
+  model: nomic-embed-text # or: text-embedding-3-small
+  db_path: memory/vector.db
+```
+
+For local (free) embeddings with Ollama:
+
+```bash
+ollama pull nomic-embed-text
+mem index run
+```
+
+For OpenAI, set `OPENAI_API_KEY` and use `provider: openai`. Re-run `mem index run` whenever your graph changes significantly.
+
+## `/memory` skill
+
+The plugin also adds a `/memory` skill — a command interface for common graph operations:
 
 ```
 /memory search <topic>       search entities in the knowledge graph
@@ -51,30 +147,18 @@ Restart Claude Code. The `/memory` skill activates automatically once the MCP to
 /memory status               graph health: entity/relation counts, server status
 ```
 
-## Examples
-
-```
-/memory search authentication
-/memory trace "Claude Code"
-/memory add "auth-service" "now uses PKCE for all OAuth flows"
-/memory episode "Completed membrain MCP integration — 11 graph tools now connected"
-/memory status
-```
-
-## How It Works
-
 | Subcommand | Requires |
 |-----------|---------|
-| `search`, `add`, `episode` | membrain MCP server (`mem mcp`) only — works without HTTP server |
+| `search`, `add`, `episode` | membrain MCP server only |
 | `trace`, `status` | membrain HTTP server (`mem serve` at `localhost:3131`) for richer output |
-
-## Graceful Degradation
-
-If the membrain MCP tools are not connected, the skill prints install and configuration instructions. The HTTP-dependent subcommands (`trace`, `status`) fall back gracefully when the server is not running.
 
 ## Desktop UI
 
-When the HTTP server is running (`mem serve`), the full membrain graph UI is available at `http://localhost:3131`. In the harness-kit desktop app, it appears as the **Memory** section with full sub-page navigation.
+When the HTTP server is running (`mem serve`), the full membrain graph explorer is available at `http://localhost:3131`. In the harness-kit desktop app, it appears as the **Memory** section.
+
+## Graceful Degradation
+
+If membrain MCP tools are not connected, the `/memory` skill prints install and setup instructions. HTTP-dependent subcommands (`trace`, `status`) fall back gracefully when the HTTP server is not running.
 
 ## Source Files
 


### PR DESCRIPTION
## Summary

Adds Agent Client Protocol (ACP) awareness to the comparator and introduces public documentation for both ACP and the comparator tool. ACP standardizes editor↔agent communication via JSON-RPC 2.0 — the same role LSP plays for language tooling. Claude Code is ACP-compatible; Cursor, Copilot, and JetBrains AI are also on the ACP registry.

This PR lays the type groundwork and UI surface for a full ACP transport implementation (board task #82), which will replace the comparator's current regex-parsed terminal output with typed `session/update` events.

## Changes

- **`packages/shared/src/types.ts`** — add `protocol?: "cli" | "acp"` and `acpVersion?: string` to `HarnessInfo`
- **`apps/desktop/src/lib/harness-definitions.ts`** — mark Claude as `protocol: "acp"`, `acpVersion: "1"`; extend `HarnessDefinition` interface
- **`apps/desktop/src/pages/comparator/SetupPhase.tsx`** — ACP badge on harness cards when `protocol === "acp"`
- **`apps/desktop/src/hooks/useComparator.ts`** — `acpMode?: boolean` on `PanelState`, resolved via `getHarness()` at panel creation (avoids changing call signature; historical sessions show no badge as intended)
- **`apps/desktop/src/pages/comparator/ResultsPhase.tsx`** — ACP badge in panel column headers
- **`website/content/docs/concepts/comparison.md`** — add ACP section to protocol landscape
- **`website/content/docs/concepts/agent-client-protocol.md`** — new: what ACP is, how it relates to harness-kit and MCP
- **`website/content/docs/apps/comparator.md`** — new: first public documentation for the comparator tool

## Test Plan

- [x] Local tests pass — 701/701 (`pnpm run test:desktop:unit`)
- [ ] CI checks pass
- [ ] ACP badge visible on Claude harness card in comparator Setup phase
- [ ] ACP badge visible in Results phase panel headers for Claude runs
- [ ] No badge shown for Cursor/Copilot/Codex (protocol not set)
- [ ] Historical comparison loads without acpMode set (badge absent — correct behavior)

## Notes

Full ACP transport (board task #82) is the natural next step: replace PTY+shell for `acp` harnesses with structured JSON-RPC over stdio, mapping `session/update` notifications to typed activity cards. This PR is intentionally scoped to type groundwork + UI surface only — no protocol behavior changes.

The `mcp-over-acp` RFD (in-flight) is architecturally significant: it routes MCP tool calls back through the ACP channel, enabling WASM sandboxes and remote deployments without side-channel processes. Worth watching before implementing full transport.