### PR TITLE
fix(docs): fix broken cross-directory link and misleading JSON key notation

### DIFF
--- a/website/content/docs/apps/comparator.md
+++ b/website/content/docs/apps/comparator.md
@@ -51,7 +51,7 @@ on historical performance for each task type.
 
 ## ACP Compatibility
 
-Harnesses marked **ACP** implement the [Agent Client Protocol](./agent-client-protocol.md),
+Harnesses marked **ACP** implement the [Agent Client Protocol](/docs/concepts/agent-client-protocol),
 which standardizes the editor↔agent communication layer. ACP-compatible harnesses:
 
 - Are discoverable through the [ACP registry](https://agentclientprotocol.com/overview/agents)

--- a/website/content/docs/concepts/memory.md
+++ b/website/content/docs/concepts/memory.md
@@ -64,7 +64,7 @@ membrain registers tools and resources your agent can call directly during any s
 
 ## Token efficiency
 
-A naive memory implementation dumps the entire graph into every context window. membrain's `search_nodes` and `open_nodes` return a `_membrain.retrievalStats` block alongside results — showing exactly how many tokens were retrieved vs. what a full dump would have cost and the percentage saved. On a mature graph this typically saves 80–95% of context overhead per query.
+A naive memory implementation dumps the entire graph into every context window. membrain's `search_nodes` and `open_nodes` return a `_membrain` stats block alongside results — showing exactly how many tokens were retrieved vs. what a full dump would have cost and the percentage saved. On a mature graph this typically saves 80–95% of context overhead per query.
 
 ## Getting started
 


### PR DESCRIPTION
## Summary

Two small doc bugs caught during code review of #149, which merged before fixes could be included.

- **`comparator.md`**: broken relative link `./agent-client-protocol.md` resolves to `docs/apps/` instead of `docs/concepts/` in Fumadocs routing — corrected to `/docs/concepts/agent-client-protocol`
- **`memory.md`**: `_membrain.retrievalStats` implied a nested JSON key path; the actual JSON key is `_membrain` (`retrievalStats` is the internal Go struct name) — corrected to `_membrain stats block`

## Test Plan
- [ ] Local tests pass
- [ ] CI checks pass
- [ ] Verify `/docs/concepts/agent-client-protocol` link resolves correctly in docs build