### PR TITLE
feat(website): mobile-first landing page and responsive DesktopMock

### DIFF
--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -34,6 +34,12 @@ export const metadata = {
   },
 };
 
+export const viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 5,
+};
+
 export default function Layout({ children }: { children: ReactNode }) {
   return (
     <html

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -84,8 +84,8 @@ export default function HomePage() {
       {/* ── Hero ── */}
       <section className="relative overflow-hidden border-b border-fd-border/30">
         {/* Copy block */}
-        <div className="mx-auto max-w-3xl px-6 pb-10 pt-20 text-center">
-          <h1 className="font-display mb-5 text-5xl font-bold leading-tight tracking-tight text-fd-foreground sm:text-5xl">
+        <div className="mx-auto max-w-3xl px-5 pb-8 pt-14 text-center sm:px-6 sm:pb-10 sm:pt-20">
+          <h1 className="font-display mb-5 text-4xl font-bold leading-tight tracking-tight text-fd-foreground sm:text-5xl">
             The configuration console{' '}
             <br className="hidden sm:block" />
             for all your harnesses.
@@ -128,7 +128,7 @@ export default function HomePage() {
         {/* Surface callouts — what's inside, directly beneath the mock */}
         <div className="mx-auto max-w-5xl px-4 pb-16 sm:px-6">
           <div
-            className="grid grid-cols-2 gap-px lg:grid-cols-4"
+            className="grid grid-cols-1 gap-px sm:grid-cols-2 lg:grid-cols-4"
             style={{ background: 'var(--fd-border)' }}
           >
             {showcaseCards.map((card) => (

--- a/website/components/site/CommandBox.tsx
+++ b/website/components/site/CommandBox.tsx
@@ -1,12 +1,12 @@
 export function CommandBox({ command }: { command: string }) {
   return (
-    <div className="relative inline-block">
+    <div className="relative block w-full max-w-full sm:inline-block sm:w-auto">
       <div
         className="absolute -inset-[1px] rounded-xl blur-[1px]"
         style={{ background: 'linear-gradient(90deg, rgba(34,177,236,0.3), rgba(14,165,233,0.2), rgba(34,177,236,0.3))' }}
         aria-hidden="true"
       />
-      <div className="relative rounded-xl border border-white/5 bg-fd-card px-5 py-3 font-mono text-sm text-fd-foreground">
+      <div className="relative overflow-x-auto whitespace-nowrap rounded-xl border border-white/5 bg-fd-card px-4 py-2.5 font-mono text-[12px] text-fd-foreground sm:px-5 sm:py-3 sm:text-sm">
         <span className="text-fd-muted-foreground" aria-hidden="true">$ </span>
         {command}
       </div>

--- a/website/components/site/DesktopMock.module.css
+++ b/website/components/site/DesktopMock.module.css
@@ -602,3 +602,145 @@
   margin-top: -6px;
   margin-bottom: 4px;
 }
+
+/* ── Mobile (<640px): demo becomes a marketing showcase ── */
+@media (max-width: 640px) {
+  .frame {
+    border-radius: 10px;
+  }
+  .titlebar {
+    padding: 9px 12px;
+    gap: 6px;
+  }
+  .tl { width: 9px; height: 9px; }
+  .titleText {
+    font-size: 10px;
+    margin-left: 10px;
+  }
+  .hintBtn {
+    font-size: 9px;
+    padding: 1px 5px;
+  }
+
+  /* Stack sidebar above content, not beside it */
+  .body {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr;
+    min-height: 440px;
+  }
+
+  /* Sidebar -> horizontal tab rail */
+  .sidebar {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    gap: 4px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding: 8px 10px;
+    border-right: none;
+    border-bottom: 1px solid var(--border-base);
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+    -webkit-overflow-scrolling: touch;
+  }
+  .sidebar::-webkit-scrollbar { display: none; }
+  /* Flatten group wrappers so buttons become direct flex children of the sidebar rail */
+  .sidebar > div { display: contents; }
+  .groupHeader { display: none; }
+
+  .item {
+    flex-shrink: 0;
+    width: auto;
+    padding: 8px 12px;
+    font-size: 12px;
+    border-left: none !important;
+    border-radius: 999px;
+    margin-bottom: 0;
+    min-height: 36px;
+    white-space: nowrap;
+  }
+  .itemActive {
+    border-left: none !important;
+    padding-left: 12px !important;
+    background: var(--accent-light) !important;
+    box-shadow: inset 0 0 0 1px var(--accent);
+  }
+  .item svg { width: 12px; height: 12px; }
+
+  /* Pane — tighter padding, larger body text */
+  .pane {
+    padding: 16px 14px;
+    gap: 10px;
+  }
+  .paneTitle { font-size: 15px; }
+  .paneSubtitle { font-size: 11px; }
+
+  /* Observatory metrics fit three-across at narrow width */
+  .metricRow { gap: 6px; }
+  .metricCard { padding: 8px 9px; }
+  .metricLabel { font-size: 8.5px; }
+  .metricValue { font-size: 16px; }
+  .metricDelta { font-size: 9px; }
+  .chartCard { min-height: 110px; padding: 10px; }
+  .chartSvg { height: 80px; }
+
+  /* Harness YAML code block */
+  .paneHarnessCode {
+    padding: 14px 12px;
+    font-size: 10.5px;
+    line-height: 1.7;
+  }
+
+  /* Marketplace + Agents — stack to single column */
+  .pluginGridMock { grid-template-columns: 1fr; gap: 8px; }
+  .agentGrid { grid-template-columns: 1fr; gap: 8px; }
+  .agentCard { padding: 11px 12px; }
+
+  /* Comparator terminals stack vertically */
+  .comparatorPane {
+    grid-template-columns: 1fr !important;
+    grid-template-rows: 1fr 1fr;
+  }
+  .term {
+    border-right: none;
+    border-bottom: 1px solid var(--border-base);
+    padding: 12px;
+    font-size: 10px;
+  }
+  .term:last-child { border-bottom: none; }
+  .termLine { font-size: 9.5px; }
+
+  /* Permissions — tighter rows */
+  .permRow {
+    padding: 8px 10px;
+    font-size: 10.5px;
+    gap: 10px;
+  }
+  .permStatus { font-size: 9px; min-width: 38px; padding: 2px 5px; }
+  .permRule { font-size: 10.5px; }
+
+  /* Parity table — allow horizontal scroll inside the pane */
+  .parityTable { font-size: 10px; }
+  .parityTable th, .parityTable td { padding: 5px 7px; }
+
+  /* Board — stack kanban columns as a list */
+  .boardCols {
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+
+  /* Roadmap — tighten labels */
+  .roadmapLabel { width: 40px; font-size: 9.5px; }
+  .roadmapStatus { width: 54px; font-size: 9px; }
+
+  /* AI Chat messages take more of the width on narrow screens */
+  .chatMsg { max-width: 95%; font-size: 11px; }
+
+  /* Memory nodes — smaller, fit inside the reduced pane */
+  .memoryNode {
+    width: 44px;
+    height: 44px;
+    font-size: 9px;
+  }
+}

--- a/website/components/site/DesktopMock.tsx
+++ b/website/components/site/DesktopMock.tsx
@@ -215,6 +215,24 @@ export function DesktopMock({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [interactive]);
 
+  // On mobile, keep the active tab visible in the horizontal sidebar rail.
+  const sidebarRef = useRef<HTMLElement | null>(null);
+  useEffect(() => {
+    const sidebar = sidebarRef.current;
+    if (!sidebar) return;
+    const active = sidebar.querySelector<HTMLButtonElement>('[aria-pressed="true"]');
+    if (!active) return;
+    const sb = sidebar.getBoundingClientRect();
+    const ab = active.getBoundingClientRect();
+    const offLeft = ab.left - sb.left;
+    const offRight = ab.right - sb.right;
+    if (offLeft < 0) {
+      sidebar.scrollBy({ left: offLeft - 12, behavior: 'smooth' });
+    } else if (offRight > 0) {
+      sidebar.scrollBy({ left: offRight + 12, behavior: 'smooth' });
+    }
+  }, [activeSection]);
+
   return (
     <div
       className={frameClass}
@@ -241,7 +259,7 @@ export function DesktopMock({
       {/* Body */}
       <div className={styles.body}>
         {/* Sidebar */}
-        <aside className={styles.sidebar}>
+        <aside className={styles.sidebar} ref={sidebarRef}>
           {SECTIONS.map((group) => (
             <div key={group.group}>
               <div className={styles.groupHeader}>{group.group}</div>

--- a/website/components/site/SiteNav.tsx
+++ b/website/components/site/SiteNav.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import { HarnessKitLogo } from '@/components/site/HarnessKitLogo';
 
 const navLinks = [
@@ -13,15 +14,41 @@ const navLinks = [
 
 export function SiteNav() {
   const pathname = usePathname();
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  // Close the mobile menu on route change.
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [pathname]);
+
+  const ThemeToggle = () => (
+    <button
+      aria-label="Toggle Theme"
+      data-theme-toggle=""
+      className="flex size-9 cursor-pointer items-center justify-center rounded-md text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
+    >
+      {/* Sun — shown in dark mode */}
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="size-4 dark:block hidden" aria-hidden="true">
+        <circle cx="12" cy="12" r="4" />
+        <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
+      </svg>
+      {/* Moon — shown in light mode */}
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="size-4 dark:hidden block" aria-hidden="true">
+        <path d="M20.985 12.486a9 9 0 1 1-9.473-9.472c.405-.022.617.46.402.803a6 6 0 0 0 8.268 8.268c.344-.215.825-.004.803.401" />
+      </svg>
+    </button>
+  );
 
   return (
     <nav className="sticky top-0 z-50 border-b border-fd-border/30 bg-fd-background/80 backdrop-blur-xl">
-      <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+      <div className="mx-auto flex max-w-6xl items-center justify-between px-5 py-3 sm:px-6 sm:py-4">
         <Link href="/" className="flex items-center gap-2.5 font-bold text-fd-foreground no-underline">
           <HarnessKitLogo glow />
           <span className="font-display">Harness Kit</span>
         </Link>
-        <div className="flex items-center gap-6 text-sm">
+
+        {/* Desktop links */}
+        <div className="flex items-center gap-6 text-sm max-sm:hidden">
           {navLinks.map(({ href, label, external }) => {
             const isActive = !external && pathname.startsWith(href);
             if (external) {
@@ -47,23 +74,66 @@ export function SiteNav() {
               </Link>
             );
           })}
+          <ThemeToggle />
+        </div>
+
+        {/* Mobile controls */}
+        <div className="flex items-center gap-1 max-sm:flex sm:hidden">
+          <ThemeToggle />
           <button
-            aria-label="Toggle Theme"
-            data-theme-toggle=""
-            className="flex size-8 cursor-pointer items-center justify-center rounded-md text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
+            type="button"
+            aria-label={menuOpen ? 'Close menu' : 'Open menu'}
+            aria-expanded={menuOpen}
+            aria-controls="site-nav-mobile-menu"
+            onClick={() => setMenuOpen((v) => !v)}
+            className="flex size-9 cursor-pointer items-center justify-center rounded-md text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
           >
-            {/* Sun — shown in dark mode */}
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="size-4 dark:block hidden" aria-hidden="true">
-              <circle cx="12" cy="12" r="4" />
-              <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
-            </svg>
-            {/* Moon — shown in light mode */}
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="size-4 dark:hidden block" aria-hidden="true">
-              <path d="M20.985 12.486a9 9 0 1 1-9.473-9.472c.405-.022.617.46.402.803a6 6 0 0 0 8.268 8.268c.344-.215.825-.004.803.401" />
-            </svg>
+            {menuOpen ? (
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="size-5" aria-hidden="true">
+                <path d="M18 6 6 18" />
+                <path d="m6 6 12 12" />
+              </svg>
+            ) : (
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="size-5" aria-hidden="true">
+                <path d="M4 6h16" />
+                <path d="M4 12h16" />
+                <path d="M4 18h16" />
+              </svg>
+            )}
           </button>
         </div>
       </div>
+
+      {/* Mobile dropdown */}
+      {menuOpen && (
+        <div
+          id="site-nav-mobile-menu"
+          className="border-t border-fd-border/30 bg-fd-background/95 backdrop-blur-xl sm:hidden"
+        >
+          <div className="mx-auto flex max-w-6xl flex-col px-5 py-2">
+            {navLinks.map(({ href, label, external }) => {
+              const isActive = !external && pathname.startsWith(href);
+              const className = `flex min-h-11 items-center rounded-md px-3 text-sm no-underline transition-colors ${
+                isActive
+                  ? 'font-medium text-fd-foreground'
+                  : 'text-fd-muted-foreground hover:text-fd-foreground'
+              }`;
+              if (external) {
+                return (
+                  <a key={href} href={href} className={className} target="_blank" rel="noreferrer">
+                    {label}
+                  </a>
+                );
+              }
+              return (
+                <Link key={href} href={href} className={className}>
+                  {label}
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      )}
     </nav>
   );
 }


### PR DESCRIPTION
## Summary

Makes the docs site first-class on mobile. John frequently pulls up the site on his phone during demos and marketing conversations — the phone is the first-impression surface, not the setup surface. This PR treats mobile as a *showcase* viewport while preserving full desktop interactivity.

### What changes

- **DesktopMock** — the hardcoded 210px sidebar collapses into a horizontal scrollable pill-tab rail below 640px. Active tab auto-scrolls into view as the 4s tour cycles. Comparator terminals stack vertically; Kanban columns stack as a list; plugin/agent grids go 1-col; Memory graph scales down.
- **SiteNav** — adds a hamburger dropdown with Docs/Explore/Plugins/GitHub on mobile. Uses `max-sm:*` variants to sidestep a Tailwind v4 cascade bug where Fumadocs emits `.hidden` after `sm:flex`, breaking the usual `hidden sm:flex` pattern.
- **Hero** — headline steps down to `text-4xl` on mobile; showcase grid now stacks `grid-cols-1 sm:grid-cols-2 lg:grid-cols-4`.
- **CommandBox** — goes full-width with `overflow-x-auto` so the install command fits narrow viewports.
- **Viewport meta** — explicit `maximumScale: 5` to preserve pinch-zoom for a11y.

### Before / after

On a 390px iPhone viewport, the old demo was unreadable — sidebar ate 56% of the width and pane text was 10px. After: horizontal tab rail above, full-width pane with legible metrics, charts, and stacked terminals.

## Test plan

- [x] iPhone SE 375×667 — no horizontal scroll, hero + demo legible
- [x] iPhone 14 Pro 390×844 — tab rail scrolls, auto-cycle follows active tab, all 11 panes render
- [x] iPad 768×1024 — desktop-style layout preserved
- [x] Desktop 1440×900 — unchanged from before
- [x] Mobile menu opens/closes correctly; close on route change
- [x] TypeScript compile clean, zero console errors
- [ ] John sanity-checks on actual device before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)