### PR TITLE
fix(website): hero typo, interactive mock tour, cyan favicon

### DIFF
--- a/website/app/icon.svg
+++ b/website/app/icon.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <rect width="32" height="32" rx="6" fill="#0d0d12"/>
-  <text x="16" y="22" text-anchor="middle" font-family="system-ui, sans-serif" font-weight="700" font-size="16" fill="#8b7aff">hk</text>
+  <rect width="32" height="32" rx="6" fill="#0d1016"/>
+  <text x="16" y="22" text-anchor="middle" font-family="system-ui, sans-serif" font-weight="700" font-size="16" fill="#4ec7f2">hk</text>
 </svg>

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -86,7 +86,8 @@ export default function HomePage() {
         {/* Copy block */}
         <div className="mx-auto max-w-3xl px-6 pb-10 pt-20 text-center">
           <h1 className="font-display mb-5 text-[2.6rem] font-bold leading-tight tracking-tight text-fd-foreground sm:text-5xl">
-            The configuration console<br className="hidden sm:block" />
+            The configuration console{' '}
+            <br className="hidden sm:block" />
             for all your harnesses.
           </h1>
           <p className="mx-auto mb-8 max-w-lg text-lg leading-relaxed text-fd-muted-foreground">

--- a/website/components/site/DesktopMock.module.css
+++ b/website/components/site/DesktopMock.module.css
@@ -39,13 +39,33 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.hintText {
+.hintBtn {
   margin-left: auto;
+  appearance: none;
+  background: none;
+  border: none;
+  padding: 2px 6px;
+  border-radius: 4px;
+  cursor: pointer;
   font-size: 10px;
   color: var(--accent-fg);
   font-weight: 500;
   opacity: 0.75;
   white-space: nowrap;
+  transition: opacity 0.15s ease, background 0.15s ease;
+  animation: hintPulse 2.5s ease-in-out infinite;
+}
+.hintBtn:hover {
+  opacity: 1;
+  background: rgba(34,177,236,0.1);
+  animation: none;
+}
+@keyframes hintPulse {
+  0%, 100% { opacity: 0.75; }
+  50%       { opacity: 0.45; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .hintBtn { animation: none; }
 }
 
 /* ── Desktop body layout ── */
@@ -141,6 +161,8 @@
   gap: 14px;
   overflow: hidden;
   height: 100%;
+  opacity: 0;
+  transition: opacity 0.15s ease;
 }
 .compact .pane {
   padding: 14px 16px;
@@ -148,6 +170,10 @@
 }
 .paneActive {
   display: flex;
+  opacity: 1;
+}
+@media (prefers-reduced-motion: reduce) {
+  .pane { transition: none; }
 }
 
 /* ── Observatory: metrics ── */

--- a/website/components/site/DesktopMock.module.css
+++ b/website/components/site/DesktopMock.module.css
@@ -11,6 +11,10 @@
 .frame:hover {
   box-shadow: 0 40px 100px -20px rgba(0,0,0,0.7), 0 0 0 1px var(--border-strong), 0 0 80px -15px var(--accent-glow);
 }
+.frame:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 
 /* ── Title bar ── */
 .titlebar {

--- a/website/components/site/DesktopMock.tsx
+++ b/website/components/site/DesktopMock.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import styles from './DesktopMock.module.css';
 
 type SectionId = 'harness' | 'marketplace' | 'observatory' | 'agents' | 'comparator' | 'security' | 'parity' | 'board' | 'roadmap' | 'ai-chat' | 'memory';
@@ -159,15 +159,71 @@ export function DesktopMock({
   compact = false,
 }: DesktopMockProps) {
   const [activeSection, setActiveSection] = useState(defaultSection);
+  const [hasInteracted, setHasInteracted] = useState(false);
+  const tourRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const frameClass = [styles.frame, compact ? styles.compact : ''].filter(Boolean).join(' ');
 
-  const handleItemClick = (id: SectionId) => {
-    if (interactive) setActiveSection(id);
+  const advance = () => {
+    setActiveSection((cur) => {
+      const idx = ALL_ITEMS.findIndex((i) => i.id === cur);
+      return ALL_ITEMS[(idx + 1) % ALL_ITEMS.length].id as SectionId;
+    });
   };
 
+  const stopTour = () => {
+    if (tourRef.current) { clearInterval(tourRef.current); tourRef.current = null; }
+  };
+
+  const handleItemClick = (id: SectionId) => {
+    if (!interactive) return;
+    stopTour();
+    setHasInteracted(true);
+    setActiveSection(id);
+  };
+
+  const handleHintClick = () => { stopTour(); advance(); };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (!interactive) return;
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+      stopTour(); setHasInteracted(true); advance();
+    } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+      stopTour(); setHasInteracted(true);
+      setActiveSection((cur) => {
+        const idx = ALL_ITEMS.findIndex((i) => i.id === cur);
+        return ALL_ITEMS[(idx - 1 + ALL_ITEMS.length) % ALL_ITEMS.length].id as SectionId;
+      });
+    }
+  };
+
+  useEffect(() => {
+    if (!interactive) return;
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (reducedMotion) return;
+    const delay = setTimeout(() => {
+      if (hasInteracted) return;
+      tourRef.current = setInterval(() => {
+        setHasInteracted((interacted) => {
+          if (interacted) { stopTour(); return interacted; }
+          advance();
+          return false;
+        });
+      }, 4000);
+    }, 2500);
+    return () => { clearTimeout(delay); stopTour(); };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [interactive]);
+
   return (
-    <div className={frameClass} role="presentation" aria-hidden="true">
+    <div
+      className={frameClass}
+      role="presentation"
+      aria-hidden="true"
+      tabIndex={interactive ? 0 : -1}
+      onKeyDown={handleKeyDown}
+      style={{ outline: 'none' }}
+    >
       {/* Title bar */}
       <div className={styles.titlebar}>
         <span className={`${styles.tl} ${styles.tlRed}`} />
@@ -176,8 +232,10 @@ export function DesktopMock({
         <span className={styles.titleText}>
           Harness Kit — {getTitleForSection(activeSection)}
         </span>
-        {interactive && (
-          <span className={styles.hintText}>click the sidebar →</span>
+        {interactive && !hasInteracted && (
+          <button className={styles.hintBtn} onClick={handleHintClick}>
+            next surface →
+          </button>
         )}
       </div>
 

--- a/website/components/site/DesktopMock.tsx
+++ b/website/components/site/DesktopMock.tsx
@@ -222,7 +222,6 @@ export function DesktopMock({
       aria-hidden="true"
       tabIndex={interactive ? 0 : -1}
       onKeyDown={handleKeyDown}
-      style={{ outline: 'none' }}
     >
       {/* Title bar */}
       <div className={styles.titlebar}>


### PR DESCRIPTION
## Summary

Three polish fixes for the marketing homepage. The typo has been live since the docs revamp; the interactive mock hint button was a dead affordance with no behavior wired up; the favicon still showed the old violet brand color after the cyan rebrand.

## Changes

- **Typo:** Hero headline rendered as "consolefor" when the `<br>` between "console" and "for" was hidden at narrow widths — fixed with explicit `{' '}` between the two words
- **Interactive mock:** "click the sidebar →" hint converted from a static `<span>` to a working button labeled "next surface →" that cycles through all 11 app surfaces; auto-tour begins after 2.5s of inactivity and cancels on first direct interaction; `←`/`→` keyboard nav added; panes cross-fade at 150ms; all animations gated behind `prefers-reduced-motion`
- **Favicon:** `app/icon.svg` updated from violet `#8b7aff` to cyan `#4ec7f2` to match the nav logo introduced in the docs revamp

## Test Plan

- [ ] Local build passes (`pnpm -C website build`)
- [ ] CI checks pass
- [ ] Manual: confirm headline reads "The configuration console for all your harnesses." at both wide and narrow widths
- [ ] Manual: click "next surface →" in the hero mock — surfaces cycle; hint disappears after clicking a sidebar item directly
- [ ] Manual: browser tab shows cyan `hk` favicon matching the nav logo

## Notes

The auto-tour and pulse animation both respect `prefers-reduced-motion: reduce` — no animation fires in that context.