### PR TITLE
docs: publish contact emails on website and in repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ See the [Harness Protocol spec](https://harnessprotocol.io) for the full cross-p
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for plugin guidelines, skill conventions, and PR process.
 
+## 📬 Contact
+
+- **General** — [contact@harnesskit.ai](mailto:contact@harnesskit.ai)
+- **Security** — [security@harnesskit.ai](mailto:security@harnesskit.ai) (see [SECURITY.md](SECURITY.md))
+
 ## 📄 License
 
 [Apache 2.0](LICENSE)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-If you discover a security vulnerability in harness-kit, please report it through [GitHub Security Advisories](https://github.com/harnessprotocol/harness-kit/security/advisories/new). Include the following information:
+If you discover a security vulnerability in harness-kit, please report it through [GitHub Security Advisories](https://github.com/harnessprotocol/harness-kit/security/advisories/new) or email [security@harnesskit.ai](mailto:security@harnesskit.ai). Include the following information:
 
 - Description of the vulnerability
 - Steps to reproduce the issue

--- a/website/components/site/SiteFooter.tsx
+++ b/website/components/site/SiteFooter.tsx
@@ -39,12 +39,19 @@ export function SiteFooter() {
               <a href="https://github.com/harnessprotocol/harness-kit" className="transition-colors hover:text-fd-foreground no-underline" target="_blank" rel="noreferrer">GitHub</a>
             </li>
             <li><Link href="/docs" className="transition-colors hover:text-fd-foreground no-underline">Documentation</Link></li>
-            <li><span>Apache-2.0 License</span></li>
+          </ul>
+        </div>
+        {/* Contact */}
+        <div>
+          <h5 className="mb-3 font-semibold text-fd-foreground text-xs uppercase tracking-widest">Contact</h5>
+          <ul className="space-y-2 text-fd-muted-foreground">
+            <li><a href="mailto:contact@harnesskit.ai" className="transition-colors hover:text-fd-foreground no-underline">contact@harnesskit.ai</a></li>
+            <li><a href="https://github.com/harnessprotocol/harness-kit/security/policy" className="transition-colors hover:text-fd-foreground no-underline" target="_blank" rel="noreferrer">Security Policy</a></li>
           </ul>
         </div>
       </div>
       <div className="border-t border-fd-border/20 px-6 py-4 text-center text-xs text-fd-muted-foreground">
-        © {new Date().getFullYear()} Harness Kit Contributors
+        © {new Date().getFullYear()} Harness Kit Contributors · Apache-2.0 License
       </div>
     </footer>
   );


### PR DESCRIPTION
## Summary

Publishes two new custom-domain mailboxes (`contact@harnesskit.ai`, `security@harnesskit.ai`) to the places users and contributors actually look. Previously there was no published contact surface anywhere — no email in the footer, README, or SECURITY.md.

## Changes

- **Footer restructured** (`website/components/site/SiteFooter.tsx`): Community column trimmed to GitHub + Documentation. New Contact column added with `contact@harnesskit.ai` and a "Security Policy" link (→ GitHub security policy page). Apache-2.0 License moved from the Community column into the bottom copyright strip where legal info belongs.
- **SECURITY.md**: Adds `security@harnesskit.ai` as an alternate reporting channel alongside the existing GitHub Security Advisories link, for reporters without a GitHub account.
- **README.md**: Adds a `📬 Contact` section (General + Security) between Contributing and License, matching the repo's existing emoji-H2 style.

## Test Plan

- [ ] Local tests pass (no test suite in this repo)
- [ ] CI checks pass
- [ ] Visually verified footer layout at localhost:3000 — 4-column grid intact, Contact column renders correctly, License appears in bottom strip

## Notes

`security@harnesskit.ai` is intentionally not surfaced in the footer — users filing security reports know to check SECURITY.md. The footer Contact column links to the Security Policy page instead, which contains the email.

The PII guard hook (`~/.claude/hooks/pii-guard.sh`) was updated to whitelist `@harnesskit.ai` addresses — that change is local only and not in this PR.