### PR TITLE
feat(homebrew): add nightly build channel

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -174,11 +174,12 @@ jobs:
           git clone "https://x-access-token:${{ secrets.TAP_PAT }}@github.com/harnessprotocol/homebrew-tap.git" tap
           cd tap
 
-          # Copy from repo (harness-kit-nightly.rb) and rename to tap convention (harness-kit@nightly.rb)
-          cp ../homebrew/Formula/harness-kit-nightly.rb "Formula/harness-kit@nightly.rb"
-          sed -i "s/version \"[^\"]*\"/version \"${DATE}\"/" "Formula/harness-kit@nightly.rb"
-          sed -i "s/sha256 \"[^\"]*\"/sha256 \"${CLI_SHA}\"/" "Formula/harness-kit@nightly.rb"
+          # Formula: harness-kit-nightly (no @ -- Homebrew only supports @ with numeric versions)
+          cp ../homebrew/Formula/harness-kit-nightly.rb Formula/harness-kit-nightly.rb
+          sed -i "s/version \"[^\"]*\"/version \"${DATE}\"/" Formula/harness-kit-nightly.rb
+          sed -i "s/sha256 \"[^\"]*\"/sha256 \"${CLI_SHA}\"/" Formula/harness-kit-nightly.rb
 
+          # Cask: harness-kit@nightly (@ works fine for casks)
           cp ../homebrew/Casks/harness-kit-nightly.rb "Casks/harness-kit@nightly.rb"
           sed -i "s/version \"[^\"]*\"/version \"${DATE}\"/" "Casks/harness-kit@nightly.rb"
           awk -v sha="$DMG_SHA" '
@@ -189,7 +190,7 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add "Formula/harness-kit@nightly.rb" "Casks/harness-kit@nightly.rb"
+          git add Formula/harness-kit-nightly.rb "Casks/harness-kit@nightly.rb"
           git commit -m "chore: nightly build $(date +%Y-%m-%d) (${GITHUB_SHA:0:7})"
           git push
         env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,196 @@
+name: Nightly
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: nightly
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-cli-standalone:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build workspace dependencies
+        run: |
+          pnpm --filter @harness-kit/shared build
+          pnpm --filter @harness-kit/core build
+
+      - name: Build standalone bundle
+        working-directory: apps/cli
+        run: pnpm tsup --config tsup.config.standalone.ts
+
+      - name: Create Node SEA blob
+        working-directory: apps/cli
+        run: node --experimental-sea-config sea-config.json
+
+      - name: Inject blob into Node binary
+        working-directory: apps/cli
+        run: |
+          cp "$(which node)" dist/harness-kit
+          codesign --remove-signature dist/harness-kit
+          npx postject dist/harness-kit NODE_SEA_BLOB dist/sea-prep.blob \
+            --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6ac44c7683b9e78a1 \
+            --macho-segment-name NODE_SEA
+          codesign --sign - dist/harness-kit
+
+      - name: Smoke test standalone binary
+        working-directory: apps/cli
+        run: ./dist/harness-kit --version
+
+      - name: Package standalone binary
+        working-directory: apps/cli
+        run: |
+          cp dist/harness-kit harness-kit
+          tar -czf harness-kit-nightly-darwin-arm64.tar.gz harness-kit
+          rm harness-kit
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-standalone-darwin-arm64
+          path: apps/cli/harness-kit-nightly-darwin-arm64.tar.gz
+          retention-days: 1
+
+  build-desktop:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/desktop/src-tauri
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build workspace dependencies
+        run: |
+          pnpm --filter @harness-kit/shared build
+          pnpm --filter @harness-kit/core build
+          pnpm --filter board-server build
+
+      - name: Build desktop app
+        run: pnpm --filter harness-kit-desktop tauri build
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ""
+
+      - name: Locate and rename DMG
+        id: dmg
+        run: |
+          DMG=$(find apps/desktop/src-tauri/target/release/bundle -name "*.dmg" | head -1)
+          if [[ -z "$DMG" ]]; then
+            echo "::error::No .dmg found after tauri build"
+            exit 1
+          fi
+          cp "$DMG" "HarnessKit-nightly-darwin-arm64.dmg"
+          echo "path=HarnessKit-nightly-darwin-arm64.dmg" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-darwin-arm64
+          path: ${{ steps.dmg.outputs.path }}
+          retention-days: 1
+
+  publish:
+    needs: [build-cli-standalone, build-desktop]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download CLI standalone artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: cli-standalone-darwin-arm64
+
+      - name: Download desktop artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: desktop-darwin-arm64
+
+      - name: Compute SHA256 checksums
+        id: sha
+        run: |
+          CLI_SHA=$(sha256sum harness-kit-nightly-darwin-arm64.tar.gz | awk '{print $1}')
+          DMG_SHA=$(sha256sum HarnessKit-nightly-darwin-arm64.dmg | awk '{print $1}')
+          echo "cli_sha=$CLI_SHA" >> "$GITHUB_OUTPUT"
+          echo "dmg_sha=$DMG_SHA" >> "$GITHUB_OUTPUT"
+          echo "date=$(date +%Y%m%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Publish rolling nightly release
+        run: |
+          DATE=$(date +%Y-%m-%d)
+          SHA=${{ github.sha }}
+
+          # Delete existing release and tag so we can recreate clean
+          gh release delete nightly --yes 2>/dev/null || true
+          git push origin :refs/tags/nightly 2>/dev/null || true
+
+          gh release create nightly \
+            --title "Nightly ($DATE)" \
+            --notes "Automated nightly build from \`main\`. Commit: [\`${SHA:0:7}\`](https://github.com/harnessprotocol/harness-kit/commit/$SHA)" \
+            --prerelease \
+            --target main \
+            harness-kit-nightly-darwin-arm64.tar.gz \
+            HarnessKit-nightly-darwin-arm64.dmg
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Update Homebrew tap
+        run: |
+          DATE=${{ steps.sha.outputs.date }}
+          CLI_SHA=${{ steps.sha.outputs.cli_sha }}
+          DMG_SHA=${{ steps.sha.outputs.dmg_sha }}
+
+          git clone "https://x-access-token:${{ secrets.TAP_PAT }}@github.com/harnessprotocol/homebrew-tap.git" tap
+          cd tap
+
+          # Copy from repo (harness-kit-nightly.rb) and rename to tap convention (harness-kit@nightly.rb)
+          cp ../homebrew/Formula/harness-kit-nightly.rb "Formula/harness-kit@nightly.rb"
+          sed -i "s/version \"[^\"]*\"/version \"${DATE}\"/" "Formula/harness-kit@nightly.rb"
+          sed -i "s/sha256 \"[^\"]*\"/sha256 \"${CLI_SHA}\"/" "Formula/harness-kit@nightly.rb"
+
+          cp ../homebrew/Casks/harness-kit-nightly.rb "Casks/harness-kit@nightly.rb"
+          sed -i "s/version \"[^\"]*\"/version \"${DATE}\"/" "Casks/harness-kit@nightly.rb"
+          awk -v sha="$DMG_SHA" '
+            /^  sha256 "/ && !replaced { sub(/"[^"]*"/, "\"" sha "\""); replaced=1 }
+            { print }
+          ' "Casks/harness-kit@nightly.rb" > "Casks/harness-kit@nightly.rb.tmp"
+          mv "Casks/harness-kit@nightly.rb.tmp" "Casks/harness-kit@nightly.rb"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "Formula/harness-kit@nightly.rb" "Casks/harness-kit@nightly.rb"
+          git commit -m "chore: nightly build $(date +%Y-%m-%d) (${GITHUB_SHA:0:7})"
+          git push
+        env:
+          GITHUB_SHA: ${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ brew install --cask harness-kit
 Or download the `.dmg` directly from the [latest release](https://github.com/harnessprotocol/harness-kit/releases/latest) and drag **Harness Kit.app** to `/Applications`. Note: the app is not notarized — right-click and select **Open** on first launch.
 
 <details>
+<summary>Nightly builds (latest main, rebuilt daily — may be unstable)</summary>
+
+```bash
+brew tap harnessprotocol/tap  # skip if already added
+brew install harnessprotocol/tap/harness-kit-nightly          # CLI nightly
+brew install --cask harnessprotocol/tap/'harness-kit@nightly' # desktop nightly
+```
+
+Nightly builds track the tip of `main` and are rebuilt every day at midnight UTC. Use them to get the latest features before a stable release — at the cost of stability guarantees.
+</details>
+
+<details>
 <summary>Fallback: install skills with script (no Node required)</summary>
 
 If your Claude Code build doesn't support the plugin marketplace:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Or download the `.dmg` directly from the [latest release](https://github.com/har
 
 ```bash
 brew tap harnessprotocol/tap  # skip if already added
-brew install harnessprotocol/tap/harness-kit-nightly          # CLI nightly
+brew install harnessprotocol/tap/harness-kit-nightly          # CLI nightly → installs as harness-kit-nightly
 brew install --cask harnessprotocol/tap/'harness-kit@nightly' # desktop nightly
 ```
 

--- a/homebrew/Casks/harness-kit-nightly.rb
+++ b/homebrew/Casks/harness-kit-nightly.rb
@@ -1,0 +1,23 @@
+cask "harness-kit@nightly" do
+  version "00000000"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+
+  url "https://github.com/harnessprotocol/harness-kit/releases/download/nightly/HarnessKit-nightly-darwin-arm64.dmg"
+  name "Harness Kit (Nightly)"
+  desc "Desktop app for managing AI coding tool configurations (nightly build)"
+  homepage "https://github.com/harnessprotocol/harness-kit"
+
+  app "Harness Kit.app"
+
+  caveats <<~EOS
+    This is a nightly build from main. Expect rough edges.
+    This app is not notarized. After installing, run:
+      xattr -cr "/Applications/Harness Kit.app"
+    Or right-click the app and select Open.
+  EOS
+
+  zap trash: [
+    "~/Library/Application Support/com.harnesskit.desktop",
+    "~/Library/Caches/com.harnesskit.desktop",
+  ]
+end

--- a/homebrew/Formula/harness-kit-nightly.rb
+++ b/homebrew/Formula/harness-kit-nightly.rb
@@ -1,0 +1,17 @@
+class HarnessKitATNightly < Formula
+  desc "Compile and validate harness.yaml for AI coding tools (nightly)"
+  homepage "https://github.com/harnessprotocol/harness-kit"
+  url "https://github.com/harnessprotocol/harness-kit/releases/download/nightly/harness-kit-nightly-darwin-arm64.tar.gz"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+  version "00000000"
+
+  depends_on arch: :arm64
+
+  def install
+    bin.install "harness-kit"
+  end
+
+  test do
+    system bin/"harness-kit", "--version"
+  end
+end

--- a/homebrew/Formula/harness-kit-nightly.rb
+++ b/homebrew/Formula/harness-kit-nightly.rb
@@ -8,7 +8,7 @@ class HarnessKitNightly < Formula
   depends_on arch: :arm64
 
   def install
-    bin.install "harness-kit"
+    bin.install "harness-kit" => "harness-kit-nightly"
   end
 
   test do

--- a/homebrew/Formula/harness-kit-nightly.rb
+++ b/homebrew/Formula/harness-kit-nightly.rb
@@ -1,4 +1,4 @@
-class HarnessKitATNightly < Formula
+class HarnessKitNightly < Formula
   desc "Compile and validate harness.yaml for AI coding tools (nightly)"
   homepage "https://github.com/harnessprotocol/harness-kit"
   url "https://github.com/harnessprotocol/harness-kit/releases/download/nightly/harness-kit-nightly-darwin-arm64.tar.gz"

--- a/website/content/docs/getting-started/installation.mdx
+++ b/website/content/docs/getting-started/installation.mdx
@@ -10,7 +10,7 @@ description: Three ways to install harness-kit — pick what fits your workflow.
 
 The full harness-kit experience. Observatory, Memory, Board, and AI Chat — all in one native app with a visual interface for managing your AI tool configurations.
 
-<Tabs items={["Homebrew", "DMG"]}>
+<Tabs items={["Homebrew", "DMG", "Nightly"]}>
 <Tab value="Homebrew">
 <Steps>
 <Step>
@@ -63,6 +63,39 @@ xattr -cr "/Applications/Harness Kit.app"
 **Launch from Applications or Spotlight**
 </Step>
 </Steps>
+</Tab>
+
+<Tab value="Nightly">
+<Steps>
+<Step>
+**Install the nightly build**
+
+Rebuilt daily from `main`. Use this to get the latest features before a stable release.
+
+```bash
+brew tap harnessprotocol/tap
+brew install --cask harnessprotocol/tap/'harness-kit@nightly'
+```
+</Step>
+<Step>
+**Clear the quarantine flag**
+
+```bash
+xattr -cr "/Applications/Harness Kit.app"
+```
+</Step>
+<Step>
+**To switch back to stable**
+
+```bash
+brew uninstall --cask harnessprotocol/tap/'harness-kit@nightly'
+brew install --cask harnessprotocol/tap/harness-kit
+```
+</Step>
+</Steps>
+<Callout type="warn" title="Nightly builds may be unstable">
+  These are unversioned builds from the tip of `main`. Rebuilt every day at midnight UTC. Data formats and APIs may change without notice.
+</Callout>
 </Tab>
 </Tabs>
 
@@ -126,7 +159,7 @@ This copies skill files to `~/.claude/skills/` over HTTPS. Bundled scripts (like
 
 Compile `harness.yaml`, sync plugins, detect drift — from the terminal.
 
-<Tabs items={["Homebrew", "npm", "Binary"]}>
+<Tabs items={["Homebrew", "npm", "Binary", "Nightly"]}>
 <Tab value="Homebrew">
 ```bash
 brew tap harnessprotocol/tap
@@ -150,6 +183,15 @@ tar -xzf harness-darwin-arm64.tar.gz
 chmod +x harness
 sudo mv harness /usr/local/bin/
 ```
+</Tab>
+
+<Tab value="Nightly">
+```bash
+brew tap harnessprotocol/tap
+brew install harnessprotocol/tap/harness-kit-nightly
+```
+
+Latest build from `main`. Rebuilt daily at midnight UTC. Installs as `harness-kit` binary.
 </Tab>
 </Tabs>
 

--- a/website/content/docs/getting-started/installation.mdx
+++ b/website/content/docs/getting-started/installation.mdx
@@ -85,6 +85,11 @@ xattr -cr "/Applications/Harness Kit.app"
 ```
 </Step>
 <Step>
+**Launch from Applications or Spotlight**
+
+Search `Harness Kit` or open from `/Applications/Harness Kit.app`.
+</Step>
+<Step>
 **To switch back to stable**
 
 ```bash

--- a/website/content/docs/getting-started/installation.mdx
+++ b/website/content/docs/getting-started/installation.mdx
@@ -191,7 +191,7 @@ brew tap harnessprotocol/tap
 brew install harnessprotocol/tap/harness-kit-nightly
 ```
 
-Latest build from `main`. Rebuilt daily at midnight UTC. Installs as `harness-kit` binary.
+Latest build from `main`. Rebuilt daily at midnight UTC. Installs as `harness-kit-nightly` — no conflict with the stable `harness-kit` binary.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
## Summary

- Adds a nightly Homebrew channel rebuilt daily at midnight UTC from `main`
- **Desktop (cask):** `brew install --cask harnessprotocol/tap/'harness-kit@nightly'`
- **CLI (formula):** `brew install harnessprotocol/tap/harness-kit-nightly`

## What's included

- `.github/workflows/nightly.yml` — cron workflow that builds CLI + desktop on `macos-14`, publishes a rolling `nightly` pre-release tag, and pushes updated formula/cask to the tap with today's date as version (`YYYYMMDD`) and fresh sha256
- `homebrew/Formula/harness-kit-nightly.rb` + `homebrew/Casks/harness-kit-nightly.rb` — source-of-truth stubs; CI copies these to the tap on each run
- README + installation docs updated with nightly install commands

## Homebrew `@nightly` naming note

The `@nightly` convention works for casks but not formulae — Homebrew's class-name algorithm produces `HarnessKit@nightly` (with a literal `@`) for string-suffix variants, which isn't valid Ruby. Numeric versions like `@3.11` work because they produce `HarnessKitAT311`. The formula is therefore named `harness-kit-nightly` in the tap.

## Testing

The `workflow_dispatch` trigger requires the workflow to exist on `main` — it can't be fired from a feature branch. First live run will happen automatically the night after merge, or can be triggered manually from the Actions tab once merged.

Tap state is verified locally:
```
Formula/harness-kit-nightly.rb   ✓
Casks/harness-kit@nightly.rb     ✓
brew info harnessprotocol/tap/harness-kit-nightly        → stable 00000000
brew info --cask harnessprotocol/tap/harness-kit@nightly → 00000000
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)