### PR TITLE
docs: agent execution system, board/roadmap overhaul, demo Q&A

### DIFF
--- a/website/app/docs/[[...slug]]/page.tsx
+++ b/website/app/docs/[[...slug]]/page.tsx
@@ -15,6 +15,7 @@ import { MarkdownViewer } from '@/components/markdown-viewer';
 import { AgentSkillBanner } from '@/components/agent-skill-banner';
 import { InstallMethodCards } from '@/components/install-method-cards';
 import { ArchitectureDiagram } from '@/components/architecture-diagram';
+import { AgentExecutionDiagram } from '@/components/agent-execution-diagram';
 
 const mdxComponents = {
   ...defaultMdxComponents,
@@ -28,6 +29,7 @@ const mdxComponents = {
   MarkdownViewer,
   InstallMethodCards,
   ArchitectureDiagram,
+  AgentExecutionDiagram,
 };
 
 export default async function Page(props: {

--- a/website/components/agent-execution-diagram.tsx
+++ b/website/components/agent-execution-diagram.tsx
@@ -1,0 +1,393 @@
+// Agent execution runtime diagram — "Agentic Task Execution" concepts page.
+// Data sourced from packages/agent-server/src/{http,ws,runner,types}.ts and
+// packages/board-server/src/http/routes.ts. Keep in sync if ports or paths change.
+
+const FONT = 'system-ui, -apple-system, sans-serif';
+const MONO = 'Menlo, Monaco, Consolas, monospace';
+const CYAN = '#22b1ec';
+const CYAN_DIM = 'rgba(34,177,236,0.18)';
+const AMBER = '#f59e0b';
+const AMBER_DIM = 'rgba(245,158,11,0.18)';
+const EMERALD = '#34d399';
+const EMERALD_DIM = 'rgba(52,211,153,0.18)';
+const SURFACE = '#0d1016';
+const SURFACE_MID = '#111827';
+const BORDER = 'rgba(255,255,255,0.09)';
+const BORDER_MID = 'rgba(255,255,255,0.14)';
+const MUTED = '#8b919e';
+const SUBTLE = '#4a5060';
+
+// Five phases in order — sourced from graph.ts
+const PHASES = [
+  { label: 'spec',     color: '#6B7FA0' },
+  { label: 'planning', color: AMBER },
+  { label: 'coding',   color: CYAN },
+  { label: 'qa review',color: EMERALD },
+  { label: 'qa fix',   color: '#fb923c' },
+];
+
+export function AgentExecutionDiagram() {
+  const W = 780;
+
+  // ── Boxes ────────────────────────────────────────────────────────────────────
+  const DC  = { x: 20,  y: 30,  w: 310, h: 95 };   // Desktop Card
+  const AS  = { x: 450, y: 30,  w: 310, h: 95 };   // agent-server :4802
+  const TOK = { x: 450, y: 142, w: 310, h: 26 };   // auth token badge
+  const LG  = { x: 20,  y: 188, w: 740, h: 148 };  // LangGraph runtime
+  const CP  = { x: 20,  y: 352, w: 220, h: 26 };   // SQLite checkpoint
+  const WT  = { x: 20,  y: 396, w: 310, h: 82 };   // worktree
+  const BS  = { x: 450, y: 396, w: 310, h: 82 };   // board-server :4800
+
+  const totalH = WT.y + WT.h + 20;   // 498
+
+  // ── Arrow helper midpoints ───────────────────────────────────────────────────
+  const dcRightX  = DC.x + DC.w;           // 330
+  const asLeftX   = AS.x;                   // 450
+  const midGapX   = (dcRightX + asLeftX) / 2;  // 390 — gap between DC and AS
+
+  const lgMidX   = LG.x + LG.w / 2;       // 390
+  const asMidX   = AS.x + AS.w / 2;        // 605
+  const asBotY   = AS.y + AS.h;            // 125
+
+  const dcMidY   = DC.y + DC.h / 2;        // 77.5
+  const asMidY   = AS.y + AS.h / 2;        // 77.5
+
+  const lgBotY   = LG.y + LG.h;            // 336
+  const wtMidX   = WT.x + WT.w / 2;        // 175
+  const bsMidX   = BS.x + BS.w / 2;        // 605
+  const wtTopY   = WT.y;                    // 396
+  const bsTopY   = BS.y;                    // 396
+
+  return (
+    <div className="not-prose my-8">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox={`0 0 ${W} ${totalH}`}
+        style={{ width: '100%', display: 'block' }}
+        aria-label="Agent execution runtime: Desktop Card sends HTTP POST to agent-server, which runs a LangGraph pipeline (spec, planning, coding, QA). The pipeline reads/writes the worktree via fs-tools and updates the board via board MCP tools. Events stream back to the card via WebSocket."
+      >
+        <defs>
+          <marker id="aed-arr-cyan" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+            <polygon points="0 0,8 3,0 6" fill={CYAN} />
+          </marker>
+          <marker id="aed-arr-amber" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+            <polygon points="0 0,8 3,0 6" fill={AMBER} />
+          </marker>
+          <marker id="aed-arr-emerald" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+            <polygon points="0 0,8 3,0 6" fill={EMERALD} />
+          </marker>
+          <marker id="aed-arr-subtle" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+            <polygon points="0 0,8 3,0 6" fill={SUBTLE} opacity="0.7" />
+          </marker>
+        </defs>
+
+        {/* ══════════════════════════════════════════════════════════════════════
+            Desktop Card (Board UI)
+        ══════════════════════════════════════════════════════════════════════ */}
+        <rect x={DC.x} y={DC.y} width={DC.w} height={DC.h} rx={10}
+          fill={SURFACE_MID} stroke={CYAN} strokeWidth={1.5} />
+
+        <text x={DC.x + DC.w / 2} y={DC.y + 18}
+          fontFamily={FONT} fontSize={8} fontWeight={700} letterSpacing="0.1em"
+          fill={SUBTLE} textAnchor="middle">
+          DESKTOP — BOARD CARD
+        </text>
+
+        {/* Phase progress badge mockup */}
+        {[
+          { label: '● Coding',  prog: 65, color: CYAN },
+          { label: 'subtask 3/8 in progress', prog: null, color: MUTED },
+        ].map((row, i) => (
+          <text key={row.label}
+            x={DC.x + 14} y={DC.y + 40 + i * 18}
+            fontFamily={MONO} fontSize={9}
+            fill={row.color}>
+            {row.label}
+          </text>
+        ))}
+
+        {/* Mini progress bar */}
+        <rect x={DC.x + 14} y={DC.y + 68} width={DC.w - 28} height={4} rx={2}
+          fill={SURFACE} />
+        <rect x={DC.x + 14} y={DC.y + 68} width={(DC.w - 28) * 0.65} height={4} rx={2}
+          fill={CYAN} opacity={0.8} />
+
+        {/* Controls row */}
+        {['Start', 'Pause', 'Steer'].map((label, i) => (
+          <g key={label}>
+            <rect x={DC.x + 14 + i * 70} y={DC.y + 78} width={62} height={16} rx={3}
+              fill={SURFACE} stroke={BORDER_MID} />
+            <text x={DC.x + 14 + i * 70 + 31} y={DC.y + 89}
+              fontFamily={FONT} fontSize={8} fill={MUTED} textAnchor="middle">
+              {label}
+            </text>
+          </g>
+        ))}
+
+        {/* ══════════════════════════════════════════════════════════════════════
+            agent-server :4802
+        ══════════════════════════════════════════════════════════════════════ */}
+        <rect x={AS.x} y={AS.y} width={AS.w} height={AS.h} rx={10}
+          fill={SURFACE_MID} stroke={AMBER_DIM} strokeWidth={1.5} />
+
+        <text x={AS.x + AS.w / 2} y={AS.y + 18}
+          fontFamily={FONT} fontSize={8} fontWeight={700} letterSpacing="0.1em"
+          fill={SUBTLE} textAnchor="middle">
+          AGENT-SERVER
+        </text>
+
+        <text x={AS.x + AS.w / 2} y={AS.y + 36}
+          fontFamily={MONO} fontSize={11} fontWeight={700}
+          fill={AMBER} textAnchor="middle">
+          :4802
+        </text>
+
+        {/* Route chips */}
+        {[
+          'POST /projects/:slug/tasks/:id/start',
+          'POST /…/pause   POST /…/resume',
+          'POST /…/steer   GET  /…/status',
+        ].map((route, i) => (
+          <text key={route}
+            x={AS.x + AS.w / 2} y={AS.y + 54 + i * 14}
+            fontFamily={MONO} fontSize={7.5} fill={SUBTLE} textAnchor="middle">
+            {route}
+          </text>
+        ))}
+
+        {/* ── Auth token badge ── */}
+        <rect x={TOK.x} y={TOK.y} width={TOK.w} height={TOK.h} rx={5}
+          fill={SURFACE} stroke={BORDER} />
+        <text x={TOK.x + 10} y={TOK.y + 17}
+          fontFamily={MONO} fontSize={8.5} fill={SUBTLE}>
+          🔑  ~/.harness-kit/agent-server.token  (0600)
+        </text>
+
+        {/* ══════════════════════════════════════════════════════════════════════
+            HTTP arrow: Card → agent-server
+        ══════════════════════════════════════════════════════════════════════ */}
+        <line
+          x1={dcRightX} y1={DC.y + 38}
+          x2={asLeftX}  y2={AS.y + 38}
+          stroke={CYAN} strokeWidth={1.5} markerEnd="url(#aed-arr-cyan)" />
+        <text x={midGapX} y={DC.y + 33}
+          fontFamily={FONT} fontSize={8.5} fontWeight={600}
+          fill={CYAN} textAnchor="middle">
+          POST /start
+        </text>
+
+        {/* WebSocket arrow: agent-server → Card */}
+        <line
+          x1={asLeftX}  y1={AS.y + 62}
+          x2={dcRightX} y2={DC.y + 62}
+          stroke={EMERALD} strokeWidth={1.5} markerEnd="url(#aed-arr-emerald)" />
+        <text x={midGapX} y={AS.y + 58}
+          fontFamily={FONT} fontSize={8} fontWeight={600}
+          fill={EMERALD} textAnchor="middle">
+          WS events
+        </text>
+        <text x={midGapX} y={AS.y + 70}
+          fontFamily={MONO} fontSize={7} fill={SUBTLE} textAnchor="middle">
+          agent_phase · agent_thought · agent_tool
+        </text>
+
+        {/* "runs" arrow: agent-server → LangGraph */}
+        <line
+          x1={asMidX} y1={asBotY}
+          x2={lgMidX} y2={LG.y}
+          stroke={AMBER} strokeWidth={1.5} markerEnd="url(#aed-arr-amber)" opacity={0.8} />
+        <text x={lgMidX + 58} y={(asBotY + LG.y) / 2 + 4}
+          fontFamily={FONT} fontSize={9} fontWeight={600}
+          fill={AMBER} textAnchor="middle" opacity={0.9}>
+          runs pipeline
+        </text>
+
+        {/* ══════════════════════════════════════════════════════════════════════
+            LangGraph Runtime
+        ══════════════════════════════════════════════════════════════════════ */}
+        <rect x={LG.x} y={LG.y} width={LG.w} height={LG.h} rx={10}
+          fill={SURFACE} stroke={AMBER_DIM} strokeWidth={1.5} />
+
+        <text x={LG.x + LG.w / 2} y={LG.y + 18}
+          fontFamily={FONT} fontSize={8} fontWeight={700} letterSpacing="0.1em"
+          fill={SUBTLE} textAnchor="middle">
+          LANGGRAPH RUNTIME — five-phase state graph
+        </text>
+
+        {/* Phase chips */}
+        {(() => {
+          const chipW = 130;
+          const chipH = 30;
+          const gap   = 8;
+          const totalChipW = PHASES.length * chipW + (PHASES.length - 1) * gap;
+          const startX = LG.x + (LG.w - totalChipW) / 2;
+          const chipY  = LG.y + 34;
+
+          return (
+            <g>
+              {PHASES.map((ph, i) => {
+                const cx = startX + i * (chipW + gap);
+                return (
+                  <g key={ph.label}>
+                    <rect x={cx} y={chipY} width={chipW} height={chipH} rx={5}
+                      fill={SURFACE_MID} stroke={ph.color} strokeWidth={1} opacity={0.9} />
+                    <text x={cx + chipW / 2} y={chipY + 19}
+                      fontFamily={MONO} fontSize={10} fontWeight={600}
+                      fill={ph.color} textAnchor="middle">
+                      {ph.label}
+                    </text>
+                  </g>
+                );
+              })}
+
+              {/* Arrows between chips */}
+              {PHASES.slice(0, -1).map((ph, i) => {
+                const x1 = startX + (i + 1) * (chipW + gap) - gap;
+                const y1 = chipY + chipH / 2;
+                const x2 = startX + (i + 1) * (chipW + gap);
+                return (
+                  <line key={`arr-${i}`}
+                    x1={x1} y1={y1} x2={x2} y2={y1}
+                    stroke={SUBTLE} strokeWidth={1}
+                    markerEnd="url(#aed-arr-subtle)" />
+                );
+              })}
+
+              {/* QA retry arc: qa_fix → coding (curved arrow back) */}
+              {(() => {
+                const qaFixIdx = 4;  // qa_fix
+                const codingIdx = 2; // coding
+                const qaFixX = startX + qaFixIdx * (chipW + gap);
+                const codingX = startX + codingIdx * (chipW + gap);
+                const arcY = chipY + chipH + 14;
+                return (
+                  <path
+                    d={`M${qaFixX + chipW / 2},${chipY + chipH} Q${(qaFixX + codingX + chipW) / 2},${arcY + 18} ${codingX + chipW / 2},${chipY + chipH}`}
+                    fill="none" stroke="#fb923c" strokeWidth={1} strokeDasharray="4 3"
+                    markerEnd="url(#aed-arr-subtle)" opacity={0.7} />
+                );
+              })()}
+
+              {/* qa_fix ← qa_review: back-arrow */}
+              {(() => {
+                const qaRevIdx = 3;
+                const qaFixIdx = 4;
+                const x1 = startX + qaRevIdx * (chipW + gap) + chipW;
+                const x2 = startX + qaFixIdx * (chipW + gap);
+                const y1 = chipY + chipH * 0.4;
+                return null; // covered by forward arrows; skip duplicate
+              })()}
+            </g>
+          );
+        })()}
+
+        {/* Retry label */}
+        <text x={LG.x + LG.w / 2} y={LG.y + LG.h - 22}
+          fontFamily={FONT} fontSize={8} fill={SUBTLE} textAnchor="middle">
+          QA fail → retry coding (max 3 attempts), then surface to human
+        </text>
+
+        {/* Tools row */}
+        {[
+          { label: 'fs-tools: read_file · write_file · edit_file · bash', color: CYAN },
+          { label: 'board MCP tools via board-server :4800/mcp', color: AMBER },
+        ].map((row, i) => (
+          <text key={row.label}
+            x={LG.x + 14} y={LG.y + 112 + i * 14}
+            fontFamily={MONO} fontSize={8}
+            fill={row.color} opacity={0.8}>
+            {row.label}
+          </text>
+        ))}
+
+        {/* SQLite checkpoint badge */}
+        <rect x={CP.x} y={CP.y} width={CP.w} height={CP.h} rx={5}
+          fill={SURFACE} stroke={BORDER} />
+        <text x={CP.x + 10} y={CP.y + 17}
+          fontFamily={MONO} fontSize={8} fill={SUBTLE}>
+          💾  SQLite checkpoint (pause/resume)
+        </text>
+
+        {/* ── Arrow: LangGraph → worktree ── */}
+        <line
+          x1={LG.x + 155} y1={lgBotY}
+          x2={wtMidX}      y2={wtTopY}
+          stroke={CYAN} strokeWidth={1.5} markerEnd="url(#aed-arr-cyan)" opacity={0.8} />
+        <text x={wtMidX - 12} y={(lgBotY + wtTopY) / 2 + 4}
+          fontFamily={FONT} fontSize={8.5} fontWeight={600}
+          fill={CYAN} textAnchor="end" opacity={0.9}>
+          fs-tools
+        </text>
+
+        {/* ── Arrow: LangGraph → board-server ── */}
+        <line
+          x1={LG.x + LG.w - 155} y1={lgBotY}
+          x2={bsMidX}              y2={bsTopY}
+          stroke={AMBER} strokeWidth={1.5} markerEnd="url(#aed-arr-amber)" opacity={0.8} />
+        <text x={bsMidX + 14} y={(lgBotY + bsTopY) / 2 + 4}
+          fontFamily={FONT} fontSize={8.5} fontWeight={600}
+          fill={AMBER} textAnchor="start" opacity={0.9}>
+          board MCP
+        </text>
+
+        {/* ══════════════════════════════════════════════════════════════════════
+            Worktree
+        ══════════════════════════════════════════════════════════════════════ */}
+        <rect x={WT.x} y={WT.y} width={WT.w} height={WT.h} rx={10}
+          fill={SURFACE_MID} stroke={CYAN_DIM} strokeWidth={1} />
+
+        <text x={WT.x + WT.w / 2} y={WT.y + 18}
+          fontFamily={FONT} fontSize={8} fontWeight={700} letterSpacing="0.1em"
+          fill={SUBTLE} textAnchor="middle">
+          WORKTREE
+        </text>
+
+        {[
+          'git worktree add .worktrees/<task-id>',
+          'isolated branch per task · files scoped here',
+        ].map((line, i) => (
+          <text key={line}
+            x={WT.x + WT.w / 2} y={WT.y + 36 + i * 16}
+            fontFamily={MONO} fontSize={8} fill={SUBTLE} textAnchor="middle">
+            {line}
+          </text>
+        ))}
+
+        <text x={WT.x + WT.w / 2} y={WT.y + 68}
+          fontFamily={FONT} fontSize={8} fill={MUTED} textAnchor="middle">
+          read/write/bash confined to worktree_path
+        </text>
+
+        {/* ══════════════════════════════════════════════════════════════════════
+            board-server :4800
+        ══════════════════════════════════════════════════════════════════════ */}
+        <rect x={BS.x} y={BS.y} width={BS.w} height={BS.h} rx={10}
+          fill={SURFACE_MID} stroke={AMBER_DIM} strokeWidth={1} />
+
+        <text x={BS.x + BS.w / 2} y={BS.y + 18}
+          fontFamily={FONT} fontSize={8} fontWeight={700} letterSpacing="0.1em"
+          fill={SUBTLE} textAnchor="middle">
+          BOARD-SERVER
+        </text>
+
+        <text x={BS.x + BS.w / 2} y={BS.y + 36}
+          fontFamily={MONO} fontSize={11} fontWeight={700}
+          fill={AMBER} textAnchor="middle">
+          :4800
+        </text>
+
+        {[
+          'subtask writes during planning · status updates',
+          'PATCH /execution ← agent-server (done/fail)',
+        ].map((line, i) => (
+          <text key={line}
+            x={BS.x + BS.w / 2} y={BS.y + 52 + i * 14}
+            fontFamily={MONO} fontSize={7.5} fill={SUBTLE} textAnchor="middle">
+            {line}
+          </text>
+        ))}
+
+      </svg>
+    </div>
+  );
+}

--- a/website/components/agent-execution-diagram.tsx
+++ b/website/components/agent-execution-diagram.tsx
@@ -160,7 +160,7 @@ export function AgentExecutionDiagram() {
           fill={SURFACE} stroke={BORDER} />
         <text x={TOK.x + 10} y={TOK.y + 17}
           fontFamily={MONO} fontSize={8.5} fill={SUBTLE}>
-          🔑  ~/.harness-kit/agent-server.token  (0600)
+          ~/.harness-kit/agent-server.token (mode 0600)
         </text>
 
         {/* ══════════════════════════════════════════════════════════════════════
@@ -268,15 +268,6 @@ export function AgentExecutionDiagram() {
                 );
               })()}
 
-              {/* qa_fix ← qa_review: back-arrow */}
-              {(() => {
-                const qaRevIdx = 3;
-                const qaFixIdx = 4;
-                const x1 = startX + qaRevIdx * (chipW + gap) + chipW;
-                const x2 = startX + qaFixIdx * (chipW + gap);
-                const y1 = chipY + chipH * 0.4;
-                return null; // covered by forward arrows; skip duplicate
-              })()}
             </g>
           );
         })()}
@@ -305,7 +296,7 @@ export function AgentExecutionDiagram() {
           fill={SURFACE} stroke={BORDER} />
         <text x={CP.x + 10} y={CP.y + 17}
           fontFamily={MONO} fontSize={8} fill={SUBTLE}>
-          💾  SQLite checkpoint (pause/resume)
+          SQLite checkpoint — pause/resume state
         </text>
 
         {/* ── Arrow: LangGraph → worktree ── */}

--- a/website/content/docs/apps/board.md
+++ b/website/content/docs/apps/board.md
@@ -111,10 +111,10 @@ While an agent is running, the card shows:
 | Control | Behavior |
 |---------|----------|
 | **Start** | Begins a new agent run from the spec phase |
-| **Stop** | Cancels immediately; no checkpoint saved |
-| **Pause** | Aborts the running graph; SQLite checkpoint preserves state |
+| **Stop** | Terminates the run permanently; cannot be resumed. Completed phases remain checkpointed but the run is abandoned. |
+| **Pause** | Aborts the running graph; SQLite checkpoint preserves state for later resumption |
 | **Resume** | Re-streams from the last checkpoint; no re-running of completed phases |
-| **Steer** | Injects a free-text instruction into the paused run; picked up on resume |
+| **Steer** | Injects a free-text instruction and immediately resumes — steer is steer + resume in one operation; no separate Resume call needed |
 
 You must pause before steering. The steer endpoint rejects requests while the
 graph is active.

--- a/website/content/docs/apps/board.md
+++ b/website/content/docs/apps/board.md
@@ -4,32 +4,42 @@ title: Board
 
 # Board
 
-The Board is a Kanban task manager built for AI-first workflows. Tasks live on a server
-that runs inside the desktop app, so your board is always local and available without
-a cloud account.
+The Board is a Kanban task manager built for AI-first workflows. Tasks live in
+a YAML file on your machine, served by a local HTTP and WebSocket server. No
+cloud account, no sync service — the board is always available and fully
+offline.
+
+The Board is also the control surface for the **agent execution engine**: each
+card can be handed to an autonomous AI agent that works through the task in
+five structured phases and streams live progress back to the card in real time.
 
 ## Projects and Epics
 
-Tasks are organized into projects. Each project contains epics — named groups that map
-to larger themes or milestones. When you have two or more projects, a tab bar appears
-at the top of the board so you can switch between them without leaving the view.
+Tasks are organized into projects. Each project contains epics — named groups
+that map to larger themes or milestones. When you have two or more projects, a
+tab bar appears at the top of the board so you can switch between them.
 
-Epics have a status (`active` or `archived`). Only active epics appear in the task
-creation form by default, keeping the list focused.
+Epics have a status (`active`, `completed`, or `archived`). Only active epics
+appear in the task creation form by default.
 
 ## Columns
 
-The board uses six columns that reflect the full lifecycle of a task:
+The board uses six columns that reflect the full AI-native task lifecycle:
 
-- **Backlog** — ideas and future work (collapsed by default)
-- **Planning** — tasks being scoped or designed
-- **In Progress** — actively being worked on
-- **Review** — ready for human or agent review
-- **Done** — completed
-- **Blocked** — stalled, waiting on something external
+| Column | Meaning |
+|--------|---------|
+| **Backlog** | Ideas and future work (collapsed by default) |
+| **Planning** | Tasks being scoped, designed, or assigned |
+| **In Progress** | Actively being worked on |
+| **AI Review** | Agent has finished — ready for automated review |
+| **Human Review** | Waiting for a person to sign off |
+| **Done** | Complete |
 
-Column collapsed state is persisted to localStorage. Dragging a task onto a collapsed
-column expands it automatically.
+A seventh visual state, **Blocked**, can be set on any task regardless of
+column — the card renders a red badge and an optional reason string.
+
+Column collapsed state persists to localStorage. Dragging a task onto a
+collapsed column expands it automatically.
 
 ## Views
 
@@ -42,28 +52,120 @@ The selected view is saved and restored on next open.
 
 ## Drag and Drop
 
-Drag any task card to move it to a different column. You can drop onto the column
-header, onto the empty space within a column, or onto another card. The board resolves
-the target status from whichever droppable element you land on.
+Drag any task card to move it to a different column. You can drop onto the
+column header, onto the empty space within a column, or onto another card. The
+board resolves the target status from whichever droppable element you land on.
 
 ## Task Detail
 
-Click any card to open the task detail panel. From there you can edit the title,
-description, status, and epic assignment, and see linked GitHub issues if the project
-has a `repo_url` configured.
+Click any card to open the task detail panel. From there you can:
+
+- Edit title, description, status, and epic assignment
+- Set priority, category, and complexity
+- See linked GitHub issues (requires `repo_url` on the project)
+- View agent execution state, subtask progress, and the thought/tool event log
+- Start, pause, resume, or steer an agent run
 
 ## Agent Execution
 
-Tasks can be handed off to an agent. The board server communicates with the
-`agent-server` (port 4802) to spawn a LangGraph execution run for a given card. Execution
-status is shown on the card and in the detail panel in real time.
+Each task can be handed to an autonomous agent. The agent runs a five-phase
+LangGraph pipeline — spec → planning → coding → QA review → QA fixing — on
+your local machine and streams live progress back to the card in real time.
+
+<AgentExecutionDiagram />
+
+### How execution starts
+
+When you click **Start** on a task, the desktop app sends a `POST` to the
+agent-server at port 4802. The agent-server starts a LangGraph run and
+immediately returns `{ ok: true }`. Progress streams over WebSocket — the
+board never blocks waiting for completion.
+
+**Task-level settings** affect how the agent runs:
+
+| Setting | Where to set it | Effect |
+|---------|-----------------|--------|
+| `default_model` | Task detail → Settings | Which Claude model the agent uses (default: claude-opus-4-6) |
+| `default_harness` | Task detail → Settings | Which harness config the agent loads |
+| `no_worktree` | Task detail → Settings | Skip worktree creation; agent works in the project root |
+
+If `no_worktree` is not set, the board-server creates a git worktree at
+`.worktrees/<task-id>` so the agent's file changes are isolated from your
+main branch.
+
+### The task card as a live surface
+
+While an agent is running, the card shows:
+
+- **Phase dot** — a colored pulsing dot labeled with the current phase
+  (Spec · Planning · Coding · QA Review · QA Fix)
+- **Progress bar** — advances as the pipeline moves through phases
+  (8% → 20% → 65% → 85% → 92% → 100%)
+- **Subtask stream** — subtasks appear on the card as the planning phase writes
+  them to the board; check marks fill in as each one is completed
+- **Event log** — in the task detail panel, a live feed of agent thoughts and
+  tool calls (reads, writes, edits, bash runs, board updates)
+
+### Execution controls
+
+| Control | Behavior |
+|---------|----------|
+| **Start** | Begins a new agent run from the spec phase |
+| **Stop** | Cancels immediately; no checkpoint saved |
+| **Pause** | Aborts the running graph; SQLite checkpoint preserves state |
+| **Resume** | Re-streams from the last checkpoint; no re-running of completed phases |
+| **Steer** | Injects a free-text instruction into the paused run; picked up on resume |
+
+You must pause before steering. The steer endpoint rejects requests while the
+graph is active.
+
+For a full technical breakdown of the five phases, event stream schema,
+security model, and pause/resume semantics, see
+[Agentic Task Execution](/docs/concepts/agentic-task-execution).
+
+## Data Model
+
+Board data lives at `~/.harness/board/projects/<slug>.yaml`. The structure:
+
+```
+Project
+├── name, slug, description, color, repo_url
+├── default_harness, default_model, max_concurrent
+└── epics[]
+     ├── id, name, description, status
+     └── tasks[]
+          ├── id, title, description, status, priority, category, complexity
+          ├── branch, worktree_path, linked_commits, no_worktree
+          ├── default_harness, default_model
+          ├── subtasks[]  { id, title, status, files, phase }
+          ├── comments[]  { author, timestamp, body }
+          └── execution   { status, phase, started_at, finished_at, exit_code }
+```
+
+The `execution.status` field tracks the agent run lifecycle:
+`idle → running → paused → completed | failed | stopped`.
+
+> **Gotcha:** Task titles or descriptions that contain `: ` (colon + space)
+> can corrupt the YAML file — the YAML parser treats the sequence as a key
+> separator. Use `—` (em dash) or rephrase to avoid colon-space in
+> user-supplied text.
 
 ## Connection Status
 
-The header shows a live connection indicator. If the board server goes offline, the
-header will display an **Offline** state and you can restart the server using the
-**Restart** button without leaving the board.
+The header shows a live connection indicator. If the board server goes offline,
+the header displays an **Offline** state with a **Restart** button — you can
+recover without restarting the full app.
 
-The title bar health dot reflects the board server's status globally. Click it to open
-the Services page, which shows all background servers and lets you check or restart
-them individually.
+The title bar health dot reflects the board server's status globally. Click it
+to open the **Services** page, which shows all four background servers (Board
+:4800, Agent :4802, Chat Relay :4801, Membrain) and lets you restart any
+individually.
+
+## Related
+
+- [Agentic Task Execution](/docs/concepts/agentic-task-execution) — deep dive into
+  the five-phase pipeline, event stream, pause/resume, and security model
+- [Roadmap](/docs/apps/roadmap) — AI-generated quarterly roadmap with features
+  that convert directly into board tasks
+- [board plugin](/docs/plugins/productivity/board) — the MCP plugin that lets
+  Claude Code interact with the board from a terminal session

--- a/website/content/docs/apps/roadmap.md
+++ b/website/content/docs/apps/roadmap.md
@@ -26,7 +26,7 @@ Generation runs in three phases, visible in a progress view as it completes:
 
 The generated roadmap includes:
 
-- A **vision statement** (1–2 sentences)
+- A **vision statement** (1–2 sentences) shown at the top of the roadmap view
 - A **target audience** profile (primary persona, secondary personas, pain
   points, goals, usage context)
 - **Phases** ordered logically (foundation → growth → scale, or similar) with

--- a/website/content/docs/apps/roadmap.md
+++ b/website/content/docs/apps/roadmap.md
@@ -4,51 +4,128 @@ title: Roadmap
 
 # Roadmap
 
-The Roadmap is a feature planning surface that sits on top of the Board. Each board
-project can have one roadmap. The roadmap organizes features into phases, priorities,
-and a kanban view, and it connects to a competitor analysis engine.
+The Roadmap is a feature planning surface that sits on top of the Board. Each
+board project can have one roadmap. The roadmap organizes features into phases,
+priorities, and a kanban view, and it connects to a competitor analysis engine.
 
 ## Generating a Roadmap
 
-If a project has no roadmap yet, the empty state offers a **Generate** action. The
-generation view uses Claude to analyze the project's existing tasks, description, and
-optionally competitor data to produce an initial set of phases and features. You can
-cancel the generation at any time and start with a blank roadmap instead.
+If a project has no roadmap yet, the empty state offers a **Generate** action.
+You can cancel generation at any time and start with a blank roadmap instead.
+
+### How generation works
+
+Generation runs in three phases, visible in a progress view as it completes:
+
+1. **Analyzing** — reads your board project's existing epics and tasks to
+   understand what you've already built and what's in flight
+2. **Generating** — calls Claude Opus with a product-strategist system prompt
+   and your project context; returns a structured JSON roadmap with 3–4 phases
+   and 10–15 features
+3. **Saving** — writes the roadmap to disk and loads it into the UI
+
+The generated roadmap includes:
+
+- A **vision statement** (1–2 sentences)
+- A **target audience** profile (primary persona, secondary personas, pain
+  points, goals, usage context)
+- **Phases** ordered logically (foundation → growth → scale, or similar) with
+  milestones
+- **Features** each with title, description, rationale, MoSCoW priority,
+  complexity/impact ratings, user stories, and acceptance criteria
+
+Priority distribution targets: ~40% Must, ~35% Should, ~20% Could, ~5% Won't.
+
+### Authentication
+
+Generation uses the Anthropic API. The system checks credentials in this order:
+
+1. `ANTHROPIC_API_KEY` environment variable
+2. Claude Code's stored OAuth token from the macOS Keychain (service
+   `Claude Code-credentials` or `Claude Code-credentials-518fa12f`)
+
+If neither is found, or the OAuth token has expired, generation shows an error
+with instructions to either set the env var or re-authenticate with
+`claude /login`.
 
 ## Views
 
 The roadmap has four tabs:
 
-- **Kanban** — features arranged in swimlane columns by phase, drag-and-drop to
-  reorder within or across phases
-- **Phases** — a vertical list of phases in defined order, each showing its features;
-  from here you can convert a feature directly into a board task
+- **Kanban** — features arranged in swimlane columns by phase, drag-and-drop
+  to reorder within or across phases
+- **Phases** — a vertical list of phases in defined order, each showing its
+  features; from here you can convert a feature directly into a board task
 - **Features** — a flat grid of all features regardless of phase or priority
 - **Priorities** — a MoSCoW four-quadrant view (Must, Should, Could, Won't)
 
 ## Features
 
-Each feature has a title, description, priority, phase assignment, and an optional
-set of competitor insight links. Open a feature to see the detail panel, where you can:
+Each feature has a title, description, priority, phase assignment, and an
+optional set of competitor insight links. Open a feature to see the detail
+panel, where you can:
 
 - Edit all fields
-- Link the feature to competitor pain points discovered in the competitor analysis
-- Convert it to a board task — you'll be prompted to pick an epic if the project
-  has more than one
+- Link the feature to competitor pain points discovered in the competitor
+  analysis
+- **Convert to board task** — creates a task in the chosen epic and sets a
+  `linkedFeatureId` back-reference so the feature and task stay connected;
+  a link appears on the feature card pointing to the task on the board
 - Navigate directly to the created task on the board
 - Delete the feature
 
 ## Phases
 
-Phases are ordered milestones (e.g., "Q1 2025", "Beta", "GA"). Each phase has a name
-and an order index. You can add phases from the header, and the phases view shows
-features grouped by phase.
+Phases are ordered milestones (e.g., "Q1 2025", "Beta", "GA"). Each phase has
+a name, description, order index, and list of milestones. You can add phases
+from the header, and the phases view shows features grouped by phase.
 
 ## Competitor Analysis
 
-The roadmap integrates a competitor analysis panel. Add competitors by name and
-product URL. The app fetches and summarizes their pain points, feature gaps, and
-positioning. These insights become linkable to roadmap features so you know which
-competitive pressures drove each decision.
+The roadmap integrates a competitor analysis panel that uses AI to summarize
+competitive positioning and surface opportunities.
 
-Access the competitor view from the **Competitors** button in the roadmap header.
+### Adding competitors
+
+Click **Competitors** in the roadmap header, then **Add Competitor**. Provide
+a name, product URL, description, and relevance rating (high/medium/low). The
+app fetches and analyzes the competitor's public presence.
+
+### What it produces
+
+For each competitor the analysis generates:
+
+| Field | Description |
+|-------|-------------|
+| **Pain points** | Customer frustrations with this competitor (severity: high/medium/low) |
+| **Strengths** | What they do well |
+| **Market position** | How they're positioned in the market |
+
+It also synthesizes across competitors:
+
+| Output | Description |
+|--------|-------------|
+| **Market gaps** | Opportunities none of them address well, with a suggested feature |
+| **Insights summary** | Top pain points, differentiator opportunities, market trends |
+
+### Linking insights to features
+
+In the feature detail panel, the **Competitor Insights** section lists pain
+points you can attach to the feature. This creates a traceable record of which
+competitive pressure drove each product decision.
+
+Features with linked insights show a competitor badge in the feature grid.
+
+### Data model
+
+Competitor and analysis data is stored alongside the roadmap in the board-server.
+Each competitor carries a `source` tag (`manual` for ones you added, `ai` for
+any AI-suggested competitors) and each pain point carries a severity
+(`high`/`medium`/`low`) and opportunity description.
+
+## Related
+
+- [Board](/docs/apps/board) — the Kanban surface where roadmap features become
+  tasks
+- [Agentic Task Execution](/docs/concepts/agentic-task-execution) — how the
+  agent works through board tasks once features are converted

--- a/website/content/docs/concepts/agentic-task-execution.md
+++ b/website/content/docs/concepts/agentic-task-execution.md
@@ -109,7 +109,7 @@ These are first-class operations, not workarounds.
 |--------|-------------|
 | **Pause** | Aborts the current LangGraph stream. The SQLite checkpointer has already saved state after the last completed node. |
 | **Resume** | Re-streams the graph from the last checkpoint — LangGraph picks up exactly where it left off without re-running completed nodes. |
-| **Steer** | Injects a `steeringMessage` into graph state while paused. On resume, every node reads this field and incorporates the instruction. Useful for course-correcting mid-run. |
+| **Steer** | Injects a `steeringMessage` into graph state and immediately resumes execution — this is steer + resume in a single operation. No separate Resume call is needed. Every node incorporates the instruction. |
 
 **Important:** you must pause before steering. The steer endpoint rejects
 requests while the graph is running.
@@ -130,7 +130,8 @@ subscribes automatically when it detects a running task.
 | `agent_done` | `taskId, exitCode` | When the graph reaches END normally |
 | `agent_error` | `taskId, message` | On unhandled errors |
 
-The full discriminated union is defined in
+All emitted event types are listed above. The complete TypeScript discriminated
+union (including reserved types not yet emitted) is in
 `packages/agent-server/src/types.ts`.
 
 ## Security and boundaries

--- a/website/content/docs/concepts/agentic-task-execution.md
+++ b/website/content/docs/concepts/agentic-task-execution.md
@@ -47,6 +47,10 @@ stateDiagram-v2
     qa_review --> [*] : FAIL (attempts ≥ 3, hand off)
 ```
 
+The edge from `coding_node` to QA is conditional — it can skip QA entirely for
+tasks with no tests. In practice it always runs QA unless the task is
+explicitly flagged.
+
 ### Phase 1 — Spec
 
 Claude Opus reads the task title, description, and existing subtasks, then
@@ -84,8 +88,8 @@ and `state: done` or `state: error` after. These stream live to the card UI.
 ### Phase 4 — QA Review
 
 A separate read-only agent reviews the implementation against the spec's
-acceptance criteria. It can read files and run `bash` (for tests) but cannot
-write. It returns `PASS` or `FAIL` with details.
+acceptance criteria. It can read files, list directories, and run `bash` (for
+tests) but cannot write. It returns `PASS` or `FAIL` with details.
 
 **Output:** `qaPassed: boolean`, `qaAttempts` incremented on failure.
 

--- a/website/content/docs/concepts/agentic-task-execution.md
+++ b/website/content/docs/concepts/agentic-task-execution.md
@@ -1,0 +1,165 @@
+---
+title: Agentic Task Execution
+---
+
+# Agentic Task Execution
+
+Every task on the Board can be handed to an autonomous agent. The agent runs a
+five-phase LangGraph pipeline on your machine, streams live progress back to
+the card, and supports pause, resume, and mid-run steering — all without
+leaving the desktop app.
+
+## The problem with raw `claude -p`
+
+You could run Claude on a task by shelling out to `claude -p "implement this"`.
+That works for one-liners, but it gives you nothing useful for real work:
+
+- No structured phases — you can't tell if it's still thinking or stuck
+- No checkpointing — a crash or sleep means starting over
+- No QA loop — the agent can't verify its own output
+- No pause or steer — once running, you're a spectator
+- No live observability — just a scrolling terminal, no typed events
+- No board integration — subtasks don't appear on the card as work proceeds
+
+The harness-kit agent-server is a dedicated local execution engine built to
+solve all of these. It runs on port 4802, communicates over HTTP and WebSocket,
+and is designed specifically for per-card autonomous work.
+
+## Architecture
+
+<AgentExecutionDiagram />
+
+## The five-phase pipeline
+
+The agent runs as a LangGraph state graph. Each run starts from the beginning
+and checkpoints after every node using SQLite, so it can be paused and resumed
+mid-phase without losing work.
+
+```mermaid
+stateDiagram-v2
+    [*] --> spec_node
+    spec_node --> planning_node
+    planning_node --> coding_node
+    coding_node --> qa_review
+    qa_review --> [*] : PASS
+    qa_review --> qa_fixing : FAIL (attempts < 3)
+    qa_fixing --> coding_node
+    qa_review --> [*] : FAIL (attempts ≥ 3, hand off)
+```
+
+### Phase 1 — Spec
+
+Claude Opus reads the task title, description, and existing subtasks, then
+writes a 500–1000 word implementation spec covering approach, key files to
+touch, edge cases, and acceptance criteria.
+
+**Output:** `spec` string in graph state, passed forward to all later phases.
+
+### Phase 2 — Planning
+
+Claude decomposes the spec into 8–15 concrete subtasks and writes them to the
+board via the Board HTTP API. Each subtask appears on the card in real time
+as it's created.
+
+**Output:** `subtasks[]` in graph state, one `agent_subtask` WS event per
+subtask created.
+
+### Phase 3 — Coding
+
+An agentic inner loop (≤80 steps) works through each subtask. The agent has
+two tool sets:
+
+| Tool set | Tools | Purpose |
+|----------|-------|---------|
+| **fs-tools** | `read_file`, `write_file`, `edit_file`, `list_directory`, `bash` | File I/O and shell commands inside the task's worktree |
+| **board MCP tools** | All board MCP tools via `board-server :4800/mcp` | Update subtask status, post comments, link branches |
+
+Every model invocation that produces prose content emits an `agent_thought`
+event. Every tool call emits an `agent_tool` event with `state: start` before
+and `state: done` or `state: error` after. These stream live to the card UI.
+
+**Output:** modified files in the worktree, completed subtasks on the board,
+`messages[]` in graph state.
+
+### Phase 4 — QA Review
+
+A separate read-only agent reviews the implementation against the spec's
+acceptance criteria. It can read files and run `bash` (for tests) but cannot
+write. It returns `PASS` or `FAIL` with details.
+
+**Output:** `qaPassed: boolean`, `qaAttempts` incremented on failure.
+
+### Phase 5 — QA Fixing (conditional)
+
+If QA fails and `qaAttempts < 3`, the fixing agent reads the QA feedback and
+patches the failures, then hands back to coding. After three failed QA
+attempts the graph exits and surfaces the failure to the human.
+
+**Retry loop:** `qa_fixing → coding_node → qa_review` repeats up to 3×.
+
+## Pause, resume, and steer
+
+These are first-class operations, not workarounds.
+
+| Action | What happens |
+|--------|-------------|
+| **Pause** | Aborts the current LangGraph stream. The SQLite checkpointer has already saved state after the last completed node. |
+| **Resume** | Re-streams the graph from the last checkpoint — LangGraph picks up exactly where it left off without re-running completed nodes. |
+| **Steer** | Injects a `steeringMessage` into graph state while paused. On resume, every node reads this field and incorporates the instruction. Useful for course-correcting mid-run. |
+
+**Important:** you must pause before steering. The steer endpoint rejects
+requests while the graph is running.
+
+## The event stream
+
+The agent-server pushes typed events over WebSocket at
+`ws://localhost:4802/ws?taskId=<id>&token=<secret>`. The desktop card
+subscribes automatically when it detects a running task.
+
+| Event type | Payload | When emitted |
+|-----------|---------|--------------|
+| `agent_phase` | `taskId, phase, progress` | At the start of each phase (progress 8/20/65/85/92%) |
+| `agent_thought` | `taskId, text, timestamp` | When the coding agent produces prose |
+| `agent_tool` | `taskId, tool, action, path, state, output?` | Before and after every tool call |
+| `agent_subtask` | `taskId, subtaskId, status` | When a subtask is created or updated |
+| `agent_steered` | `taskId` | After a steering message is accepted |
+| `agent_done` | `taskId, exitCode` | When the graph reaches END normally |
+| `agent_error` | `taskId, message` | On unhandled errors |
+
+The full discriminated union is defined in
+`packages/agent-server/src/types.ts`.
+
+## Security and boundaries
+
+The agent-server is designed to be local-first and restricted:
+
+- **Runs entirely on your machine** — no data leaves `localhost`
+- **Bearer token auth** — token stored at `~/.harness-kit/agent-server.token`
+  (mode 0600), generated on first start, read by the desktop app via a Tauri
+  command; all HTTP routes and WebSocket upgrades require it
+- **CORS locked to Tauri** — `Access-Control-Allow-Origin: tauri://localhost`
+  only; browser tabs cannot reach the agent-server
+- **Worktree isolation** — the coding and QA-fixing agents receive
+  `worktree_path` from the task; all file-system tool calls are rooted there
+- **Tool allowlist** — `StartAgentOptions.allowedTools` lets you restrict which
+  tools the agent can use (e.g., `["read_file", "list_directory"]` for a
+  read-only run)
+
+## What you get vs. raw Claude Code
+
+| Capability | Raw `claude -p` | Board agent-server |
+|------------|----------------|-------------------|
+| Structured phases with progress | ✗ | ✓ (5 phases, % progress) |
+| Live subtask creation on the card | ✗ | ✓ (planning node writes to board) |
+| Pause and resume | ✗ | ✓ (SQLite checkpoint) |
+| Mid-run steering | ✗ | ✓ (steeringMessage channel) |
+| Automated QA loop | ✗ | ✓ (up to 3 fix attempts) |
+| Typed WebSocket event stream | ✗ | ✓ (agent_phase/thought/tool/subtask) |
+| Isolated worktree per task | Manual | ✓ (board-server spins up worktree) |
+| Board status written back | Manual | ✓ (PATCH /execution on done/fail) |
+
+## Related
+
+- [Board](/docs/apps/board) — the Kanban surface that surfaces agent execution
+- [Understanding Agents](/docs/concepts/agents) — Claude Code subagents
+  (AGENT.md, custom subagent definitions) — distinct from this execution engine

--- a/website/content/docs/concepts/meta.json
+++ b/website/content/docs/concepts/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "plugins-vs-skills",
     "agents",
+    "agentic-task-execution",
     "memory",
     "secrets-management",
     "cross-harness-portability",

--- a/website/content/docs/faq.md
+++ b/website/content/docs/faq.md
@@ -110,3 +110,81 @@ Two plugins have optional environment variable dependencies:
 - **review** — `GH_TOKEN` enables reviewing pull requests by number (`/review 123`). Without it, review works for local branches and paths.
 
 For setup instructions — shell profile, direnv, 1Password CLI, CI — see the [Secrets Management guide](/docs/guides/secrets-management).
+
+## Board & Agent Execution
+
+### Can I trust the board's agent to run unsupervised?
+
+It depends on the task. The agent is capable and runs autonomously, but it is
+designed to be steerable, not fire-and-forget. For long or risky tasks:
+
+- Use the **Pause** button and review progress after each major phase
+- Set `allowedTools` to restrict what the agent can do (e.g., read-only mode)
+- Keep `no_worktree` off so file changes are isolated in a git worktree
+
+The QA loop catches many errors automatically, but review before merging the
+worktree's changes. The agent's file edits don't touch your main branch until
+you explicitly merge them.
+
+### What happens if my laptop sleeps mid-run?
+
+The agent-server is a local Node.js process, so it will pause when the process
+is interrupted (sleep, app quit, crash). The LangGraph SQLite checkpoint
+preserves state after each completed node. When you reopen the desktop app and
+click **Resume**, the pipeline picks up from the last saved checkpoint — no
+re-running of completed phases.
+
+If the agent-server is not running when you try to resume, the Services page
+lets you restart it without restarting the full app.
+
+### Does this work without an Anthropic API key?
+
+**For the board's agent execution:** The agent-server uses `ANTHROPIC_API_KEY`
+if set. If not set, it falls back to Claude Code's stored OAuth token from the
+macOS Keychain. If you're already logged in to Claude Code, no extra setup is
+needed.
+
+**For roadmap generation:** Same — `ANTHROPIC_API_KEY` or Claude Code
+Keychain OAuth, checked in that order.
+
+**For plugins:** Skills run inside Claude Code, which handles auth. Plugins
+don't need their own API key.
+
+### What models does the agent use?
+
+The board agent defaults to **claude-opus-4-6** for all five phases (spec,
+planning, coding, QA review, QA fixing). You can override this per task with
+the `default_model` setting in the task detail panel. Full model IDs are
+accepted (e.g., `claude-sonnet-4-6`) or shorthand aliases (`opus`, `sonnet`,
+`haiku`).
+
+Roadmap generation always uses claude-opus-4-6.
+
+### Does the agent run remote code or make network calls?
+
+The agent runs entirely on your machine. It communicates over `localhost` only:
+
+- The agent-server listens on `:4802` (CORS restricted to `tauri://localhost`)
+- The board-server listens on `:4800`
+- File system access is scoped to the task's worktree path
+- The agent can run `bash` commands — this is intentional and necessary for
+  running tests, but you can restrict it via `allowedTools`
+
+The only external network call is to the Anthropic API for Claude completions.
+
+### How is this different from Devin, Cognition, or Cursor's background agents?
+
+Those are cloud-hosted services. The harness-kit board agent runs 100% locally:
+
+| | Cloud agents (Devin, etc.) | harness-kit board agent |
+|---|---|---|
+| **Where it runs** | Cloud VM | Your machine |
+| **Data leaves your network** | Yes | No (except Anthropic API calls) |
+| **Cost model** | Subscription + per-task | Your Anthropic API usage only |
+| **Pause, steer, inspect** | Varies | First-class: pause, steer, live event log |
+| **Checkpoint/resume** | Cloud-managed | SQLite on your disk |
+| **Integrates with your IDE** | Via plugin | Native — same machine, same files |
+
+The trade-off: cloud agents can run in the background while your laptop is off.
+The harness-kit agent requires the desktop app to be open. This is a deliberate
+design choice — local-first, inspectable, no data leaving your machine.

--- a/website/content/docs/faq.md
+++ b/website/content/docs/faq.md
@@ -154,9 +154,8 @@ don't need their own API key.
 
 The board agent defaults to **claude-opus-4-6** for all five phases (spec,
 planning, coding, QA review, QA fixing). You can override this per task with
-the `default_model` setting in the task detail panel. Full model IDs are
-accepted (e.g., `claude-sonnet-4-6`) or shorthand aliases (`opus`, `sonnet`,
-`haiku`).
+the `default_model` setting in the task detail panel. Use full model IDs
+(e.g., `claude-sonnet-4-6`, `claude-haiku-4-5-20251001`).
 
 Roadmap generation always uses claude-opus-4-6.
 

--- a/website/content/docs/getting-started/architecture.mdx
+++ b/website/content/docs/getting-started/architecture.mdx
@@ -64,17 +64,30 @@ The desktop app is a management console organized into named sections. It reads 
 
 **WORKFLOWS**
 
-- **Board** — AI-native Kanban board with real-time two-way sync; agents pick up cards, flag for review
-- **Roadmap** — AI-generated quarterly roadmaps and competitor analysis tied to your board
+- **Board** — AI-native Kanban board; each card can be handed to an autonomous
+  agent that runs a five-phase LangGraph pipeline (spec → planning → coding →
+  QA review → QA fix) locally on your machine, streaming live progress back to
+  the card. See [Agentic Task Execution](/docs/concepts/agentic-task-execution).
+- **Roadmap** — AI-generated quarterly roadmaps and competitor analysis tied to
+  your board; features convert directly into board tasks
 
 **Standalone sections**
 
-- **Agents** — monitor and manage specialist subagents running across your harness
+- **Agents** — detection panel for AI coding agents installed on your machine
 - **Comparator** — run the same prompt across Claude Code, Cursor, and Copilot side by side
 - **Parity** — track which plugins, MCP servers, and skills are loaded in each connected AI tool
 - **AI Chat** — keyboard-first chat window with Ollama support and integrated tools
 - **Memory** — browse, search, and manage the knowledge graph your agents orient themselves in
-- **Services** — live status dashboard for the four background servers (Board, Chat, Memory, Agent); the title bar health dot links here
+- **Services** — live status dashboard for the four background servers; the title bar health dot links here
+
+**Background servers** — four processes run inside the desktop app:
+
+| Server | Port | Purpose |
+|--------|------|---------|
+| Board server | :4800 | YAML store, WebSocket hub, MCP endpoint, roadmap/competitor API |
+| Chat relay | :4801 | Self-hosted WebSocket relay for team chat |
+| Agent server | :4802 | LangGraph execution engine for per-card agent runs |
+| Membrain | — | Graph-based memory MCP server (enabled in Labs) |
 
 ---
 

--- a/website/content/docs/plugins/productivity/board.mdx
+++ b/website/content/docs/plugins/productivity/board.mdx
@@ -7,11 +7,17 @@ description: Kanban project board with real-time two-way sync between Claude and
 
 # board
 
-A lightweight Kanban board with real-time two-way sync between Claude and a web UI. Tasks live in `~/.harness/board/projects/<slug>.yaml`. Claude interacts via MCP tools; you interact via browser.
+A lightweight Kanban board with real-time two-way sync between Claude Code and
+the desktop app. Tasks live in `~/.harness/board/projects/<slug>.yaml`. Claude
+interacts via MCP tools; you interact via the Board page in the desktop app.
+
+This plugin is the **MCP surface** used by the agent-server during per-card
+autonomous runs. When the agent's planning phase creates subtasks or the
+coding phase marks them complete, it calls these same MCP tools.
 
 ## Requirements
 
-- Node.js (for the board server — installed as part of harness-kit desktop or via `pnpm board:install`)
+- Node.js (installed as part of harness-kit desktop, or via `pnpm board:install`)
 
 ## Install
 
@@ -22,13 +28,14 @@ A lightweight Kanban board with real-time two-way sync between Claude and a web 
 
 ## Usage
 
-### Open the board UI
+### Open the board
 
 ```
 /board
 ```
 
-Launches the board web UI. If the server is not running, the plugin prints instructions to install it as a persistent launchd service.
+Launches the Board page in the desktop app. If the board server is not running,
+the plugin prints instructions to start it as a persistent launchd service.
 
 ### Create a task
 
@@ -55,16 +62,21 @@ Shows a summary of all tasks grouped by status column.
 
 ## Status Columns
 
-| Status | Meaning |
-|--------|---------|
-| `backlog` | Not started |
-| `in-progress` | Being worked on |
-| `review` | Ready for human review |
-| `done` | Complete |
+The board uses six columns. Use the exact slugs below in MCP tool calls:
+
+| Slug | Display name | Meaning |
+|------|-------------|---------|
+| `backlog` | Backlog | Not started |
+| `planning` | Planning | Being scoped or designed |
+| `in-progress` | In Progress | Actively being worked on |
+| `ai-review` | AI Review | Agent finished, awaiting automated check |
+| `human-review` | Human Review | Waiting for a person to sign off |
+| `done` | Done | Complete |
 
 ## MCP Tools
 
-The board plugin exposes MCP tools for deeper integration:
+The board plugin exposes these MCP tools (available to Claude Code and to the
+agent-server's LangGraph pipeline):
 
 | Tool | Purpose |
 |------|---------|
@@ -73,19 +85,22 @@ The board plugin exposes MCP tools for deeper integration:
 | `create_task` | Create a task |
 | `update_task` | Edit title, description, flags |
 | `move_task` | Change status column |
-| `add_comment` | Post a comment |
-| `list_tasks` | Read board state (filterable) |
-| `link_branch` | Associate a branch or worktree |
+| `add_comment` | Post a comment (author: `claude` or `user`) |
+| `list_tasks` | Read board state (filterable by epic or status) |
+| `link_branch` | Associate a branch or worktree path |
 | `link_commit` | Attach a commit SHA |
-| `request_review` | Flag task ready for review |
+| `request_review` | Flag task ready for human review |
 | `block_task` / `unblock_task` | Mark or clear blocked status |
 
 ## Workflow Integration
 
-When Claude starts work on a task, it can automatically:
+When Claude Code starts work on a task from a terminal session, it can
+automatically:
 
 1. Move the task to `in-progress` and link the working branch
 2. Post progress comments as work proceeds
 3. Flag `request_review` when done
 4. Move to `done` after merge
 
+The same tools run during autonomous agent execution via the desktop app's
+agent-server — see [Agentic Task Execution](/docs/concepts/agentic-task-execution).


### PR DESCRIPTION
## Summary

- **New page** `concepts/agentic-task-execution.md` — full technical reference for the 5-phase LangGraph pipeline (spec → planning → coding → QA review → QA fixing), Mermaid state machine, WebSocket event schema, pause/resume/steer semantics, security model, and comparison vs raw Claude Code
- **New diagram** `components/agent-execution-diagram.tsx` — React SVG hero diagram showing Desktop card → agent-server :4802 → LangGraph runtime → worktree (fs-tools) + board-server :4800
- **`apps/board.md`** — agent execution section fully rewritten: live card surface (phase dot, progress bar, subtask stream, event log), all 5 controls (Start/Stop/Pause/Resume/Steer), data model YAML structure, execution lifecycle, YAML corruption gotcha
- **`apps/roadmap.md`** — added generation pipeline (3 phases), auth fallback (API key → Claude Code Keychain OAuth), competitor analysis data model, feature→task roundtrip with `linkedFeatureId`
- **`faq.md`** — new "Board & Agent Execution" section with 6 Q&As covering unsupervised use, sleep/resume, auth without API key, model defaults, local-only execution, and comparison vs Devin/Cognition/Cursor
- **`getting-started/architecture.mdx`** — background servers table (:4800/:4801/:4802/Membrain), link to new concepts page
- **`plugins/productivity/board.mdx`** — fixed stale 4-column status list → correct 6-column table; added agent-server MCP surface note

## Test Plan

- [x] `pnpm -C website build` passes clean (58 pages, TypeScript clean, no errors)
- [ ] Click through `/docs/concepts/agentic-task-execution`, `/docs/apps/board`, `/docs/apps/roadmap`, `/docs/faq`, `/docs/getting-started/architecture` in dev server
- [ ] Verify Mermaid state machine renders in light and dark mode
- [ ] Verify `<AgentExecutionDiagram />` renders at desktop and mobile widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)