### PR TITLE
feat(desktop): AI chat revamp — stats surface, agentic tools, system prompt

### DIFF
--- a/apps/desktop/src-tauri/src/ai/client.rs
+++ b/apps/desktop/src-tauri/src/ai/client.rs
@@ -7,8 +7,8 @@ use std::time::Duration;
 use tokio::time::timeout;
 
 use crate::ai::types::{
-    ChatRequest, DownloadProgress, ModelInfo, ModelsResponse, PullProgressRaw, StreamEvent,
-    ToolCall,
+    ChatRequest, DownloadProgress, ModelDetails, ModelInfo, ModelShowResponse, ModelsResponse,
+    PullProgressRaw, RunningModel, RunningModelsResponse, StreamEvent, ToolCall,
 };
 
 // ─── UTF-8-safe stream buffer ────────────────────────────────────────────────
@@ -100,11 +100,13 @@ pub fn parse_line(line: &str) -> Vec<StreamEvent> {
     // Done flag (may accompany the last content chunk, though Ollama usually sends
     // an empty-content done line after all content chunks)
     if json["done"].as_bool().unwrap_or(false) {
-        let eval_count = json["eval_count"].as_u64();
-        let prompt_eval_count = json["prompt_eval_count"].as_u64();
         events.push(StreamEvent::Done {
-            eval_count,
-            prompt_eval_count,
+            eval_count: json["eval_count"].as_u64(),
+            prompt_eval_count: json["prompt_eval_count"].as_u64(),
+            total_duration: json["total_duration"].as_u64(),
+            load_duration: json["load_duration"].as_u64(),
+            prompt_eval_duration: json["prompt_eval_duration"].as_u64(),
+            eval_duration: json["eval_duration"].as_u64(),
         });
     }
 
@@ -234,6 +236,10 @@ impl OllamaClient {
                 let _ = on_event(StreamEvent::Done {
                     eval_count: None,
                     prompt_eval_count: None,
+                    total_duration: None,
+                    load_duration: None,
+                    prompt_eval_duration: None,
+                    eval_duration: None,
                 });
                 return Ok(());
             }
@@ -267,6 +273,112 @@ impl OllamaClient {
         }
 
         Ok(())
+    }
+
+    /// Returns all models currently loaded in Ollama's memory (/api/ps).
+    pub async fn get_running_models(&self) -> Result<Vec<RunningModel>, String> {
+        let url = format!("{}/api/ps", self.base_url());
+        let response = self
+            .client
+            .get(&url)
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .map_err(|e| format!("Failed to reach Ollama /api/ps: {}", e))?;
+
+        if !response.status().is_success() {
+            return Err(format!("Ollama /api/ps returned {}", response.status()));
+        }
+
+        let body: RunningModelsResponse = response
+            .json()
+            .await
+            .map_err(|e| format!("Failed to parse /api/ps response: {}", e))?;
+
+        Ok(body
+            .models
+            .into_iter()
+            .map(|m| RunningModel {
+                name: m.name,
+                size_vram: m.size_vram,
+                expires_at: m.expires_at,
+            })
+            .collect())
+    }
+
+    /// Returns metadata for a specific model (/api/show).
+    pub async fn show_model(&self, name: &str) -> Result<ModelDetails, String> {
+        let url = format!("{}/api/show", self.base_url());
+        let payload = serde_json::json!({ "name": name });
+        let response = self
+            .client
+            .post(&url)
+            .json(&payload)
+            .timeout(Duration::from_secs(10))
+            .send()
+            .await
+            .map_err(|e| format!("Failed to reach Ollama /api/show: {}", e))?;
+
+        if !response.status().is_success() {
+            return Err(format!("Ollama /api/show returned {}", response.status()));
+        }
+
+        let body: ModelShowResponse = response
+            .json()
+            .await
+            .map_err(|e| format!("Failed to parse /api/show response: {}", e))?;
+
+        // Extract context_length from the architecture-specific model_info map.
+        // Ollama stores it as "<arch>.context_length" (e.g. "llama.context_length").
+        let context_length = body.model_info.as_ref().and_then(|info| {
+            info.as_object()?.iter().find_map(|(k, v)| {
+                if k.ends_with(".context_length") {
+                    v.as_i64()
+                } else {
+                    None
+                }
+            })
+        });
+
+        let (family, parameter_size, quantization_level) = body
+            .details
+            .map(|d| (d.family, d.parameter_size, d.quantization_level))
+            .unwrap_or((None, None, None));
+
+        Ok(ModelDetails {
+            name: name.to_string(),
+            family,
+            parameter_size,
+            quantization_level,
+            capabilities: body.capabilities.unwrap_or_default(),
+            context_length,
+        })
+    }
+
+    /// Returns the Ollama server version string.
+    pub async fn get_version(&self) -> Result<String, String> {
+        let url = format!("{}/api/version", self.base_url());
+        let response = self
+            .client
+            .get(&url)
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .map_err(|e| format!("Failed to reach Ollama /api/version: {}", e))?;
+
+        if !response.status().is_success() {
+            return Err(format!("Ollama /api/version returned {}", response.status()));
+        }
+
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .map_err(|e| format!("Failed to parse /api/version response: {}", e))?;
+
+        body["version"]
+            .as_str()
+            .map(|s| s.to_string())
+            .ok_or_else(|| "Missing 'version' field in /api/version response".to_string())
     }
 
     /// Downloads a model, calling `on_progress` with each progress update.
@@ -349,7 +461,7 @@ mod tests {
         assert_eq!(events.len(), 1);
         assert!(matches!(
             &events[0],
-            StreamEvent::Done { eval_count: Some(42), prompt_eval_count: Some(7) }
+            StreamEvent::Done { eval_count: Some(42), prompt_eval_count: Some(7), .. }
         ));
     }
 

--- a/apps/desktop/src-tauri/src/ai/commands.rs
+++ b/apps/desktop/src-tauri/src/ai/commands.rs
@@ -1,5 +1,8 @@
 use crate::ai::client::OllamaState;
-use crate::ai::types::{ChatMessage, ChatRequest, DownloadProgress, ModelInfo, StreamEvent, ToolDef};
+use crate::ai::types::{
+    ChatMessage, ChatRequest, DownloadProgress, ModelDetails, ModelInfo, RunningModel, StreamEvent,
+    ToolDef,
+};
 use crate::db::Db;
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::Ordering;
@@ -23,6 +26,8 @@ pub struct AISessionRow {
     pub model: Option<String>,
     pub created_at: String,
     pub updated_at: String,
+    pub system_prompt: Option<String>,
+    pub context_sources_json: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -33,6 +38,7 @@ pub struct AIMessageRow {
     pub role: String,
     pub content: String,
     pub timestamp: String,
+    pub metadata_json: Option<String>,
 }
 
 // ─── Ollama service commands ─────────────────────────────────────────────────
@@ -153,6 +159,25 @@ pub fn update_ai_session_title(
 }
 
 #[tauri::command]
+pub fn update_ai_session_prompt(
+    db: State<'_, Db>,
+    id: String,
+    system_prompt: Option<String>,
+    context_sources_json: Option<String>,
+) -> Result<(), String> {
+    let conn = db.conn.lock().map_err(|e| e.to_string())?;
+    let now = chrono::Utc::now().to_rfc3339();
+
+    conn.execute(
+        "UPDATE ai_sessions SET system_prompt = ?1, context_sources_json = ?2, updated_at = ?3 WHERE id = ?4",
+        rusqlite::params![system_prompt, context_sources_json, now, id],
+    )
+    .map_err(|e| e.to_string())?;
+
+    Ok(())
+}
+
+#[tauri::command]
 pub fn delete_ai_session(
     db: State<'_, Db>,
     id: String,
@@ -174,7 +199,7 @@ pub fn list_ai_sessions(db: State<'_, Db>) -> Result<Vec<AISessionRow>, String> 
 
     let mut stmt = conn
         .prepare(
-            "SELECT id, title, model, created_at, updated_at FROM ai_sessions ORDER BY updated_at DESC",
+            "SELECT id, title, model, created_at, updated_at, system_prompt, context_sources_json FROM ai_sessions ORDER BY updated_at DESC",
         )
         .map_err(|e| e.to_string())?;
 
@@ -186,6 +211,8 @@ pub fn list_ai_sessions(db: State<'_, Db>) -> Result<Vec<AISessionRow>, String> 
                 model: row.get(2)?,
                 created_at: row.get(3)?,
                 updated_at: row.get(4)?,
+                system_prompt: row.get(5)?,
+                context_sources_json: row.get(6)?,
             })
         })
         .map_err(|e| e.to_string())?
@@ -204,7 +231,7 @@ pub fn load_ai_session(
 
     let session = conn
         .query_row(
-            "SELECT id, title, model, created_at, updated_at FROM ai_sessions WHERE id = ?1",
+            "SELECT id, title, model, created_at, updated_at, system_prompt, context_sources_json FROM ai_sessions WHERE id = ?1",
             rusqlite::params![session_id],
             |row| {
                 Ok(AISessionRow {
@@ -213,6 +240,8 @@ pub fn load_ai_session(
                     model: row.get(2)?,
                     created_at: row.get(3)?,
                     updated_at: row.get(4)?,
+                    system_prompt: row.get(5)?,
+                    context_sources_json: row.get(6)?,
                 })
             },
         )
@@ -220,7 +249,7 @@ pub fn load_ai_session(
 
     let mut stmt = conn
         .prepare(
-            "SELECT id, session_id, role, content, timestamp FROM ai_messages WHERE session_id = ?1 ORDER BY timestamp ASC",
+            "SELECT id, session_id, role, content, timestamp, metadata_json FROM ai_messages WHERE session_id = ?1 ORDER BY timestamp ASC",
         )
         .map_err(|e| e.to_string())?;
 
@@ -232,6 +261,7 @@ pub fn load_ai_session(
                 role: row.get(2)?,
                 content: row.get(3)?,
                 timestamp: row.get(4)?,
+                metadata_json: row.get(5)?,
             })
         })
         .map_err(|e| e.to_string())?
@@ -248,13 +278,14 @@ pub fn save_ai_message(
     session_id: String,
     role: String,
     content: String,
+    metadata_json: Option<String>,
 ) -> Result<(), String> {
     let conn = db.conn.lock().map_err(|e| e.to_string())?;
     let timestamp = chrono::Utc::now().to_rfc3339();
 
     conn.execute(
-        "INSERT INTO ai_messages (id, session_id, role, content, timestamp) VALUES (?1, ?2, ?3, ?4, ?5)",
-        rusqlite::params![id, session_id, role, content, timestamp],
+        "INSERT INTO ai_messages (id, session_id, role, content, timestamp, metadata_json) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        rusqlite::params![id, session_id, role, content, timestamp, metadata_json],
     )
     .map_err(|e| e.to_string())?;
 
@@ -266,6 +297,30 @@ pub fn save_ai_message(
     .map_err(|e| e.to_string())?;
 
     Ok(())
+}
+
+// ─── Model introspection commands ───────────────────────────────────────────
+
+#[tauri::command]
+pub async fn list_running_models(
+    ollama: State<'_, OllamaState>,
+) -> Result<Vec<RunningModel>, String> {
+    ollama.client.get_running_models().await
+}
+
+#[tauri::command]
+pub async fn show_model(
+    name: String,
+    ollama: State<'_, OllamaState>,
+) -> Result<ModelDetails, String> {
+    ollama.client.show_model(&name).await
+}
+
+#[tauri::command]
+pub async fn get_ollama_version(
+    ollama: State<'_, OllamaState>,
+) -> Result<String, String> {
+    ollama.client.get_version().await
 }
 
 // ─── AI config commands ──────────────────────────────────────────────────────

--- a/apps/desktop/src-tauri/src/ai/types.rs
+++ b/apps/desktop/src-tauri/src/ai/types.rs
@@ -75,10 +75,14 @@ pub enum StreamEvent {
     Text { content: String },
     /// Model requested one or more tool calls
     ToolCalls { calls: Vec<ToolCall> },
-    /// Stream finished (carries Ollama eval metrics)
+    /// Stream finished (carries Ollama eval metrics and timing in nanoseconds)
     Done {
         eval_count: Option<u64>,
         prompt_eval_count: Option<u64>,
+        total_duration: Option<u64>,
+        load_duration: Option<u64>,
+        prompt_eval_duration: Option<u64>,
+        eval_duration: Option<u64>,
     },
     /// Non-fatal warning (e.g. non-UTF-8 bytes, malformed JSON line)
     Warn { message: String },
@@ -100,6 +104,61 @@ pub struct ModelInfo {
 #[derive(Debug, Clone, Deserialize)]
 pub struct ModelsResponse {
     pub models: Vec<ModelInfo>,
+}
+
+// ─── Running models (/api/ps) ─────────────────────────────────────────────────
+
+/// Raw running-model entry from Ollama /api/ps (snake_case — matches wire format)
+#[derive(Debug, Clone, Deserialize)]
+pub struct RunningModelRaw {
+    pub name: String,
+    pub size_vram: Option<i64>,
+    pub expires_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RunningModelsResponse {
+    pub models: Vec<RunningModelRaw>,
+}
+
+/// Frontend-facing running model info (camelCase)
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RunningModel {
+    pub name: String,
+    pub size_vram: Option<i64>,
+    pub expires_at: Option<String>,
+}
+
+// ─── Model details (/api/show) ────────────────────────────────────────────────
+
+/// The "details" sub-object in /api/show response
+#[derive(Debug, Clone, Deserialize)]
+pub struct ModelDetailsInfo {
+    pub family: Option<String>,
+    pub parameter_size: Option<String>,
+    pub quantization_level: Option<String>,
+}
+
+/// Subset of /api/show response we use (snake_case — matches wire format)
+#[derive(Debug, Clone, Deserialize)]
+pub struct ModelShowResponse {
+    pub details: Option<ModelDetailsInfo>,
+    pub capabilities: Option<Vec<String>>,
+    /// Free-form map of architecture-specific metadata (e.g. "llama.context_length")
+    pub model_info: Option<serde_json::Value>,
+}
+
+/// Frontend-facing model details (camelCase)
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelDetails {
+    pub name: String,
+    pub family: Option<String>,
+    pub parameter_size: Option<String>,
+    pub quantization_level: Option<String>,
+    pub capabilities: Vec<String>,
+    pub context_length: Option<i64>,
 }
 
 // ─── Pull progress ───────────────────────────────────────────────────────────

--- a/apps/desktop/src-tauri/src/db.rs
+++ b/apps/desktop/src-tauri/src/db.rs
@@ -208,6 +208,19 @@ pub fn init(data_dir: &Path) -> Result<Db, String> {
         }
     }
 
+    // Migration: extend ai_sessions with visible system prompt and context source config
+    for (col, ddl) in &[
+        ("system_prompt", "ALTER TABLE ai_sessions ADD COLUMN system_prompt TEXT;"),
+        ("context_sources_json", "ALTER TABLE ai_sessions ADD COLUMN context_sources_json TEXT;"),
+    ] {
+        if let Err(e) = conn.execute_batch(ddl) {
+            let msg = e.to_string();
+            if !msg.contains("duplicate column name") {
+                return Err(format!("Migration failed (ai_sessions.{}): {}", col, msg));
+            }
+        }
+    }
+
     Ok(Db {
         conn: Mutex::new(conn),
     })

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -225,12 +225,16 @@ pub fn run() {
             ai::commands::cancel_ai_stream,
             ai::commands::create_ai_session,
             ai::commands::update_ai_session_title,
+            ai::commands::update_ai_session_prompt,
             ai::commands::delete_ai_session,
             ai::commands::list_ai_sessions,
             ai::commands::load_ai_session,
             ai::commands::save_ai_message,
             ai::commands::get_ai_config,
             ai::commands::set_ai_config,
+            ai::commands::list_running_models,
+            ai::commands::show_model,
+            ai::commands::get_ollama_version,
         ])
         .setup(|app| {
             let state = app.state::<BoardServerState>();

--- a/apps/desktop/src/components/ai/InspectorPanel.tsx
+++ b/apps/desktop/src/components/ai/InspectorPanel.tsx
@@ -1,0 +1,156 @@
+import { useState } from 'react';
+import type { RunningModel, ModelDetails } from '../../lib/tauri';
+import type { TurnStats } from '../../hooks/useAIChat';
+
+interface Props {
+  model: string;
+  modelDetails: ModelDetails | null;
+  runningModels: RunningModel[];
+  messageStats: { id: string; stats: TurnStats }[];
+}
+
+function fmtBytes(n: number | null | undefined): string {
+  if (n == null) return '—';
+  if (n >= 1_073_741_824) return `${(n / 1_073_741_824).toFixed(1)} GB`;
+  if (n >= 1_048_576) return `${(n / 1_048_576).toFixed(0)} MB`;
+  return `${(n / 1_024).toFixed(0)} KB`;
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  const [open, setOpen] = useState(true);
+  return (
+    <div style={{ borderBottom: '1px solid var(--border)' }}>
+      <button
+        onClick={() => setOpen((o) => !o)}
+        style={{
+          width: '100%',
+          background: 'none',
+          border: 'none',
+          padding: '7px 12px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          cursor: 'pointer',
+          color: 'var(--fg-muted)',
+          fontSize: 10,
+          fontWeight: 600,
+          letterSpacing: '0.08em',
+          textTransform: 'uppercase',
+        }}
+      >
+        {title}
+        <span style={{ fontSize: 9, color: 'var(--fg-subtle)' }}>{open ? '▾' : '▸'}</span>
+      </button>
+      {open && <div style={{ padding: '0 12px 10px' }}>{children}</div>}
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string | null | undefined }) {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 4 }}>
+      <span style={{ fontSize: 10, color: 'var(--fg-subtle)', fontFamily: 'monospace' }}>{label}</span>
+      <span style={{ fontSize: 10, color: 'var(--fg-muted)', fontFamily: 'monospace', textAlign: 'right' }}>
+        {value ?? '—'}
+      </span>
+    </div>
+  );
+}
+
+export function InspectorPanel({ model, modelDetails, runningModels, messageStats }: Props) {
+  const totalTokens = messageStats.reduce((sum, s) => sum + (s.stats.evalCount ?? 0), 0);
+  const totalPromptTokens = messageStats.reduce((sum, s) => sum + (s.stats.promptEvalCount ?? 0), 0);
+
+  return (
+    <div
+      style={{
+        width: 220,
+        flexShrink: 0,
+        borderLeft: '1px solid var(--border)',
+        background: 'var(--bg-surface)',
+        display: 'flex',
+        flexDirection: 'column',
+        overflowY: 'auto',
+        fontSize: 11,
+      }}
+    >
+      {/* Active model */}
+      <Section title="Active Model">
+        <Row label="name" value={model || '—'} />
+        <Row label="family" value={modelDetails?.family} />
+        <Row label="params" value={modelDetails?.parameterSize} />
+        <Row label="quant" value={modelDetails?.quantizationLevel} />
+        <Row label="ctx" value={modelDetails?.contextLength?.toLocaleString()} />
+        {modelDetails?.capabilities && modelDetails.capabilities.length > 0 && (
+          <div style={{ marginTop: 4, display: 'flex', flexWrap: 'wrap', gap: 3 }}>
+            {modelDetails.capabilities.map((cap) => (
+              <span
+                key={cap}
+                style={{
+                  fontSize: 9,
+                  background: cap === 'tools' ? 'var(--accent)' : 'var(--bg-elevated, var(--border))',
+                  color: cap === 'tools' ? '#fff' : 'var(--fg-muted)',
+                  borderRadius: 3,
+                  padding: '1px 5px',
+                  fontWeight: 600,
+                }}
+              >
+                {cap}
+              </span>
+            ))}
+          </div>
+        )}
+      </Section>
+
+      {/* Running models */}
+      <Section title="In Memory">
+        {runningModels.length === 0 ? (
+          <span style={{ fontSize: 10, color: 'var(--fg-subtle)' }}>none loaded</span>
+        ) : (
+          runningModels.map((m) => (
+            <div key={m.name} style={{ marginBottom: 6 }}>
+              <div style={{ fontSize: 10, color: 'var(--fg-muted)', fontFamily: 'monospace', wordBreak: 'break-all' }}>
+                {m.name}
+              </div>
+              <div style={{ fontSize: 9, color: 'var(--fg-subtle)', fontFamily: 'monospace' }}>
+                vram {fmtBytes(m.sizeVram)}
+                {m.expiresAt && (
+                  <> · expires {new Date(m.expiresAt).toLocaleTimeString()}</>
+                )}
+              </div>
+            </div>
+          ))
+        )}
+      </Section>
+
+      {/* Session token history */}
+      <Section title="Session Tokens">
+        <Row label="output tok" value={totalTokens > 0 ? totalTokens.toLocaleString() : '—'} />
+        <Row label="input tok" value={totalPromptTokens > 0 ? totalPromptTokens.toLocaleString() : '—'} />
+        {messageStats.length > 0 && (
+          <div style={{ marginTop: 6 }}>
+            {messageStats.slice(-8).map((s) => {
+              const tps = s.stats.tokensPerSec;
+              return (
+                <div
+                  key={s.id}
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    fontSize: 9,
+                    color: 'var(--fg-subtle)',
+                    fontFamily: 'monospace',
+                    marginBottom: 2,
+                  }}
+                >
+                  <span>{s.stats.evalCount ?? 0} tok</span>
+                  <span>{tps != null ? `${tps.toFixed(0)} t/s` : '—'}</span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </Section>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/ai/OllamaStatus.tsx
+++ b/apps/desktop/src/components/ai/OllamaStatus.tsx
@@ -4,6 +4,8 @@ import type { OllamaState } from '../../hooks/useOllama';
 interface Props {
   ollama: Pick<OllamaState, 'running' | 'checking' | 'timedOut' | 'retry' | 'models'>;
   baseUrl?: string;
+  version?: string | null;
+  runningCount?: number;
   isStreaming?: boolean;
   onCancelStream?: () => void;
 }
@@ -31,6 +33,8 @@ function Popover({
   checking,
   models,
   baseUrl,
+  version,
+  runningCount,
   isStreaming,
   onRetry,
   onCancelStream,
@@ -40,6 +44,8 @@ function Popover({
   checking: boolean;
   models: OllamaState['models'];
   baseUrl: string;
+  version?: string | null;
+  runningCount?: number;
   isStreaming?: boolean;
   onRetry: () => void;
   onCancelStream?: () => void;
@@ -105,10 +111,24 @@ function Popover({
         {baseUrl}
       </div>
 
-      {/* Model count */}
+      {/* Model count + in-memory count */}
       <div style={{ fontSize: 11, color: 'var(--fg-subtle)' }}>
-        {running ? `${models.length} model${models.length !== 1 ? 's' : ''} loaded` : '—'}
+        {running
+          ? `${models.length} model${models.length !== 1 ? 's' : ''} available`
+          : '—'}
+        {running && runningCount != null && runningCount > 0 && (
+          <span style={{ color: 'var(--accent)', marginLeft: 6 }}>
+            {runningCount} in memory
+          </span>
+        )}
       </div>
+
+      {/* Version */}
+      {version && (
+        <div style={{ fontSize: 10, color: 'var(--fg-subtle)', fontFamily: 'monospace' }}>
+          v{version}
+        </div>
+      )}
 
       <div style={{ height: 1, background: 'var(--border)', margin: '2px 0' }} />
 
@@ -134,7 +154,7 @@ function Popover({
   );
 }
 
-export function OllamaStatus({ ollama, baseUrl = 'http://localhost:11434', isStreaming, onCancelStream }: Props) {
+export function OllamaStatus({ ollama, baseUrl = 'http://localhost:11434', version, runningCount, isStreaming, onCancelStream }: Props) {
   const { running, checking, timedOut, retry, models } = ollama;
   const [open, setOpen] = useState(false);
 
@@ -185,6 +205,8 @@ export function OllamaStatus({ ollama, baseUrl = 'http://localhost:11434', isStr
           checking={checking}
           models={models}
           baseUrl={baseUrl}
+          version={version}
+          runningCount={runningCount}
           isStreaming={isStreaming}
           onRetry={retry}
           onCancelStream={onCancelStream}

--- a/apps/desktop/src/components/ai/StatsStrip.tsx
+++ b/apps/desktop/src/components/ai/StatsStrip.tsx
@@ -1,0 +1,92 @@
+import type { TurnStats } from '../../hooks/useAIChat';
+import type { RunningModel, ModelDetails } from '../../lib/tauri';
+
+interface Props {
+  model: string;
+  modelInfo: { size: number | null } | null;
+  modelDetails: ModelDetails | null;
+  runningModels: RunningModel[];
+  lastTurnStats: TurnStats | null;
+  conversationTokens: number;
+}
+
+function fmtBytes(n: number | null | undefined): string {
+  if (n == null) return '—';
+  if (n >= 1_073_741_824) return `${(n / 1_073_741_824).toFixed(1)} GB`;
+  if (n >= 1_048_576) return `${(n / 1_048_576).toFixed(0)} MB`;
+  return `${(n / 1_024).toFixed(0)} KB`;
+}
+
+const SEP = <span style={{ color: 'var(--border)', margin: '0 5px' }}>·</span>;
+
+export function StatsStrip({ model, modelInfo, modelDetails, runningModels, lastTurnStats, conversationTokens }: Props) {
+  const running = runningModels.find((m) => m.name === model || m.name.startsWith(model.split(':')[0]));
+  const vram = running?.sizeVram;
+  const ctxLen = modelDetails?.contextLength;
+  const modelSize = modelInfo?.size;
+  const tps = lastTurnStats?.tokensPerSec;
+  const totalMs = lastTurnStats?.totalDurationNs != null ? lastTurnStats.totalDurationNs / 1_000_000 : null;
+
+  const cellStyle: React.CSSProperties = {
+    fontSize: 10,
+    color: 'var(--fg-muted)',
+    fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
+    whiteSpace: 'nowrap',
+  };
+
+  const labelStyle: React.CSSProperties = {
+    ...cellStyle,
+    color: 'var(--fg-subtle)',
+    marginRight: 3,
+  };
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 0,
+        padding: '3px 14px',
+        borderTop: '1px solid var(--border)',
+        background: 'var(--bg-surface)',
+        flexShrink: 0,
+        flexWrap: 'wrap',
+        rowGap: 2,
+      }}
+    >
+      {/* Model */}
+      <span style={labelStyle}>model</span>
+      <span style={cellStyle}>{model || '—'}</span>
+      {SEP}
+
+      {/* Context window */}
+      <span style={labelStyle}>ctx</span>
+      <span style={cellStyle}>{ctxLen != null ? ctxLen.toLocaleString() : '—'}</span>
+      {SEP}
+
+      {/* Model size on disk */}
+      <span style={labelStyle}>size</span>
+      <span style={cellStyle}>{fmtBytes(modelSize)}</span>
+      {SEP}
+
+      {/* VRAM */}
+      <span style={labelStyle}>vram</span>
+      <span style={cellStyle}>{vram != null ? fmtBytes(vram) : '—'}</span>
+      {SEP}
+
+      {/* Conversation tokens */}
+      <span style={labelStyle}>tokens</span>
+      <span style={cellStyle}>{conversationTokens > 0 ? conversationTokens.toLocaleString() : '—'}</span>
+      {SEP}
+
+      {/* Last-turn tokens/sec */}
+      <span style={labelStyle}>tps</span>
+      <span style={cellStyle}>{tps != null ? `${tps.toFixed(0)} tok/s` : '—'}</span>
+      {SEP}
+
+      {/* Last-turn total latency */}
+      <span style={labelStyle}>last</span>
+      <span style={cellStyle}>{totalMs != null ? `${(totalMs / 1000).toFixed(1)}s` : '—'}</span>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/ai/SystemPromptPanel.tsx
+++ b/apps/desktop/src/components/ai/SystemPromptPanel.tsx
@@ -91,11 +91,9 @@ export function SystemPromptPanel({ sessionId, onPromptChange }: Props) {
   };
 
   const handleLock = () => {
-    setLocked((l) => {
-      const next = !l;
-      if (!next) regenerate(enabled, SYSTEM_PROMPT);
-      return next;
-    });
+    const next = !locked;
+    setLocked(next);
+    if (!next) regenerate(enabled, SYSTEM_PROMPT);
   };
 
   const handleReset = () => {

--- a/apps/desktop/src/components/ai/SystemPromptPanel.tsx
+++ b/apps/desktop/src/components/ai/SystemPromptPanel.tsx
@@ -1,0 +1,270 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useLocation } from 'react-router-dom';
+import { aiUpdateSessionPrompt } from '../../lib/tauri';
+import {
+  buildSystemPrompt,
+  type ContextSourceKey,
+} from '../../hooks/ai/contextSources';
+import { SYSTEM_PROMPT } from '../../hooks/ai/toolRegistry';
+
+interface Props {
+  sessionId: string | null;
+  onPromptChange: (prompt: string) => void;
+}
+
+const ALL_SOURCES: ContextSourceKey[] = [
+  'harness.yaml',
+  'board',
+  'route',
+  'recent-sessions',
+  'claude.md',
+];
+
+const SOURCE_LABELS: Record<ContextSourceKey, string> = {
+  'harness.yaml': 'harness.yaml',
+  'board': 'board',
+  'route': 'route',
+  'recent-sessions': 'sessions',
+  'claude.md': 'CLAUDE.md',
+};
+
+const DEFAULT_SOURCES = new Set<ContextSourceKey>(['harness.yaml', 'route']);
+
+export function SystemPromptPanel({ sessionId, onPromptChange }: Props) {
+  const location = useLocation();
+  const [open, setOpen] = useState(true);
+  const [locked, setLocked] = useState(false);
+  const [enabled, setEnabled] = useState<Set<ContextSourceKey>>(DEFAULT_SOURCES);
+  const [text, setText] = useState(SYSTEM_PROMPT);
+  const [loading, setLoading] = useState(false);
+
+  const regenerate = useCallback(async (sources: Set<ContextSourceKey>, base: string) => {
+    if (sources.size === 0) {
+      onPromptChange(base);
+      setText(base);
+      return;
+    }
+    setLoading(true);
+    try {
+      const ctx = await buildSystemPrompt(sources, location.pathname);
+      const full = ctx ? `${base}\n\n${ctx}` : base;
+      setText(full);
+      onPromptChange(full);
+    } finally {
+      setLoading(false);
+    }
+  }, [location.pathname, onPromptChange]);
+
+  // Auto-populate on mount and when chips change (unless locked)
+  useEffect(() => {
+    if (!locked) {
+      regenerate(enabled, SYSTEM_PROMPT);
+    }
+  }, [enabled, locked]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const persist = useCallback(async (prompt: string, sources: Set<ContextSourceKey>) => {
+    if (!sessionId) return;
+    await aiUpdateSessionPrompt(
+      sessionId,
+      prompt,
+      JSON.stringify([...sources]),
+    ).catch(() => {});
+  }, [sessionId]);
+
+  const handleToggleSource = (key: ContextSourceKey) => {
+    if (locked) return;
+    setEnabled((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const handleTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setText(e.target.value);
+    onPromptChange(e.target.value);
+  };
+
+  const handleTextBlur = () => {
+    persist(text, enabled);
+  };
+
+  const handleLock = () => {
+    setLocked((l) => {
+      const next = !l;
+      if (!next) regenerate(enabled, SYSTEM_PROMPT);
+      return next;
+    });
+  };
+
+  const handleReset = () => {
+    setLocked(false);
+    setEnabled(DEFAULT_SOURCES);
+    regenerate(DEFAULT_SOURCES, SYSTEM_PROMPT);
+  };
+
+  const handleClear = () => {
+    setLocked(true);
+    setText('');
+    onPromptChange('');
+    persist('', enabled);
+  };
+
+  const monoStyle: React.CSSProperties = {
+    fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
+  };
+
+  const chipBase: React.CSSProperties = {
+    ...monoStyle,
+    fontSize: 10,
+    padding: '2px 7px',
+    borderRadius: 4,
+    border: '1px solid var(--border)',
+    cursor: locked ? 'default' : 'pointer',
+    transition: 'background 0.1s',
+    userSelect: 'none',
+  };
+
+  return (
+    <div
+      style={{
+        borderBottom: '1px solid var(--border)',
+        background: 'var(--bg-surface)',
+        flexShrink: 0,
+      }}
+    >
+      {/* Header row */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          padding: '5px 14px',
+          cursor: 'pointer',
+        }}
+        onClick={() => setOpen((o) => !o)}
+      >
+        <span
+          style={{
+            ...monoStyle,
+            fontSize: 10,
+            fontWeight: 600,
+            letterSpacing: '0.08em',
+            textTransform: 'uppercase',
+            color: 'var(--fg-muted)',
+            flex: 1,
+          }}
+        >
+          System Prompt
+          {locked && (
+            <span style={{ marginLeft: 6, color: 'var(--accent)', fontSize: 9 }}>LOCKED</span>
+          )}
+        </span>
+        <span style={{ fontSize: 9, color: 'var(--fg-subtle)' }}>{open ? '▾' : '▸'}</span>
+      </div>
+
+      {open && (
+        <div style={{ padding: '0 14px 10px' }}>
+          {/* Source chips */}
+          <div style={{ display: 'flex', gap: 5, flexWrap: 'wrap', marginBottom: 8 }}>
+            {ALL_SOURCES.map((key) => {
+              const active = enabled.has(key);
+              return (
+                <button
+                  key={key}
+                  style={{
+                    ...chipBase,
+                    background: active ? 'var(--accent-subtle)' : 'transparent',
+                    color: active ? 'var(--accent)' : 'var(--fg-subtle)',
+                    borderColor: active ? 'var(--accent)' : 'var(--border)',
+                    opacity: locked ? 0.5 : 1,
+                  }}
+                  onClick={(e) => { e.stopPropagation(); handleToggleSource(key); }}
+                  title={active ? `Remove ${key} from context` : `Add ${key} to context`}
+                >
+                  {SOURCE_LABELS[key]}
+                </button>
+              );
+            })}
+            {loading && (
+              <span style={{ ...monoStyle, fontSize: 10, color: 'var(--fg-subtle)', alignSelf: 'center' }}>
+                loading…
+              </span>
+            )}
+          </div>
+
+          {/* Prompt textarea */}
+          <textarea
+            value={text}
+            onChange={handleTextChange}
+            onBlur={handleTextBlur}
+            rows={5}
+            style={{
+              ...monoStyle,
+              width: '100%',
+              fontSize: 11,
+              background: 'var(--bg-base)',
+              color: 'var(--fg)',
+              border: '1px solid var(--border)',
+              borderRadius: 4,
+              padding: '6px 8px',
+              resize: 'vertical',
+              lineHeight: 1.5,
+              boxSizing: 'border-box',
+            }}
+          />
+
+          {/* Action buttons */}
+          <div style={{ display: 'flex', gap: 6, marginTop: 6, justifyContent: 'flex-end' }}>
+            <button
+              onClick={handleLock}
+              style={{
+                ...monoStyle,
+                fontSize: 10,
+                padding: '2px 8px',
+                background: locked ? 'var(--accent-subtle)' : 'transparent',
+                color: locked ? 'var(--accent)' : 'var(--fg-muted)',
+                border: `1px solid ${locked ? 'var(--accent)' : 'var(--border)'}`,
+                borderRadius: 4,
+                cursor: 'pointer',
+              }}
+            >
+              {locked ? 'unlock' : 'lock'}
+            </button>
+            <button
+              onClick={handleReset}
+              style={{
+                ...monoStyle,
+                fontSize: 10,
+                padding: '2px 8px',
+                background: 'transparent',
+                color: 'var(--fg-muted)',
+                border: '1px solid var(--border)',
+                borderRadius: 4,
+                cursor: 'pointer',
+              }}
+            >
+              reset
+            </button>
+            <button
+              onClick={handleClear}
+              style={{
+                ...monoStyle,
+                fontSize: 10,
+                padding: '2px 8px',
+                background: 'transparent',
+                color: 'var(--fg-muted)',
+                border: '1px solid var(--border)',
+                borderRadius: 4,
+                cursor: 'pointer',
+              }}
+            >
+              clear
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/ai/terminal/AssistantRow.tsx
+++ b/apps/desktop/src/components/ai/terminal/AssistantRow.tsx
@@ -1,13 +1,17 @@
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import type { TurnStats } from '../../../hooks/useAIChat';
 
 interface Props {
   content: string;
   streaming?: boolean;
   incomplete?: boolean;
+  stats?: TurnStats;
 }
 
-export function AssistantRow({ content, streaming, incomplete }: Props) {
+export function AssistantRow({ content, streaming, incomplete, stats }: Props) {
+  const showStats = !streaming && stats && (stats.evalCount != null || stats.tokensPerSec != null);
+
   return (
     <div
       style={{
@@ -29,6 +33,28 @@ export function AssistantRow({ content, streaming, incomplete }: Props) {
           </span>
         )}
       </div>
+      {showStats && (
+        <div
+          style={{
+            marginTop: 4,
+            fontSize: 10,
+            color: 'var(--fg-subtle)',
+            fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
+            display: 'flex',
+            gap: 6,
+          }}
+        >
+          {stats!.evalCount != null && (
+            <span>{stats!.evalCount.toLocaleString()} tok</span>
+          )}
+          {stats!.totalDurationNs != null && (
+            <span>{(stats!.totalDurationNs / 1_000_000_000).toFixed(2)}s</span>
+          )}
+          {stats!.tokensPerSec != null && (
+            <span>{stats!.tokensPerSec.toFixed(0)} tok/s</span>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/components/ai/terminal/TerminalTranscript.tsx
+++ b/apps/desktop/src/components/ai/terminal/TerminalTranscript.tsx
@@ -82,6 +82,7 @@ export function TerminalTranscript({ transcript, isStreaming, onApprove, onDeny 
                   content={row.content}
                   streaming={row.streaming}
                   incomplete={row.incomplete}
+                  stats={row.stats}
                 />
               );
             case 'thinking':

--- a/apps/desktop/src/components/ai/terminal/TranscriptToolbar.tsx
+++ b/apps/desktop/src/components/ai/terminal/TranscriptToolbar.tsx
@@ -1,16 +1,6 @@
 import { OllamaStatus } from '../OllamaStatus';
 import type { OllamaState } from '../../../hooks/useOllama';
-
-// Models that support tool-calling via Ollama
-const TOOL_CAPABLE_PREFIXES = [
-  'qwen3', 'qwen2.5', 'llama3.1', 'llama3.2',
-  'mistral-nemo', 'command-r-plus', 'command-r',
-];
-
-function modelSupportsTools(name: string): boolean {
-  const lower = name.toLowerCase();
-  return TOOL_CAPABLE_PREFIXES.some((prefix) => lower.startsWith(prefix));
-}
+import type { ModelDetails } from '../../../lib/tauri';
 
 interface Props {
   ollama: Pick<OllamaState, 'running' | 'checking' | 'timedOut' | 'retry' | 'models'>;
@@ -18,10 +8,16 @@ interface Props {
   onModelSelect: (model: string) => void;
   onNew: () => void;
   baseUrl?: string;
+  version?: string | null;
+  runningCount?: number;
   isStreaming?: boolean;
   onCancelStream?: () => void;
   mode: 'styled' | 'raw';
   onToggleMode: () => void;
+  modelDetails?: ModelDetails | null;
+  currentToolHop?: number;
+  inspectorOpen?: boolean;
+  onToggleInspector?: () => void;
 }
 
 export function TranscriptToolbar({
@@ -30,10 +26,16 @@ export function TranscriptToolbar({
   onModelSelect,
   onNew,
   baseUrl,
+  version,
+  runningCount,
   isStreaming,
   onCancelStream,
   mode,
   onToggleMode,
+  modelDetails,
+  currentToolHop,
+  inspectorOpen,
+  onToggleInspector,
 }: Props) {
   const btnStyle: React.CSSProperties = {
     background: 'none',
@@ -47,6 +49,9 @@ export function TranscriptToolbar({
     alignItems: 'center',
     gap: 4,
   };
+
+  const hasTools = modelDetails?.capabilities?.includes('tools') ?? false;
+  const noToolsKnown = modelDetails != null && !hasTools;
 
   return (
     <div
@@ -90,9 +95,11 @@ export function TranscriptToolbar({
             ))
           )}
         </select>
-        {selectedModel && modelSupportsTools(selectedModel) && (
+
+        {/* Tool-capability pill — shown once modelDetails is loaded */}
+        {hasTools && (
           <span
-            title="Supports tool-calling"
+            title={`Capabilities: ${modelDetails!.capabilities.join(', ')}`}
             style={{
               fontSize: 9,
               background: 'var(--accent)',
@@ -106,17 +113,68 @@ export function TranscriptToolbar({
             tools
           </span>
         )}
+        {noToolsKnown && (
+          <span
+            title={`Capabilities: ${modelDetails!.capabilities.join(', ') || 'none reported'}`}
+            style={{
+              fontSize: 9,
+              background: 'var(--border)',
+              color: 'var(--fg-subtle)',
+              borderRadius: 3,
+              padding: '1px 4px',
+              letterSpacing: '0.03em',
+              fontWeight: 600,
+            }}
+          >
+            no tools
+          </span>
+        )}
+
+        {/* Tool-hop counter — visible during active multi-turn loop */}
+        {isStreaming && currentToolHop != null && currentToolHop > 0 && (
+          <span
+            title={`Tool hop ${currentToolHop} of 6`}
+            style={{
+              fontSize: 9,
+              background: 'var(--bg-elevated, #1e2030)',
+              border: '1px solid var(--border)',
+              color: 'var(--fg-muted)',
+              borderRadius: 3,
+              padding: '1px 5px',
+              fontFamily: 'monospace',
+            }}
+          >
+            hop {currentToolHop}
+          </span>
+        )}
       </div>
 
       {/* Status + cancel */}
       <OllamaStatus
         ollama={ollama}
         baseUrl={baseUrl}
+        version={version}
+        runningCount={runningCount}
         isStreaming={isStreaming}
         onCancelStream={onCancelStream}
       />
 
       <div style={{ flex: 1 }} />
+
+      {/* Inspector toggle */}
+      {onToggleInspector && (
+        <button
+          style={{
+            ...btnStyle,
+            borderColor: inspectorOpen ? 'var(--accent)' : 'var(--border)',
+            color: inspectorOpen ? 'var(--accent)' : 'var(--fg-muted)',
+          }}
+          onClick={onToggleInspector}
+          title="Toggle inspector panel"
+        >
+          ⌥ inspect
+        </button>
+      )}
 
       {/* Mode toggle */}
       <button

--- a/apps/desktop/src/hooks/__tests__/useOllama.test.ts
+++ b/apps/desktop/src/hooks/__tests__/useOllama.test.ts
@@ -7,11 +7,17 @@ import type { DownloadProgress } from "../../lib/tauri";
 const mockAiCheckOllama = vi.fn();
 const mockAiListModels = vi.fn();
 const mockAiPullModel = vi.fn();
+const mockAiListRunningModels = vi.fn();
+const mockAiShowModel = vi.fn();
+const mockAiGetOllamaVersion = vi.fn();
 
 vi.mock("../../lib/tauri", () => ({
   aiCheckOllama: mockAiCheckOllama,
   aiListModels: mockAiListModels,
   aiPullModel: mockAiPullModel,
+  aiListRunningModels: mockAiListRunningModels,
+  aiShowModel: mockAiShowModel,
+  aiGetOllamaVersion: mockAiGetOllamaVersion,
 }));
 
 // Channel mock — exposes onmessage so tests can push progress events
@@ -30,11 +36,16 @@ beforeEach(() => {
   mockAiCheckOllama.mockReset();
   mockAiListModels.mockReset();
   mockAiPullModel.mockReset();
+  mockAiListRunningModels.mockReset();
+  mockAiShowModel.mockReset();
+  mockAiGetOllamaVersion.mockReset();
   mockChannelInstance.onmessage = null;
 
   // Default: Ollama not running
   mockAiCheckOllama.mockResolvedValue({ running: false });
   mockAiListModels.mockResolvedValue([]);
+  mockAiListRunningModels.mockResolvedValue([]);
+  mockAiGetOllamaVersion.mockResolvedValue("0.6.0");
 });
 
 afterEach(() => {

--- a/apps/desktop/src/hooks/ai/contextSources.ts
+++ b/apps/desktop/src/hooks/ai/contextSources.ts
@@ -1,0 +1,138 @@
+import { readHarnessFile, readClaudeMd, aiListSessions } from '../../lib/tauri';
+import { api } from '../../lib/board-api';
+
+export interface ContextFragment {
+  source: string;
+  text: string;
+}
+
+export type ContextSourceKey =
+  | 'harness.yaml'
+  | 'board'
+  | 'route'
+  | 'recent-sessions'
+  | 'claude.md';
+
+export async function harnessYamlFragment(): Promise<ContextFragment> {
+  try {
+    const result = await readHarnessFile();
+    if (!result.found || !result.content) {
+      return { source: 'harness.yaml', text: '(no harness.yaml found)' };
+    }
+    const lines = result.content.split('\n');
+    const preview = lines.slice(0, 40).join('\n');
+    const suffix = lines.length > 40 ? `\n... (${lines.length - 40} more lines)` : '';
+    return {
+      source: 'harness.yaml',
+      text: `Current harness.yaml (${result.path ?? 'unknown path'}):\n\`\`\`yaml\n${preview}${suffix}\n\`\`\``,
+    };
+  } catch {
+    return { source: 'harness.yaml', text: '(could not read harness.yaml)' };
+  }
+}
+
+export async function activeBoardProjectFragment(): Promise<ContextFragment> {
+  try {
+    const projects = await api.projects.list();
+    if (projects.length === 0) {
+      return { source: 'board', text: '(no board projects found)' };
+    }
+
+    const lines: string[] = [`Board projects (${projects.length} total):`];
+    for (const project of projects.slice(0, 3)) {
+      const tasks = await api.tasks.list(project.slug, { status: 'in_progress' }).catch(() => []);
+      const inFlight = tasks.slice(0, 5);
+      lines.push(`\n**${project.name}** (${project.slug})`);
+      if (project.description) lines.push(`  ${project.description}`);
+      if (inFlight.length > 0) {
+        lines.push(`  In-progress tasks:`);
+        for (const t of inFlight) {
+          lines.push(`    - [${t.id}] ${t.title} (${t.priority ?? 'normal'})`);
+        }
+      }
+    }
+
+    return { source: 'board', text: lines.join('\n') };
+  } catch {
+    return { source: 'board', text: '(board server not reachable)' };
+  }
+}
+
+export function currentRouteFragment(pathname: string): ContextFragment {
+  const routeLabels: Record<string, string> = {
+    '/ai-chat': 'AI Chat',
+    '/board': 'Kanban Board',
+    '/harness': 'Harness Config',
+    '/plugins': 'Plugins',
+    '/security': 'Security',
+    '/observatory': 'Observatory',
+    '/memory': 'Memory',
+    '/sync': 'Sync',
+    '/settings': 'Settings',
+    '/comparator': 'Comparator',
+    '/roadmap': 'Roadmap',
+  };
+
+  const label = Object.entries(routeLabels).find(([k]) => pathname.startsWith(k))?.[1]
+    ?? pathname;
+
+  return {
+    source: 'route',
+    text: `Current view: ${label} (${pathname})`,
+  };
+}
+
+export async function recentSessionsFragment(): Promise<ContextFragment> {
+  try {
+    const sessions = await aiListSessions();
+    const recent = sessions
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+      .slice(0, 5);
+
+    if (recent.length === 0) {
+      return { source: 'recent-sessions', text: '(no prior AI chat sessions)' };
+    }
+
+    const lines = ['Recent AI chat sessions:'];
+    for (const s of recent) {
+      const title = s.title ?? '(untitled)';
+      const model = s.model ?? 'unknown';
+      lines.push(`  - ${title} [${model}]`);
+    }
+    return { source: 'recent-sessions', text: lines.join('\n') };
+  } catch {
+    return { source: 'recent-sessions', text: '(could not load session history)' };
+  }
+}
+
+export async function claudeMdFragment(): Promise<ContextFragment> {
+  try {
+    const content = await readClaudeMd('CLAUDE.md');
+    const lines = content.split('\n');
+    const preview = lines.slice(0, 50).join('\n');
+    const suffix = lines.length > 50 ? `\n... (${lines.length - 50} more lines)` : '';
+    return {
+      source: 'claude.md',
+      text: `CLAUDE.md:\n\`\`\`\n${preview}${suffix}\n\`\`\``,
+    };
+  } catch {
+    return { source: 'claude.md', text: '(no CLAUDE.md found)' };
+  }
+}
+
+export async function buildSystemPrompt(
+  enabled: Set<ContextSourceKey>,
+  pathname: string,
+): Promise<string> {
+  const fetchers: Array<[ContextSourceKey, () => Promise<ContextFragment> | ContextFragment]> = [
+    ['harness.yaml', harnessYamlFragment],
+    ['board', activeBoardProjectFragment],
+    ['route', () => currentRouteFragment(pathname)],
+    ['recent-sessions', recentSessionsFragment],
+    ['claude.md', claudeMdFragment],
+  ];
+
+  const active = fetchers.filter(([key]) => enabled.has(key));
+  const frags = await Promise.all(active.map(([, fn]) => fn()));
+  return frags.map((f) => f.text).join('\n\n');
+}

--- a/apps/desktop/src/hooks/ai/handlers/git.ts
+++ b/apps/desktop/src/hooks/ai/handlers/git.ts
@@ -1,0 +1,93 @@
+import { invoke } from '@tauri-apps/api/core';
+import type { ToolDef, ToolResult } from '../toolTypes';
+
+export const gitTools: ToolDef[] = [
+  {
+    name: 'git.diff',
+    description: 'Get the git diff of a worktree against a specific commit',
+    parameters: {
+      type: 'object',
+      properties: {
+        worktree_path: { type: 'string', description: 'Absolute path to the worktree' },
+        commit: { type: 'string', description: 'Commit SHA to diff against (defaults to HEAD)' },
+      },
+      required: ['worktree_path'],
+    },
+    category: 'read',
+    handler: async (args: unknown): Promise<ToolResult> => {
+      const { worktree_path, commit = 'HEAD' } = args as {
+        worktree_path: string;
+        commit?: string;
+      };
+      try {
+        const diff = await invoke<string>('get_diff_against_commit', {
+          worktreePath: worktree_path,
+          commit,
+        });
+        return { ok: true, content: { diff } };
+      } catch (e) {
+        return { ok: false, content: { error: String(e) } };
+      }
+    },
+    describe: (args) =>
+      `Diff "${(args as { worktree_path?: string })?.worktree_path ?? '?'}" against HEAD`,
+  },
+
+  {
+    name: 'git.create_worktree',
+    description: 'Create a new git worktree for a board task',
+    parameters: {
+      type: 'object',
+      properties: {
+        project_slug: { type: 'string', description: 'Board project slug' },
+        task_id: { type: 'string', description: 'Task ID to create the worktree for' },
+      },
+      required: ['project_slug', 'task_id'],
+    },
+    category: 'write',
+    handler: async (args: unknown): Promise<ToolResult> => {
+      const { project_slug, task_id } = args as { project_slug: string; task_id: string };
+      try {
+        const result = await invoke('create_worktrees', {
+          projectSlug: project_slug,
+          taskId: task_id,
+        });
+        return { ok: true, content: result };
+      } catch (e) {
+        return { ok: false, content: { error: String(e) } };
+      }
+    },
+    describe: (args) => {
+      const { project_slug, task_id } = (args as { project_slug?: string; task_id?: string }) ?? {};
+      return `Create worktree for task ${task_id ?? '?'} in ${project_slug ?? '?'}`;
+    },
+  },
+
+  {
+    name: 'git.remove_worktree',
+    description: 'Remove an existing git worktree',
+    parameters: {
+      type: 'object',
+      properties: {
+        project_slug: { type: 'string', description: 'Board project slug' },
+        task_id: { type: 'string', description: 'Task ID whose worktree to remove' },
+      },
+      required: ['project_slug', 'task_id'],
+    },
+    category: 'write',
+    handler: async (args: unknown): Promise<ToolResult> => {
+      const { project_slug, task_id } = args as { project_slug: string; task_id: string };
+      try {
+        await invoke('remove_worktrees', {
+          projectSlug: project_slug,
+          taskId: task_id,
+        });
+        return { ok: true, content: { message: `Worktree removed for task ${task_id}` } };
+      } catch (e) {
+        return { ok: false, content: { error: String(e) } };
+      }
+    },
+    describe: (args) =>
+      `Remove worktree for task ${(args as { task_id?: string })?.task_id ?? '?'}`,
+  },
+];

--- a/apps/desktop/src/hooks/ai/handlers/harness.ts
+++ b/apps/desktop/src/hooks/ai/handlers/harness.ts
@@ -5,11 +5,7 @@ export const harnessTools: ToolDef[] = [
   {
     name: 'harness.detect_agents',
     description: 'Detect which AI agent harnesses are installed (Claude Code, Cursor, Copilot, Codex, etc.)',
-    parameters: {
-      type: 'object',
-      properties: {},
-      required: [],
-    },
+    parameters: { type: 'object', properties: {}, required: [] },
     category: 'read',
     handler: async (): Promise<ToolResult> => {
       try {
@@ -20,5 +16,63 @@ export const harnessTools: ToolDef[] = [
       }
     },
     describe: () => 'Detect installed AI agent harnesses',
+  },
+
+  {
+    name: 'harness.read_config',
+    description: 'Read the current harness.yaml configuration file',
+    parameters: { type: 'object', properties: {}, required: [] },
+    category: 'read',
+    handler: async (): Promise<ToolResult> => {
+      try {
+        const content = await invoke<string>('read_harness_file');
+        return { ok: true, content: { yaml: content } };
+      } catch (e) {
+        return { ok: false, content: { error: String(e) } };
+      }
+    },
+    describe: () => 'Read harness.yaml',
+  },
+
+  {
+    name: 'harness.write_config',
+    description: 'Write new content to the harness.yaml configuration file. Provide the full YAML content.',
+    parameters: {
+      type: 'object',
+      properties: {
+        content: { type: 'string', description: 'Full YAML content to write' },
+      },
+      required: ['content'],
+    },
+    category: 'write',
+    handler: async (args: unknown): Promise<ToolResult> => {
+      const { content } = args as { content: string };
+      try {
+        await invoke('write_harness_file', { content });
+        return { ok: true, content: { message: 'harness.yaml updated' } };
+      } catch (e) {
+        return { ok: false, content: { error: String(e) } };
+      }
+    },
+    describe: (args) => {
+      const lines = ((args as { content?: string })?.content ?? '').split('\n').length;
+      return `Write harness.yaml (${lines} lines)`;
+    },
+  },
+
+  {
+    name: 'harness.list_profiles',
+    description: 'List all available harness profiles',
+    parameters: { type: 'object', properties: {}, required: [] },
+    category: 'read',
+    handler: async (): Promise<ToolResult> => {
+      try {
+        const data = await invoke('list_custom_profiles');
+        return { ok: true, content: data };
+      } catch (e) {
+        return { ok: false, content: { error: String(e) } };
+      }
+    },
+    describe: () => 'List harness profiles',
   },
 ];

--- a/apps/desktop/src/hooks/ai/handlers/mcp.ts
+++ b/apps/desktop/src/hooks/ai/handlers/mcp.ts
@@ -1,0 +1,83 @@
+import { invoke } from '@tauri-apps/api/core';
+import type { ToolDef, ToolResult } from '../toolTypes';
+
+export const mcpTools: ToolDef[] = [
+  {
+    name: 'mcp.list',
+    description: 'List all configured MCP servers in ~/.claude/mcp.json',
+    parameters: { type: 'object', properties: {}, required: [] },
+    category: 'read',
+    handler: async (): Promise<ToolResult> => {
+      try {
+        const content = await invoke<string>('read_mcp_config');
+        try {
+          return { ok: true, content: JSON.parse(content) };
+        } catch {
+          return { ok: true, content: { raw: content } };
+        }
+      } catch (e) {
+        return { ok: false, content: { error: String(e) } };
+      }
+    },
+    describe: () => 'List MCP servers',
+  },
+
+  {
+    name: 'mcp.add',
+    description: 'Add or update an MCP server entry in ~/.claude/mcp.json. Provide the server name and its configuration object.',
+    parameters: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Server name (key in the mcpServers object)' },
+        config: {
+          type: 'object',
+          description: 'Server config (e.g. { command: "node", args: [...], env: {...} })',
+        },
+      },
+      required: ['name', 'config'],
+    },
+    category: 'write',
+    handler: async (args: unknown): Promise<ToolResult> => {
+      const { name, config } = args as { name: string; config: unknown };
+      try {
+        const raw = await invoke<string>('read_mcp_config').catch(() => '{}');
+        let parsed: { mcpServers?: Record<string, unknown> } = {};
+        try { parsed = JSON.parse(raw); } catch { /* start fresh */ }
+        parsed.mcpServers = { ...(parsed.mcpServers ?? {}), [name]: config };
+        await invoke('write_mcp_config', { content: JSON.stringify(parsed, null, 2) });
+        return { ok: true, content: { message: `MCP server "${name}" added/updated` } };
+      } catch (e) {
+        return { ok: false, content: { error: String(e) } };
+      }
+    },
+    describe: (args) => `Add MCP server "${(args as { name?: string })?.name ?? '?'}"`,
+  },
+
+  {
+    name: 'mcp.remove',
+    description: 'Remove an MCP server from ~/.claude/mcp.json by name',
+    parameters: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Server name to remove' },
+      },
+      required: ['name'],
+    },
+    category: 'write',
+    handler: async (args: unknown): Promise<ToolResult> => {
+      const { name } = args as { name: string };
+      try {
+        const raw = await invoke<string>('read_mcp_config').catch(() => '{}');
+        let parsed: { mcpServers?: Record<string, unknown> } = {};
+        try { parsed = JSON.parse(raw); } catch { /* start fresh */ }
+        const { [name]: _removed, ...rest } = parsed.mcpServers ?? {};
+        parsed.mcpServers = rest;
+        await invoke('write_mcp_config', { content: JSON.stringify(parsed, null, 2) });
+        return { ok: true, content: { message: `MCP server "${name}" removed` } };
+      } catch (e) {
+        return { ok: false, content: { error: String(e) } };
+      }
+    },
+    describe: (args) => `Remove MCP server "${(args as { name?: string })?.name ?? '?'}"`,
+  },
+];

--- a/apps/desktop/src/hooks/ai/handlers/mcp.ts
+++ b/apps/desktop/src/hooks/ai/handlers/mcp.ts
@@ -50,7 +50,13 @@ export const mcpTools: ToolDef[] = [
         return { ok: false, content: { error: String(e) } };
       }
     },
-    describe: (args) => `Add MCP server "${(args as { name?: string })?.name ?? '?'}"`,
+    describe: (args) => {
+      const { name, config } = (args as { name?: string; config?: unknown }) ?? {};
+      const configPreview = config !== undefined
+        ? `\n${JSON.stringify(config, null, 2)}`
+        : '';
+      return `Add MCP server "${name ?? '?'}"${configPreview}`;
+    },
   },
 
   {

--- a/apps/desktop/src/hooks/ai/handlers/parity.ts
+++ b/apps/desktop/src/hooks/ai/handlers/parity.ts
@@ -1,0 +1,20 @@
+import { invoke } from '@tauri-apps/api/core';
+import type { ToolDef, ToolResult } from '../toolTypes';
+
+export const parityTools: ToolDef[] = [
+  {
+    name: 'parity.run_scan',
+    description: 'Run a parity scan to compare harness configurations across detected AI agents',
+    parameters: { type: 'object', properties: {}, required: [] },
+    category: 'read',
+    handler: async (): Promise<ToolResult> => {
+      try {
+        const data = await invoke('run_parity_scan');
+        return { ok: true, content: data };
+      } catch (e) {
+        return { ok: false, content: { error: String(e) } };
+      }
+    },
+    describe: () => 'Run parity scan',
+  },
+];

--- a/apps/desktop/src/hooks/ai/handlers/plugins.ts
+++ b/apps/desktop/src/hooks/ai/handlers/plugins.ts
@@ -1,0 +1,43 @@
+import { invoke } from '@tauri-apps/api/core';
+import type { ToolDef, ToolResult } from '../toolTypes';
+
+export const pluginTools: ToolDef[] = [
+  {
+    name: 'plugins.list_installed',
+    description: 'List all installed Claude Code plugins',
+    parameters: { type: 'object', properties: {}, required: [] },
+    category: 'read',
+    handler: async (): Promise<ToolResult> => {
+      try {
+        const data = await invoke('list_installed_plugins');
+        return { ok: true, content: data };
+      } catch (e) {
+        return { ok: false, content: { error: String(e) } };
+      }
+    },
+    describe: () => 'List installed plugins',
+  },
+
+  {
+    name: 'plugins.uninstall',
+    description: 'Uninstall a Claude Code plugin by name',
+    parameters: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Plugin name to uninstall' },
+      },
+      required: ['name'],
+    },
+    category: 'write',
+    handler: async (args: unknown): Promise<ToolResult> => {
+      const { name } = args as { name: string };
+      try {
+        await invoke('uninstall_plugin', { name });
+        return { ok: true, content: { message: `Plugin "${name}" uninstalled` } };
+      } catch (e) {
+        return { ok: false, content: { error: String(e) } };
+      }
+    },
+    describe: (args) => `Uninstall plugin "${(args as { name?: string })?.name ?? '?'}"`,
+  },
+];

--- a/apps/desktop/src/hooks/ai/handlers/sync.ts
+++ b/apps/desktop/src/hooks/ai/handlers/sync.ts
@@ -1,0 +1,75 @@
+import { invoke } from '@tauri-apps/api/core';
+import type { ToolDef, ToolResult } from '../toolTypes';
+
+export const syncTools: ToolDef[] = [
+  {
+    name: 'sync.read_file',
+    description: 'Read the contents of a synced file (e.g. CLAUDE.md) by its relative path',
+    parameters: {
+      type: 'object',
+      properties: {
+        path: { type: 'string', description: 'Relative path to the file' },
+      },
+      required: ['path'],
+    },
+    category: 'read',
+    handler: async (args: unknown): Promise<ToolResult> => {
+      const { path } = args as { path: string };
+      try {
+        const content = await invoke<string>('sync_read_file', { path });
+        return { ok: true, content: { path, content } };
+      } catch (e) {
+        return { ok: false, content: { error: String(e) } };
+      }
+    },
+    describe: (args) => `Read "${(args as { path?: string })?.path ?? '?'}"`,
+  },
+
+  {
+    name: 'sync.write_files',
+    description: 'Write one or more files to the sync directory. Provide an object mapping relative paths to file contents.',
+    parameters: {
+      type: 'object',
+      properties: {
+        files: {
+          type: 'object',
+          description: 'Map of relative path → file content strings',
+        },
+      },
+      required: ['files'],
+    },
+    category: 'write',
+    handler: async (args: unknown): Promise<ToolResult> => {
+      const { files } = args as { files: Record<string, string> };
+      try {
+        await invoke('sync_write_files', { files });
+        const count = Object.keys(files).length;
+        return { ok: true, content: { message: `Wrote ${count} file${count !== 1 ? 's' : ''}` } };
+      } catch (e) {
+        return { ok: false, content: { error: String(e) } };
+      }
+    },
+    describe: (args) => {
+      const files = (args as { files?: Record<string, string> })?.files ?? {};
+      const keys = Object.keys(files);
+      if (keys.length === 1) return `Write "${keys[0]}"`;
+      return `Write ${keys.length} files`;
+    },
+  },
+
+  {
+    name: 'sync.create_backup',
+    description: 'Create a backup snapshot of the current sync directory state',
+    parameters: { type: 'object', properties: {}, required: [] },
+    category: 'write',
+    handler: async (): Promise<ToolResult> => {
+      try {
+        const result = await invoke<string>('sync_create_backup');
+        return { ok: true, content: { message: result } };
+      } catch (e) {
+        return { ok: false, content: { error: String(e) } };
+      }
+    },
+    describe: () => 'Create sync backup',
+  },
+];

--- a/apps/desktop/src/hooks/ai/toolRegistry.ts
+++ b/apps/desktop/src/hooks/ai/toolRegistry.ts
@@ -1,35 +1,37 @@
-/**
- * Tool registry — the complete catalog of 12 tools across 5 surfaces.
- * Import toolsForOllama(TOOLS) to get the array the Ollama API expects.
- */
 import type { ToolDef } from './toolTypes';
+import type { ModelDetails } from '../../lib/tauri';
 import { securityTools } from './handlers/security';
 import { observatoryTools } from './handlers/observatory';
 import { memoryTools } from './handlers/memory';
 import { boardTools } from './handlers/board';
 import { harnessTools } from './handlers/harness';
+import { pluginTools } from './handlers/plugins';
+import { mcpTools } from './handlers/mcp';
+import { gitTools } from './handlers/git';
+import { syncTools } from './handlers/sync';
+import { parityTools } from './handlers/parity';
 
 export const TOOLS: ToolDef[] = [
-  ...securityTools,       // security.read_permissions, security.list_audit, security.apply_preset
-  ...observatoryTools,    // observatory.stats, observatory.list_sessions
-  ...memoryTools,         // memory.search, memory.get_graph_stats, memory.add_observation
-  ...boardTools,          // board.list_projects, board.list_tasks, board.create_task
-  ...harnessTools,        // harness.detect_agents
+  ...securityTools,    // security.read_permissions, security.list_audit, security.apply_preset
+  ...observatoryTools, // observatory.stats, observatory.list_sessions
+  ...memoryTools,      // memory.search, memory.get_graph_stats, memory.add_observation
+  ...boardTools,       // board.list_projects, board.list_tasks, board.create_task
+  ...harnessTools,     // harness.detect_agents, harness.read_config, harness.write_config, harness.list_profiles
+  ...pluginTools,      // plugins.list_installed, plugins.uninstall
+  ...mcpTools,         // mcp.list, mcp.add, mcp.remove
+  ...gitTools,         // git.diff, git.create_worktree, git.remove_worktree
+  ...syncTools,        // sync.read_file, sync.write_files, sync.create_backup
+  ...parityTools,      // parity.run_scan
 ];
 
-/** Models known to support Ollama tool-calling */
-const TOOL_CAPABLE_PREFIXES = [
-  'qwen3', 'qwen2.5', 'llama3.1', 'llama3.2',
-  'mistral-nemo', 'command-r-plus', 'command-r',
-];
-
-export function modelSupportsTools(modelName: string): boolean {
-  const lower = modelName.toLowerCase();
-  return TOOL_CAPABLE_PREFIXES.some((p) => lower.startsWith(p));
+export function modelSupportsTools(modelDetails: ModelDetails | null | undefined): boolean {
+  return modelDetails?.capabilities?.includes('tools') ?? false;
 }
 
 export const SYSTEM_PROMPT =
-  `You are the Harness Kit AI assistant. You have access to tools for reading and modifying security settings, ` +
-  `viewing Claude usage statistics and sessions, searching memory, querying and updating the Kanban board, ` +
-  `and detecting installed AI agent harnesses. Use tools when the user asks about any of these surfaces. ` +
-  `Always cite the data you retrieved. For write operations, briefly explain what you are about to do before proceeding.`;
+  `You are the Harness Kit AI assistant, running inside the Harness Kit desktop app. ` +
+  `You have access to tools across ten surfaces: security settings, Claude usage statistics, ` +
+  `memory graph, Kanban board, harness configuration, plugins, MCP servers, git worktrees, ` +
+  `file sync, and parity scanning. ` +
+  `Use tools when the user asks about any of these surfaces. Always cite the data you retrieved. ` +
+  `For write operations, briefly explain what you are about to do before invoking the tool.`;

--- a/apps/desktop/src/hooks/useAIChat.ts
+++ b/apps/desktop/src/hooks/useAIChat.ts
@@ -19,9 +19,20 @@ import { logAIError } from "./ai/logging";
 import { dispatchToolCall } from "./ai/dispatch";
 import { TOOLS, SYSTEM_PROMPT, modelSupportsTools } from "./ai/toolRegistry";
 import { toolsForOllama, type ToolDef } from "./ai/toolTypes";
+import type { ModelDetails } from "../lib/tauri";
 import { useApprovalState } from "./ai/approvalState";
 
 // ─── Transcript types ────────────────────────────────────────────────────────
+
+export interface TurnStats {
+  evalCount?: number;
+  promptEvalCount?: number;
+  totalDurationNs?: number;
+  loadDurationNs?: number;
+  promptEvalDurationNs?: number;
+  evalDurationNs?: number;
+  tokensPerSec?: number;
+}
 
 export type TranscriptRow =
   | { kind: "user"; id: string; content: string; ts: string }
@@ -32,6 +43,7 @@ export type TranscriptRow =
       ts: string;
       streaming?: boolean;
       incomplete?: boolean;
+      stats?: TurnStats;
     }
   | { kind: "thinking"; id: string }
   | { kind: "system"; id: string; content: string }
@@ -60,8 +72,12 @@ export interface UseAIChatReturn {
   /** Ordered list of rows to render in the transcript */
   transcript: TranscriptRow[];
   isStreaming: boolean;
+  /** Stats from the most recent completed turn */
+  lastTurnStats: TurnStats | null;
+  /** Current tool-hop index during an active multi-turn loop (0 when not in a loop) */
+  currentToolHop: number;
   error: string | null;
-  sendMessage: (content: string, model: string) => Promise<void>;
+  sendMessage: (content: string, model: string, systemPrompt?: string, modelDetails?: ModelDetails | null) => Promise<void>;
   cancelStream: () => void;
   createSession: (model: string) => Promise<string>;
   loadSession: (id: string) => Promise<void>;
@@ -98,6 +114,8 @@ export function useAIChat(): UseAIChatReturn {
   const [currentSession, setCurrentSession] = useState<AISessionRow | null>(null);
   const [transcript, setTranscript] = useState<TranscriptRow[]>([]);
   const [isStreaming, setIsStreaming] = useState(false);
+  const [lastTurnStats, setLastTurnStats] = useState<TurnStats | null>(null);
+  const [currentToolHop, setCurrentToolHop] = useState(0);
   const [error, setError] = useState<string | null>(null);
 
   // Refs for use inside async callbacks / Channel.onmessage
@@ -166,6 +184,8 @@ export function useAIChat(): UseAIChatReturn {
       model,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
+      systemPrompt: null,
+      contextSourcesJson: null,
     };
     if (mountedRef.current) {
       setCurrentSession(newSession);
@@ -240,7 +260,7 @@ export function useAIChat(): UseAIChatReturn {
       assistantId: string,
       existingContent: string
     ) =>
-      new Promise<{ assistantText: string; toolCalls: ToolCall[]; done: boolean }>(
+      new Promise<{ assistantText: string; toolCalls: ToolCall[]; done: boolean; stats: TurnStats }>(
         (resolve, reject) => {
           let fullText = existingContent;
           let pendingToolCalls: ToolCall[] = [];
@@ -271,12 +291,26 @@ export function useAIChat(): UseAIChatReturn {
             } else if (event.kind === "done") {
               if (!finished) {
                 finished = true;
-                // Finalize assistant row
+                const d = event.data;
+                const tokensPerSec =
+                  d.evalCount && d.evalDuration && d.evalDuration > 0
+                    ? d.evalCount / (d.evalDuration / 1e9)
+                    : undefined;
+                const stats: TurnStats = {
+                  evalCount: d.evalCount,
+                  promptEvalCount: d.promptEvalCount,
+                  totalDurationNs: d.totalDuration,
+                  loadDurationNs: d.loadDuration,
+                  promptEvalDurationNs: d.promptEvalDuration,
+                  evalDurationNs: d.evalDuration,
+                  tokensPerSec,
+                };
+                // Finalize assistant row (with stats attached)
                 if (started) {
                   setTranscript((prev) => {
                     const next = prev.map((r) =>
                       r.id === assistantId && r.kind === "assistant"
-                        ? { ...r, content: fullText, streaming: false }
+                        ? { ...r, content: fullText, streaming: false, stats }
                         : r
                     );
                     transcriptRef.current = next;
@@ -290,7 +324,7 @@ export function useAIChat(): UseAIChatReturn {
                     return next;
                   });
                 }
-                resolve({ assistantText: fullText, toolCalls: pendingToolCalls, done: true });
+                resolve({ assistantText: fullText, toolCalls: pendingToolCalls, done: true, stats });
               }
             } else if (event.kind === "warn") {
               appendRow({ kind: "system", id: crypto.randomUUID(), content: `⚠ ${event.data.message}` });
@@ -324,7 +358,7 @@ export function useAIChat(): UseAIChatReturn {
                     return next;
                   });
                 }
-                resolve({ assistantText: fullText, toolCalls: [], done: false });
+                resolve({ assistantText: fullText, toolCalls: [], done: false, stats: {} });
               }
             })
             .catch(reject);
@@ -334,7 +368,7 @@ export function useAIChat(): UseAIChatReturn {
   );
 
   const sendMessage = useCallback(
-    async (content: string, model: string) => {
+    async (content: string, model: string, systemPrompt?: string, modelDetails?: ModelDetails | null) => {
       if (isStreaming) return;
 
       setError(null);
@@ -354,6 +388,8 @@ export function useAIChat(): UseAIChatReturn {
             model,
             createdAt: new Date().toISOString(),
             updatedAt: new Date().toISOString(),
+            systemPrompt: null,
+            contextSourcesJson: null,
           };
           if (mountedRef.current) {
             setCurrentSession(session);
@@ -375,8 +411,9 @@ export function useAIChat(): UseAIChatReturn {
         appendRow({ kind: "thinking", id: thinkingId });
 
         // Build conversation history with system prompt
-        const useTools = modelSupportsTools(model);
-        const systemMsg: AIChatMessage = { role: "system", content: SYSTEM_PROMPT };
+        const useTools = modelSupportsTools(modelDetails);
+        const activeSystemPrompt = systemPrompt ?? SYSTEM_PROMPT;
+        const systemMsg: AIChatMessage = { role: "system", content: activeSystemPrompt };
         const history: AIChatMessage[] = [
           systemMsg,
           ...transcriptRef.current
@@ -390,8 +427,10 @@ export function useAIChat(): UseAIChatReturn {
         let assistantId = crypto.randomUUID();
 
         // ── Multi-turn tool loop ───────────────────────────────────────────
+        setCurrentToolHop(0);
         for (let hop = 0; hop < MAX_TOOL_HOPS; hop++) {
-          const { assistantText, toolCalls, done } = await streamOnce(
+          if (hop > 0 && mountedRef.current) setCurrentToolHop(hop);
+          const { assistantText, toolCalls, done, stats } = await streamOnce(
             model,
             history,
             ollamaTools,
@@ -400,9 +439,14 @@ export function useAIChat(): UseAIChatReturn {
             ""
           );
 
+          if (mountedRef.current) setLastTurnStats(stats);
+
           if (assistantText) {
             history.push({ role: "assistant", content: assistantText, tool_calls: toolCalls.length ? toolCalls : undefined });
-            aiSaveMessage(assistantId, sessionId, "assistant", assistantText).catch((e) =>
+            const metadataJson = Object.keys(stats).length
+              ? JSON.stringify({ model, ...stats })
+              : undefined;
+            aiSaveMessage(assistantId, sessionId, "assistant", assistantText, metadataJson).catch((e) =>
               logAIError("persist assistant message", e)
             );
           }
@@ -521,7 +565,10 @@ export function useAIChat(): UseAIChatReturn {
           approval.resolveAll(false);
         }
       } finally {
-        if (mountedRef.current) setIsStreaming(false);
+        if (mountedRef.current) {
+          setIsStreaming(false);
+          setCurrentToolHop(0);
+        }
       }
     },
     [isStreaming, appendRow, approval, streamOnce]
@@ -532,6 +579,8 @@ export function useAIChat(): UseAIChatReturn {
     currentSession,
     transcript,
     isStreaming,
+    lastTurnStats,
+    currentToolHop,
     error,
     sendMessage,
     cancelStream,

--- a/apps/desktop/src/hooks/useOllama.ts
+++ b/apps/desktop/src/hooks/useOllama.ts
@@ -3,8 +3,13 @@ import { Channel } from "@tauri-apps/api/core";
 import {
   aiCheckOllama,
   aiListModels,
+  aiListRunningModels,
+  aiShowModel,
+  aiGetOllamaVersion,
   aiPullModel,
   type AIModelInfo,
+  type RunningModel,
+  type ModelDetails,
   type DownloadProgress,
 } from "../lib/tauri";
 import { logAIError } from "./ai/logging";
@@ -17,9 +22,13 @@ export interface OllamaState {
   checking: boolean;
   timedOut: boolean;
   models: AIModelInfo[];
+  runningModels: RunningModel[];
+  modelDetails: Record<string, ModelDetails>;
+  version: string | null;
   error: string | null;
   retry: () => void;
   listModels: () => Promise<void>;
+  fetchModelDetails: (name: string) => Promise<ModelDetails | null>;
   pullModel: (model: string, onProgress: (p: DownloadProgress) => void) => Promise<void>;
 }
 
@@ -28,6 +37,9 @@ export function useOllama(): OllamaState {
   const [checking, setChecking] = useState(true);
   const [timedOut, setTimedOut] = useState(false);
   const [models, setModels] = useState<AIModelInfo[]>([]);
+  const [runningModels, setRunningModels] = useState<RunningModel[]>([]);
+  const [modelDetails, setModelDetails] = useState<Record<string, ModelDetails>>({});
+  const [version, setVersion] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const pollCount = useRef(0);
   const mountedRef = useRef(true);
@@ -56,17 +68,26 @@ export function useOllama(): OllamaState {
           setTimedOut(false);
           pollCount.current = 0;
 
-          // Leading edge: only refresh models when Ollama just came up
+          // Always poll running models (changes frequently as models load/unload)
+          aiListRunningModels()
+            .then((m) => { if (mountedRef.current) setRunningModels(m); })
+            .catch(() => {}); // non-fatal — older Ollama versions may not support /api/ps
+
+          // Leading edge: only refresh model list + version when Ollama just came up
           if (!wasRunning) {
             setError(null);
             aiListModels()
               .then((m) => { if (mountedRef.current) setModels(m); })
               .catch((e) => { if (mountedRef.current) { logAIError("listModels", e); setError(String(e)); } });
+            aiGetOllamaVersion()
+              .then((v) => { if (mountedRef.current) setVersion(v); })
+              .catch(() => {}); // non-fatal
           }
         } else {
           prevRunningRef.current = false;
           setRunning(false);
           setChecking(true);
+          setRunningModels([]);
 
           // Transition: Ollama was running, now it's not
           if (wasRunning) {
@@ -83,6 +104,7 @@ export function useOllama(): OllamaState {
         if (!alive || !mountedRef.current) return;
         prevRunningRef.current = false;
         setRunning(false);
+        setRunningModels([]);
         pollCount.current += 1;
         if (pollCount.current >= MAX_POLLS) {
           setTimedOut(true);
@@ -120,6 +142,21 @@ export function useOllama(): OllamaState {
     }
   }, []);
 
+  const fetchModelDetails = useCallback(async (name: string): Promise<ModelDetails | null> => {
+    // Return cached entry if already fetched
+    if (modelDetails[name]) return modelDetails[name];
+    try {
+      const details = await aiShowModel(name);
+      if (mountedRef.current) {
+        setModelDetails((prev) => ({ ...prev, [name]: details }));
+      }
+      return details;
+    } catch (e) {
+      logAIError("showModel", e);
+      return null;
+    }
+  }, [modelDetails]);
+
   const pullModel = useCallback(
     async (model: string, onProgress: (p: DownloadProgress) => void): Promise<void> => {
       const channel = new Channel<DownloadProgress>();
@@ -137,5 +174,18 @@ export function useOllama(): OllamaState {
     [listModels],
   );
 
-  return { running, checking, timedOut, models, error, retry, listModels, pullModel };
+  return {
+    running,
+    checking,
+    timedOut,
+    models,
+    runningModels,
+    modelDetails,
+    version,
+    error,
+    retry,
+    listModels,
+    fetchModelDetails,
+    pullModel,
+  };
 }

--- a/apps/desktop/src/lib/tauri.ts
+++ b/apps/desktop/src/lib/tauri.ts
@@ -654,7 +654,17 @@ export interface AIChatMessage {
 export type StreamEvent =
   | { kind: "text"; data: { content: string } }
   | { kind: "toolCalls"; data: { calls: ToolCall[] } }
-  | { kind: "done"; data: { evalCount?: number; promptEvalCount?: number } }
+  | {
+      kind: "done";
+      data: {
+        evalCount?: number;
+        promptEvalCount?: number;
+        totalDuration?: number;
+        loadDuration?: number;
+        promptEvalDuration?: number;
+        evalDuration?: number;
+      };
+    }
   | { kind: "warn"; data: { message: string } };
 
 export interface DownloadProgress {
@@ -671,6 +681,8 @@ export interface AISessionRow {
   model: string | null;
   createdAt: string;
   updatedAt: string;
+  systemPrompt: string | null;
+  contextSourcesJson: string | null;
 }
 
 export interface AIMessageRow {
@@ -679,6 +691,22 @@ export interface AIMessageRow {
   role: string;
   content: string;
   timestamp: string;
+  metadataJson: string | null;
+}
+
+export interface RunningModel {
+  name: string;
+  sizeVram: number | null;
+  expiresAt: string | null;
+}
+
+export interface ModelDetails {
+  name: string;
+  family: string | null;
+  parameterSize: string | null;
+  quantizationLevel: string | null;
+  capabilities: string[];
+  contextLength: number | null;
 }
 
 export interface AISessionDetail {
@@ -740,8 +768,29 @@ export async function aiSaveMessage(
   sessionId: string,
   role: string,
   content: string,
+  metadataJson?: string,
 ): Promise<void> {
-  return invoke<void>("save_ai_message", { id, sessionId, role, content });
+  return invoke<void>("save_ai_message", { id, sessionId, role, content, metadataJson });
+}
+
+export async function aiUpdateSessionPrompt(
+  id: string,
+  systemPrompt: string | null,
+  contextSourcesJson: string | null,
+): Promise<void> {
+  return invoke<void>("update_ai_session_prompt", { id, systemPrompt, contextSourcesJson });
+}
+
+export async function aiListRunningModels(): Promise<RunningModel[]> {
+  return invoke<RunningModel[]>("list_running_models");
+}
+
+export async function aiShowModel(name: string): Promise<ModelDetails> {
+  return invoke<ModelDetails>("show_model", { name });
+}
+
+export async function aiGetOllamaVersion(): Promise<string> {
+  return invoke<string>("get_ollama_version");
 }
 
 export interface AIConfig {

--- a/apps/desktop/src/pages/ai/AIChatPage.tsx
+++ b/apps/desktop/src/pages/ai/AIChatPage.tsx
@@ -62,6 +62,8 @@ export default function AIChatPage() {
 
   const modelDetails = ollama.modelDetails[selectedModel] ?? null;
 
+  const handlePromptChange = useCallback((p: string) => setSystemPrompt(p || undefined), []);
+
   const handleSend = useCallback(async (content: string) => {
     const model = getModel();
     if (!model) return;
@@ -164,7 +166,7 @@ export default function AIChatPage() {
           {/* System prompt panel — above transcript */}
           <SystemPromptPanel
             sessionId={chat.currentSession?.id ?? null}
-            onPromptChange={(p) => setSystemPrompt(p || undefined)}
+            onPromptChange={handlePromptChange}
           />
 
           {mode === 'styled' ? (

--- a/apps/desktop/src/pages/ai/AIChatPage.tsx
+++ b/apps/desktop/src/pages/ai/AIChatPage.tsx
@@ -5,6 +5,11 @@ import { TranscriptToolbar } from '../../components/ai/terminal/TranscriptToolba
 import { TerminalTranscript } from '../../components/ai/terminal/TerminalTranscript';
 import { TranscriptInput } from '../../components/ai/terminal/TranscriptInput';
 import { SessionList } from '../../components/ai/SessionList';
+import { StatsStrip } from '../../components/ai/StatsStrip';
+import { InspectorPanel } from '../../components/ai/InspectorPanel';
+import { SystemPromptPanel } from '../../components/ai/SystemPromptPanel';
+import { aiGetConfig } from '../../lib/tauri';
+import type { TurnStats } from '../../hooks/useAIChat';
 
 export default function AIChatPage() {
   const ollama = useOllama();
@@ -12,6 +17,14 @@ export default function AIChatPage() {
   const [selectedModel, setSelectedModel] = useState('');
   const [mode, setMode] = useState<'styled' | 'raw'>('styled');
   const [sessionPickerOpen, setSessionPickerOpen] = useState(false);
+  const [inspectorOpen, setInspectorOpen] = useState(false);
+  const [baseUrl, setBaseUrl] = useState('http://localhost:11434');
+  const [systemPrompt, setSystemPrompt] = useState<string | undefined>(undefined);
+
+  // Load runtime base URL once
+  useEffect(() => {
+    aiGetConfig().then((cfg) => setBaseUrl(cfg.baseUrl)).catch(() => {});
+  }, []);
 
   // Seed the model selector once models load
   useEffect(() => {
@@ -23,6 +36,13 @@ export default function AIChatPage() {
       );
     }
   }, [ollama.models, selectedModel]);
+
+  // Fetch model details when selection changes
+  useEffect(() => {
+    if (selectedModel && ollama.running) {
+      ollama.fetchModelDetails(selectedModel).catch(() => {});
+    }
+  }, [selectedModel, ollama.running]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Persist selected model
   const handleModelSelect = useCallback((model: string) => {
@@ -40,11 +60,13 @@ export default function AIChatPage() {
     await chat.createSession(model);
   }, [chat, getModel, ollama.running]);
 
+  const modelDetails = ollama.modelDetails[selectedModel] ?? null;
+
   const handleSend = useCallback(async (content: string) => {
     const model = getModel();
     if (!model) return;
-    await chat.sendMessage(content, model);
-  }, [chat, getModel]);
+    await chat.sendMessage(content, model, systemPrompt, modelDetails);
+  }, [chat, getModel, systemPrompt, modelDetails]);
 
   const handleSelectSession = useCallback(async (id: string) => {
     await chat.loadSession(id);
@@ -97,6 +119,16 @@ export default function AIChatPage() {
     prevTranscriptLenRef.current = current.length;
   }, [chat.transcript]);
 
+  // Derive per-message stats list for InspectorPanel
+  const messageStats: { id: string; stats: TurnStats }[] = chat.transcript
+    .filter((r) => r.kind === 'assistant' && r.stats != null)
+    .map((r) => ({ id: r.id, stats: (r as Extract<typeof r, { kind: 'assistant' }>).stats! }));
+
+  // Cumulative conversation token count for StatsStrip
+  const conversationTokens = messageStats.reduce((s, m) => s + (m.stats.evalCount ?? 0), 0);
+
+  const modelInfo = ollama.models.find((m) => m.name === selectedModel) ?? null;
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden', position: 'relative' }}>
       {/* Toolbar */}
@@ -105,10 +137,17 @@ export default function AIChatPage() {
         selectedModel={selectedModel}
         onModelSelect={handleModelSelect}
         onNew={handleNewChat}
+        baseUrl={baseUrl}
+        version={ollama.version}
+        runningCount={ollama.runningModels.length}
         isStreaming={chat.isStreaming}
         onCancelStream={chat.cancelStream}
         mode={mode}
         onToggleMode={() => setMode((m) => m === 'styled' ? 'raw' : 'styled')}
+        modelDetails={modelDetails}
+        currentToolHop={chat.currentToolHop}
+        inspectorOpen={inspectorOpen}
+        onToggleInspector={() => setInspectorOpen((o) => !o)}
       />
 
       {/* Ollama not running notice */}
@@ -118,25 +157,56 @@ export default function AIChatPage() {
         </div>
       )}
 
-      {/* Transcript area */}
-      {mode === 'styled' ? (
-        <TerminalTranscript
-          transcript={chat.transcript}
-          isStreaming={chat.isStreaming}
-          onApprove={(rowId) => chat.resolveApproval(rowId, true)}
-          onDeny={(rowId) => chat.resolveApproval(rowId, false)}
-        />
-      ) : (
-        <RawView chunks={rawChunksRef.current} outputTick={rawTick} />
-      )}
+      {/* Main content row: transcript + optional inspector */}
+      <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
+        {/* Transcript area */}
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+          {/* System prompt panel — above transcript */}
+          <SystemPromptPanel
+            sessionId={chat.currentSession?.id ?? null}
+            onPromptChange={(p) => setSystemPrompt(p || undefined)}
+          />
 
-      {/* Input */}
-      <TranscriptInput
-        onSend={handleSend}
-        isStreaming={chat.isStreaming}
-        onCancel={chat.cancelStream}
-        disabled={!ollama.running || !selectedModel}
-      />
+          {mode === 'styled' ? (
+            <TerminalTranscript
+              transcript={chat.transcript}
+              isStreaming={chat.isStreaming}
+              onApprove={(rowId) => chat.resolveApproval(rowId, true)}
+              onDeny={(rowId) => chat.resolveApproval(rowId, false)}
+            />
+          ) : (
+            <RawView chunks={rawChunksRef.current} outputTick={rawTick} />
+          )}
+
+          {/* Stats strip */}
+          <StatsStrip
+            model={selectedModel}
+            modelInfo={modelInfo}
+            modelDetails={modelDetails}
+            runningModels={ollama.runningModels}
+            lastTurnStats={chat.lastTurnStats}
+            conversationTokens={conversationTokens}
+          />
+
+          {/* Input */}
+          <TranscriptInput
+            onSend={handleSend}
+            isStreaming={chat.isStreaming}
+            onCancel={chat.cancelStream}
+            disabled={!ollama.running || !selectedModel}
+          />
+        </div>
+
+        {/* Inspector panel */}
+        {inspectorOpen && (
+          <InspectorPanel
+            model={selectedModel}
+            modelDetails={modelDetails}
+            runningModels={ollama.runningModels}
+            messageStats={messageStats}
+          />
+        )}
+      </div>
 
       {/* Session picker overlay (Cmd+K) */}
       {sessionPickerOpen && (


### PR DESCRIPTION
## Summary

Revamps the AI chat feature from a thin Ollama wrapper into an engineer-grade tool. Three coordinated workstreams: (1) surfacing the telemetry Ollama was already emitting but the UI was discarding, (2) widening the tool registry from 5 surfaces to 10 with full harness-kit coverage, and (3) a visible, editable system prompt panel that auto-populates from workspace context so the model starts every session aware of what it's working with.

## Changes

**Workstream 1 — Stats visibility**
- Parse all 4 Ollama timing fields from the done event (`total_duration`, `load_duration`, `prompt_eval_duration`, `eval_duration`) and propagate through the Rust→TS stack to the UI
- New Tauri commands: `list_running_models` (→ `/api/ps`), `show_model` (→ `/api/show`), `get_ollama_version`
- `StatsStrip`: persistent monospace bar showing model · ctx window · disk size · VRAM · cumulative tokens · last-turn tps · latency
- `InspectorPanel`: right-side collapsible panel with active model details (family, quant, capabilities), in-memory models with VRAM + expiry, per-session token chart
- Per-message `[N tok · Xs · N tok/s]` footer on AssistantRow
- `TranscriptToolbar`: capability-driven `tools`/`no tools` pill (replaces prefix allowlist), hop counter during multi-turn loops
- `useOllama`: polls running models every tick, lazy-fetches model details on select, exposes version
- `useAIChat`: computes tokens/sec, attaches `TurnStats` to each row, persists `metadata_json` per message
- DB migration: `system_prompt` + `context_sources_json` columns on `ai_sessions`

**Workstream 2 — Agentic action expansion**
- 6 new handler files: `harness` (read/write config, list profiles), `plugins` (list/uninstall), `mcp` (list/add/remove), `git` (diff/create/remove worktree), `sync` (read/write/backup files), `parity` (run scan)
- `toolRegistry`: imports all 10 handler sets; replaces model-prefix allowlist with `modelSupportsTools(modelDetails)` driven by the capabilities array from `/api/show`; updated system prompt to describe all surfaces

**Workstream 3 — Visible/editable system prompt**
- `contextSources.ts`: 5 async fragment generators (`harnessYaml`, `activeBoardProject`, `currentRoute`, `recentSessions`, `claudeMd`) + `buildSystemPrompt` combinator
- `SystemPromptPanel`: collapsible panel above the transcript; source-toggle chips auto-populate the prompt; editable textarea; Lock/Reset/Clear actions; persists per-session via `update_ai_session_prompt`

## Test Plan
- [x] Local tests pass (695/695, 2 pre-existing unrelated failures in `HarnessFilePage` and `SyncPage` test suites due to `@harness-kit/core` resolution in worktree — not introduced by this PR)
- [x] TypeScript: `pnpm tsc --noEmit` clean
- [ ] CI checks pass
- [ ] Manual: navigate to `/ai-chat`, send a message, confirm StatsStrip shows tps/ctx/size after response
- [ ] Manual: open InspectorPanel, confirm model capabilities/family/quant display
- [ ] Manual: toggle system prompt source chips, confirm prompt textarea updates; lock, send, confirm locked prompt is used
- [ ] Manual: ask "list my installed plugins" — confirm `plugins.list_installed` fires
- [ ] Manual: select a non-tool-capable model — confirm `no tools` pill; select qwen3 — confirm `tools` pill

## Notes

- Tool-capable model detection now uses `/api/show` capabilities array instead of a hardcoded prefix list — any future model Ollama marks as `tools`-capable will automatically get the tool payload without a code change
- `sync.write_files` and `harness.write_config` are `write`-category tools and route through the existing `WriteApprovalRow` approval gate — no change to the approval UX
- `buildSystemPrompt` in `contextSources.ts` fetches all enabled sources in parallel (`Promise.all`) and joins them in declaration order
- The `SystemPromptPanel` is pre-populated on mount using the `harness.yaml` and `route` chips enabled by default; other chips are opt-in