### PR TITLE
feat(desktop): improve enterprise demo readiness

### DIFF
--- a/apps/desktop/src/components/WelcomeScreen.tsx
+++ b/apps/desktop/src/components/WelcomeScreen.tsx
@@ -8,10 +8,18 @@ interface WelcomeScreenProps {
 
 const cards: { title: string; body: React.ReactNode }[] = [
   {
-    title: "AI Chat",
+    title: "Configure",
+    body: "Keep harness.yaml as the source of truth, then compile it to Claude Code, Cursor, Copilot, Codex, and other native configs.",
+  },
+  {
+    title: "Operate",
+    body: "Use Board, Roadmap, Agents, Terminals, and Comparator to turn AI coding into a repeatable workflow instead of one-off sessions.",
+  },
+  {
+    title: "Govern",
     body: (
       <>
-        Requires Ollama running locally.{" "}
+        Inspect permissions, secrets, audit logs, local services, parity, and usage. AI Chat still needs{" "}
         <button
           onClick={() => open("https://ollama.ai")}
           style={{
@@ -26,35 +34,9 @@ const cards: { title: string; body: React.ReactNode }[] = [
             textUnderlineOffset: "2px",
           }}
         >
-          Download Ollama ↗
+          Ollama
         </button>
-      </>
-    ),
-  },
-  {
-    title: "Board, Roadmap & Memory",
-    body: "These features run a local server. They start automatically when you navigate to them.",
-  },
-  {
-    title: "Plugins",
-    body: (
-      <>
-        Add the Claude Code marketplace to install skills:{" "}
-        <code
-          style={{
-            fontSize: "11px",
-            background: "var(--bg-base)",
-            border: "1px solid var(--border-subtle)",
-            borderRadius: "4px",
-            padding: "1px 5px",
-            color: "var(--fg-base)",
-            letterSpacing: "0",
-            fontFamily: "ui-monospace, 'SF Mono', Menlo, monospace",
-            wordBreak: "break-all",
-          }}
-        >
-          /plugin marketplace add harnessprotocol/harness-kit
-        </code>
+        .
       </>
     ),
   },
@@ -147,8 +129,7 @@ export default function WelcomeScreen({ onDismiss }: WelcomeScreenProps) {
             textAlign: "center",
           }}
         >
-          Your all-in-one desktop companion for Claude Code — manage harnesses, plugins,
-          AI chat, boards, and more.
+          Portable AI coding governance, workflows, and observability across every tool your team uses.
         </p>
 
         {/* Info cards */}

--- a/apps/desktop/src/hooks/useGlobalShortcuts.ts
+++ b/apps/desktop/src/hooks/useGlobalShortcuts.ts
@@ -6,6 +6,7 @@ export const NAV_PATHS = [
   "/marketplace",
   "/observatory",
   "/agents",
+  "/terminals",
   "/comparator",
   "/security/permissions",
   "/parity",

--- a/apps/desktop/src/layouts/AppLayout.tsx
+++ b/apps/desktop/src/layouts/AppLayout.tsx
@@ -26,8 +26,8 @@ type NavSection = {
 export const NAV_SECTIONS: NavSection[] = [
   {
     id: "harness",
-    label: "Harness",
-    group: "CORE",
+    label: "Configure",
+    group: "CONFIGURE",
     icon: (
       <svg width="15" height="15" viewBox="0 0 20 20" fill="currentColor" style={{ opacity: 0.7, flexShrink: 0 }}>
         <path fillRule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clipRule="evenodd" />
@@ -55,7 +55,6 @@ export const NAV_SECTIONS: NavSection[] = [
   {
     id: "observatory",
     label: "Observatory",
-    group: "INSIGHTS",
     icon: (
       <svg width="15" height="15" viewBox="0 0 20 20" fill="currentColor" style={{ opacity: 0.7, flexShrink: 0 }}>
         <path d="M2 11a1 1 0 011-1h2a1 1 0 011 1v5a1 1 0 01-1 1H3a1 1 0 01-1-1v-5zM8 7a1 1 0 011-1h2a1 1 0 011 1v9a1 1 0 01-1 1H9a1 1 0 01-1-1V7zM14 4a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1h-2a1 1 0 01-1-1V4z" />
@@ -70,6 +69,7 @@ export const NAV_SECTIONS: NavSection[] = [
   {
     id: "agents",
     label: "Agents",
+    group: "OPERATE",
     icon: (
       <svg width="15" height="15" viewBox="0 0 20 20" fill="currentColor" style={{ opacity: 0.7, flexShrink: 0 }}>
         <path d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3zM6 8a2 2 0 11-4 0 2 2 0 014 0zM16 18v-3a5.972 5.972 0 00-.75-2.906A3.005 3.005 0 0119 15v3h-3zM4.75 12.094A5.973 5.973 0 004 15v3H1v-3a3 3 0 013.75-2.906z" />
@@ -79,6 +79,16 @@ export const NAV_SECTIONS: NavSection[] = [
   },
   {
     id: "terminals",
+    label: "Terminals",
+    icon: (
+      <svg width="15" height="15" viewBox="0 0 20 20" fill="currentColor" style={{ opacity: 0.7, flexShrink: 0 }}>
+        <path fillRule="evenodd" d="M2 5a2 2 0 012-2h12a2 2 0 012 2v10a2 2 0 01-2 2H4a2 2 0 01-2-2V5zm3.293 2.293a1 1 0 011.414 0L9 9.586a1 1 0 010 1.414l-2.293 2.293a1 1 0 01-1.414-1.414L6.586 10 5.293 8.707a1 1 0 010-1.414zM10 13a1 1 0 100 2h4a1 1 0 100-2h-4z" clipRule="evenodd" />
+      </svg>
+    ),
+    path: "/terminals",
+  },
+  {
+    id: "comparator",
     label: "Comparator",
     icon: (
       <svg width="15" height="15" viewBox="0 0 20 20" fill="currentColor" style={{ opacity: 0.7, flexShrink: 0 }}>
@@ -91,7 +101,7 @@ export const NAV_SECTIONS: NavSection[] = [
   {
     id: "security",
     label: "Security",
-    group: "SYSTEM",
+    group: "GOVERN",
     icon: (
       <svg width="15" height="15" viewBox="0 0 20 20" fill="currentColor" style={{ opacity: 0.7, flexShrink: 0 }}>
         <path fillRule="evenodd" d="M2.166 4.999A11.954 11.954 0 0010 1.944 11.954 11.954 0 0017.834 5c.11.65.166 1.32.166 2.001 0 5.225-3.34 9.67-8 11.317C5.34 16.67 2 12.225 2 7c0-.682.057-1.35.166-2.001zm11.541 3.708a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
@@ -121,7 +131,6 @@ export const NAV_SECTIONS: NavSection[] = [
   {
     id: "board",
     label: "Board",
-    group: "WORKFLOWS",
     icon: (
       <svg width="15" height="15" viewBox="0 0 20 20" fill="currentColor" style={{ opacity: 0.7, flexShrink: 0 }}>
         <path d="M2 4a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H3a1 1 0 01-1-1V4zM3 9a1 1 0 000 2h6a1 1 0 000-2H3zM3 14a1 1 0 000 2h6a1 1 0 000-2H3zM14 9a1 1 0 000 2h3a1 1 0 000-2h-3zM14 14a1 1 0 000 2h3a1 1 0 000-2h-3z" />

--- a/apps/desktop/src/lib/tauri.ts
+++ b/apps/desktop/src/lib/tauri.ts
@@ -9,6 +9,13 @@ import type {
   ComparisonSummary, ComparisonDetail, FileDiffInput, FileDiffRow,
 } from "@harness-kit/shared";
 
+export const DESKTOP_RUNTIME_UNAVAILABLE_MESSAGE =
+  "Browser preview mode: filesystem actions require the Harness Kit desktop runtime.";
+
+export function isTauriRuntimeAvailable(): boolean {
+  return typeof window !== "undefined" && !!(window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
+}
+
 // ── Plugin commands ──────────────────────────────────────────
 
 export async function listInstalledPlugins(): Promise<InstalledPlugin[]> {

--- a/apps/desktop/src/pages/agents/AgentsPage.test.tsx
+++ b/apps/desktop/src/pages/agents/AgentsPage.test.tsx
@@ -64,6 +64,7 @@ function renderPage() {
 describe("AgentsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
   });
 
   it("shows loading skeletons before agents resolve", () => {
@@ -118,6 +119,8 @@ describe("AgentsPage", () => {
     await waitFor(() => {
       expect(screen.getByTestId("add-to-comparator-btn")).toBeDisabled();
     });
+    expect(screen.getByText("1 agent staged for the next comparison.")).toBeInTheDocument();
+    expect(JSON.parse(localStorage.getItem("harness-kit-comparator-staged-agents") ?? "[]")).toEqual(["aider"]);
   });
 
   it("renders protocol badge for each agent", async () => {

--- a/apps/desktop/src/pages/agents/AgentsPage.tsx
+++ b/apps/desktop/src/pages/agents/AgentsPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { useNavigate } from "react-router-dom";
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -224,17 +225,37 @@ function AgentCard({ agent, onAddToComparator }: {
 // ── Page ─────────────────────────────────────────────────────
 
 export default function AgentsPage() {
+  const navigate = useNavigate();
   const [agents, setAgents] = useState<AgentInfo[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [stagedAgentIds, setStagedAgentIds] = useState<Set<string>>(() => {
+    try {
+      return new Set<string>(JSON.parse(localStorage.getItem("harness-kit-comparator-staged-agents") ?? "[]"));
+    } catch {
+      return new Set();
+    }
+  });
 
   useEffect(() => {
     invoke<AgentInfo[]>("detect_agents")
-      .then(setAgents)
+      .then((detected) => {
+        setAgents(detected.map((agent) => (
+          stagedAgentIds.has(agent.id)
+            ? { ...agent, addToComparator: false }
+            : agent
+        )));
+      })
       .catch((e) => setError(String(e)));
-  }, []);
+  }, [stagedAgentIds]);
 
   function handleAddToComparator(id: string) {
-    // Mark the agent as no longer addable (prevents double-clicks)
+    const next = new Set(stagedAgentIds);
+    next.add(id);
+    setStagedAgentIds(next);
+    try {
+      localStorage.setItem("harness-kit-comparator-staged-agents", JSON.stringify([...next]));
+    } catch {}
+
     setAgents((prev) =>
       prev
         ? prev.map((a) => (a.id === id ? { ...a, addToComparator: false } : a))
@@ -267,6 +288,37 @@ export default function AgentsPage() {
             ? `${installedCount} of ${agents.length} agents detected on this machine`
             : "Detecting installed CLI agents…"}
         </p>
+        {stagedAgentIds.size > 0 && (
+          <div style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            marginTop: 14,
+            padding: "10px 12px",
+            borderRadius: 8,
+            border: `1px solid ${tokens.borderBase}`,
+            background: tokens.bgSurface,
+          }}>
+            <span style={{ flex: 1, fontSize: 12, color: tokens.fgMuted }}>
+              {stagedAgentIds.size} agent{stagedAgentIds.size === 1 ? "" : "s"} staged for the next comparison.
+            </span>
+            <button
+              onClick={() => navigate("/comparator")}
+              style={{
+                border: `1px solid ${tokens.accent}`,
+                borderRadius: 6,
+                background: "rgba(14,165,233,0.1)",
+                color: tokens.accent,
+                cursor: "pointer",
+                fontSize: 12,
+                fontWeight: 600,
+                padding: "5px 10px",
+              }}
+            >
+              Open Comparator
+            </button>
+          </div>
+        )}
       </div>
 
       {/* Error state */}

--- a/apps/desktop/src/pages/agents/AgentsPage.tsx
+++ b/apps/desktop/src/pages/agents/AgentsPage.tsx
@@ -246,7 +246,8 @@ export default function AgentsPage() {
         )));
       })
       .catch((e) => setError(String(e)));
-  }, [stagedAgentIds]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   function handleAddToComparator(id: string) {
     const next = new Set(stagedAgentIds);

--- a/apps/desktop/src/pages/board/BoardProjectsPage.tsx
+++ b/apps/desktop/src/pages/board/BoardProjectsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type FormEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { api } from '../../lib/board-api';
 import type { Project } from '../../lib/board-api';
@@ -12,6 +12,10 @@ export default function BoardProjectsPage() {
   const [loading, setLoading] = useState(true);
   const [projects, setProjects] = useState<Project[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [projectName, setProjectName] = useState('');
+  const [projectDescription, setProjectDescription] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!ready) return;
@@ -34,6 +38,27 @@ export default function BoardProjectsPage() {
         setLoading(false);
       });
   }, [ready, navigate]);
+
+  async function handleCreateProject(e: FormEvent) {
+    e.preventDefault();
+    const name = projectName.trim();
+    if (!name || creating) return;
+
+    setCreating(true);
+    setCreateError(null);
+    try {
+      const project = await api.projects.create({
+        name,
+        description: projectDescription.trim() || undefined,
+        color: '#0ea5e9',
+      });
+      navigate(`/board/${project.slug}`, { replace: true });
+    } catch (err) {
+      setCreateError(String(err));
+    } finally {
+      setCreating(false);
+    }
+  }
 
   if (timedOut) {
     return <BoardServerOffline serverState={serverState} />;
@@ -115,24 +140,111 @@ export default function BoardProjectsPage() {
 
   // No projects
   return (
-    <div className="board-scope" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', flexDirection: 'column', gap: 16 }}>
-      <h1 style={{ color: 'var(--text-primary)', fontSize: 20, fontWeight: 600, margin: 0 }}>
-        No projects yet
-      </h1>
-      <p style={{ color: 'var(--text-muted)', fontSize: 14, margin: 0, textAlign: 'center', maxWidth: 320 }}>
-        Create a project with an MCP tool call or from the board server:
-      </p>
-      <code style={{
-        background: 'var(--bg-elevated)',
+    <div className="board-scope" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: '100%', padding: 32 }}>
+      <div style={{
+        width: '100%',
+        maxWidth: 560,
+        background: 'var(--bg-surface)',
         border: '1px solid var(--border)',
-        borderRadius: 6,
-        padding: '8px 16px',
-        fontSize: 13,
-        color: 'var(--text-secondary)',
-        fontFamily: 'monospace',
+        borderRadius: 8,
+        padding: 24,
+        boxShadow: 'var(--shadow-sm)',
       }}>
-        create_project(name: "My Project")
-      </code>
+        <div style={{ marginBottom: 20 }}>
+          <div style={{
+            fontSize: 10,
+            fontWeight: 700,
+            letterSpacing: '0.06em',
+            textTransform: 'uppercase',
+            color: 'var(--accent-text)',
+            marginBottom: 8,
+          }}>
+            Workflow board
+          </div>
+          <h1 style={{ color: 'var(--text-primary)', fontSize: 20, fontWeight: 650, margin: 0 }}>
+            Create your first project
+          </h1>
+          <p style={{ color: 'var(--text-muted)', fontSize: 13, margin: '6px 0 0', lineHeight: 1.55 }}>
+            Set up a local project board for epics, tasks, roadmap conversion, and agent execution.
+          </p>
+        </div>
+
+        <form onSubmit={handleCreateProject} style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <label style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            <span style={{ color: 'var(--text-secondary)', fontSize: 12, fontWeight: 600 }}>Project name</span>
+            <input
+              value={projectName}
+              onChange={e => setProjectName(e.target.value)}
+              placeholder="Enterprise demo workspace"
+              autoFocus
+              style={{
+                background: 'var(--bg-elevated)',
+                border: '1px solid var(--border)',
+                borderRadius: 6,
+                color: 'var(--text-primary)',
+                fontSize: 13,
+                padding: '9px 11px',
+                outline: 'none',
+              }}
+            />
+          </label>
+
+          <label style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            <span style={{ color: 'var(--text-secondary)', fontSize: 12, fontWeight: 600 }}>Description</span>
+            <textarea
+              value={projectDescription}
+              onChange={e => setProjectDescription(e.target.value)}
+              placeholder="Portable AI coding governance, workflows, and observability."
+              rows={3}
+              style={{
+                background: 'var(--bg-elevated)',
+                border: '1px solid var(--border)',
+                borderRadius: 6,
+                color: 'var(--text-primary)',
+                fontFamily: 'inherit',
+                fontSize: 13,
+                lineHeight: 1.5,
+                padding: '9px 11px',
+                resize: 'vertical',
+                outline: 'none',
+              }}
+            />
+          </label>
+
+          {createError && (
+            <div style={{ color: 'var(--danger)', fontSize: 12 }}>
+              {createError}
+            </div>
+          )}
+
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12, marginTop: 4 }}>
+            <code style={{
+              color: 'var(--text-muted)',
+              fontFamily: 'ui-monospace, monospace',
+              fontSize: 11,
+            }}>
+              Local server :4800
+            </code>
+            <button
+              type="submit"
+              disabled={!projectName.trim() || creating}
+              style={{
+                background: projectName.trim() && !creating ? 'var(--accent)' : 'var(--border)',
+                border: 'none',
+                borderRadius: 6,
+                color: '#fff',
+                cursor: projectName.trim() && !creating ? 'pointer' : 'not-allowed',
+                fontSize: 12,
+                fontWeight: 650,
+                padding: '8px 16px',
+                opacity: projectName.trim() && !creating ? 1 : 0.55,
+              }}
+            >
+              {creating ? 'Creating...' : 'Create Project'}
+            </button>
+          </div>
+        </form>
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/pages/board/__tests__/BoardProjectsPage.test.tsx
+++ b/apps/desktop/src/pages/board/__tests__/BoardProjectsPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import BoardProjectsPage from "../BoardProjectsPage";
 import type { Project } from "../../../lib/board-api";
@@ -17,10 +17,11 @@ vi.mock("../../../hooks/useBoardServerReady", () => ({
 // ── Mock board-api ─────────────────────────────────────────────
 
 let mockProjectsList: () => Promise<Project[]>;
+let mockProjectsCreate: (body: { name: string; description?: string; color?: string }) => Promise<Project>;
 
 vi.mock("../../../lib/board-api", () => ({
   get api() {
-    return { projects: { list: mockProjectsList } };
+    return { projects: { list: mockProjectsList, create: mockProjectsCreate } };
   },
   BOARD_SERVER_BASE: "http://localhost:4800",
 }));
@@ -55,6 +56,7 @@ function renderPage() {
 beforeEach(() => {
   mockUseBoardServerReady = () => ({ ready: false });
   mockProjectsList = vi.fn().mockResolvedValue([]);
+  mockProjectsCreate = vi.fn().mockResolvedValue(projectAlpha);
 });
 
 // ── Tests ──────────────────────────────────────────────────────
@@ -99,7 +101,25 @@ describe("BoardProjectsPage — ready with no projects", () => {
 
   it("shows 'No projects yet' message", async () => {
     renderPage();
-    expect(await screen.findByText("No projects yet")).toBeInTheDocument();
+    expect(await screen.findByText("Create your first project")).toBeInTheDocument();
+  });
+
+  it("creates a project from the empty state", async () => {
+    mockProjectsCreate = vi.fn().mockResolvedValue(projectAlpha);
+    renderPage();
+
+    fireEvent.change(await screen.findByPlaceholderText("Enterprise demo workspace"), {
+      target: { value: "Enterprise demo workspace" },
+    });
+    fireEvent.click(screen.getByText("Create Project"));
+
+    await waitFor(() => {
+      expect(mockProjectsCreate).toHaveBeenCalledWith({
+        name: "Enterprise demo workspace",
+        description: undefined,
+        color: "#0ea5e9",
+      });
+    });
   });
 });
 

--- a/apps/desktop/src/pages/comparator/SetupPhase.tsx
+++ b/apps/desktop/src/pages/comparator/SetupPhase.tsx
@@ -57,6 +57,7 @@ const monoStack = 'ui-monospace, "SF Mono", monospace';
 // ── Max harnesses ───────────────────────────────────────────
 
 const MAX_SELECTED = 4;
+const STAGED_AGENTS_KEY = "harness-kit-comparator-staged-agents";
 
 // ── Styles ──────────────────────────────────────────────────
 
@@ -310,16 +311,27 @@ export default function SetupPhase({ onStart }: SetupPhaseProps) {
     invoke<HarnessInfo[]>("detect_harnesses")
       .then((detected) => {
         setHarnesses(detected);
-        // Pre-select all available harnesses (up to MAX_SELECTED).
+        let staged = new Set<string>();
+        try {
+          staged = new Set<string>(JSON.parse(localStorage.getItem(STAGED_AGENTS_KEY) ?? "[]"));
+        } catch {}
+
         const map = new Map<string, HarnessSelection>();
         let count = 0;
+        const availableStaged = detected.filter((h) => h.available && staged.has(h.id));
+        const preselect = availableStaged.length > 0 ? availableStaged : detected.filter((h) => h.available);
+        const preselectIds = new Set(preselect.slice(0, MAX_SELECTED).map((h) => h.id));
+
         for (const h of detected) {
-          if (h.available && count < MAX_SELECTED) {
+          if (preselectIds.has(h.id) && count < MAX_SELECTED) {
             map.set(h.id, { selected: true, model: h.defaultModel ?? null });
             count++;
           } else {
             map.set(h.id, { selected: false, model: h.defaultModel ?? null });
           }
+        }
+        if (availableStaged.length > 0) {
+          try { localStorage.removeItem(STAGED_AGENTS_KEY); } catch {}
         }
         setSelections(map);
       })

--- a/apps/desktop/src/pages/harness/PluginsPage.tsx
+++ b/apps/desktop/src/pages/harness/PluginsPage.tsx
@@ -5,6 +5,7 @@ import {
   listInstalledPlugins, checkPluginUpdates, uninstallPlugin,
   importPluginFromPath, importPluginFromZip,
   exportPluginAsZip, exportPluginToFolder,
+  isTauriRuntimeAvailable,
 } from "../../lib/tauri";
 import type { InstalledPlugin, PluginUpdateInfo } from "@harness-kit/shared";
 import ContextMenu, { type ContextMenuItem } from "../../components/ContextMenu";
@@ -16,6 +17,41 @@ import UninstallDialog from "./plugins/UninstallDialog";
 import { useChat } from "../../contexts/ChatContext";
 import { emitChatShare } from "../../lib/chat-events";
 
+const PREVIEW_PLUGINS: InstalledPlugin[] = [
+  {
+    name: "research",
+    version: "0.3.0",
+    description: "Index source material and synthesize reusable project research.",
+    marketplace: "harness-kit",
+    source: "browser-preview://plugins/research",
+    category: "Knowledge",
+    tags: ["research", "memory"],
+    component_counts: { skills: 1, agents: 0, scripts: 2 },
+  },
+  {
+    name: "board",
+    version: "0.2.0",
+    description: "Manage project tasks through a lightweight local Kanban board.",
+    marketplace: "harness-kit",
+    source: "browser-preview://plugins/board",
+    category: "Operate",
+    tags: ["workflow", "tasks"],
+    component_counts: { skills: 1, agents: 0, scripts: 1 },
+  },
+  {
+    name: "harness-share",
+    version: "0.3.0",
+    description: "Compile and sync harness.yaml across AI tool configurations.",
+    marketplace: "harness-kit",
+    source: "browser-preview://plugins/harness-share",
+    category: "Configure",
+    tags: ["sync", "configuration"],
+    component_counts: { skills: 4, agents: 0, scripts: 3 },
+  },
+];
+
+const DESKTOP_RUNTIME_MESSAGE = "Browser preview mode: plugin filesystem actions require the Harness Kit desktop runtime.";
+
 export default function PluginsPage() {
   const navigate = useNavigate();
   const { state: chatState } = useChat();
@@ -23,6 +59,8 @@ export default function PluginsPage() {
   const [updates, setUpdates] = useState<Record<string, PluginUpdateInfo>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [runtimeNotice, setRuntimeNotice] = useState<string | null>(null);
+  const [tauriAvailable] = useState(isTauriRuntimeAvailable);
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; plugin: InstalledPlugin } | null>(null);
 
   // Filters
@@ -37,6 +75,17 @@ export default function PluginsPage() {
   const [uninstallTarget, setUninstallTarget] = useState<InstalledPlugin | null>(null);
 
   const loadPlugins = useCallback(() => {
+    if (!tauriAvailable) {
+      setPlugins(PREVIEW_PLUGINS);
+      setUpdates({});
+      setError(null);
+      setRuntimeNotice(DESKTOP_RUNTIME_MESSAGE);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setRuntimeNotice(null);
     listInstalledPlugins()
       .then(setPlugins)
       .catch((e) => setError(String(e)))
@@ -49,9 +98,13 @@ export default function PluginsPage() {
         setUpdates(map);
       })
       .catch(() => {}); // updates are best-effort
-  }, []);
+  }, [tauriAvailable]);
 
   useEffect(loadPlugins, [loadPlugins]);
+
+  function showDesktopOnlyNotice() {
+    setRuntimeNotice(DESKTOP_RUNTIME_MESSAGE);
+  }
 
   // Derived data
   const categories = useMemo(
@@ -104,6 +157,11 @@ export default function PluginsPage() {
     dragRef.current = 0;
     setDragCount(0);
 
+    if (!tauriAvailable) {
+      showDesktopOnlyNotice();
+      return;
+    }
+
     const files = e.dataTransfer.files;
     if (files.length === 0) return;
 
@@ -134,6 +192,11 @@ export default function PluginsPage() {
   // ── Import from folder picker ────────────────────────────
 
   async function handleImportFolder() {
+    if (!tauriAvailable) {
+      showDesktopOnlyNotice();
+      return;
+    }
+
     try {
       const { open } = await import("@tauri-apps/plugin-dialog");
       const selected = await open({ directory: true, title: "Select plugin folder" });
@@ -162,6 +225,12 @@ export default function PluginsPage() {
 
   async function handleUninstall() {
     if (!uninstallTarget) return;
+    if (!tauriAvailable) {
+      setUninstallTarget(null);
+      showDesktopOnlyNotice();
+      return;
+    }
+
     const pluginName = uninstallTarget.name;
     try {
       await uninstallPlugin(pluginName);
@@ -179,6 +248,14 @@ export default function PluginsPage() {
   // ── Context menu builder ─────────────────────────────────
 
   function buildContextMenuItems(plugin: InstalledPlugin): ContextMenuItem[] {
+    if (!tauriAvailable) {
+      return [
+        { label: "Copy name", onClick: () => navigator.clipboard.writeText(plugin.name) },
+        { separator: true },
+        { label: "Desktop runtime required", onClick: showDesktopOnlyNotice },
+      ];
+    }
+
     return [
       { label: "Copy name", onClick: () => navigator.clipboard.writeText(plugin.name) },
       {
@@ -244,11 +321,14 @@ export default function PluginsPage() {
         <div style={{ display: "flex", gap: "8px" }}>
           <button
             onClick={handleImportFolder}
+            disabled={!tauriAvailable}
+            title={tauriAvailable ? "Import a plugin folder" : DESKTOP_RUNTIME_MESSAGE}
             style={{
               fontSize: "12px", fontWeight: 500, padding: "5px 12px",
               borderRadius: "6px", border: "1px solid var(--accent)",
               background: "rgba(91,80,232,0.08)", color: "var(--accent-text)",
-              cursor: "pointer",
+              cursor: tauriAvailable ? "pointer" : "not-allowed",
+              opacity: tauriAvailable ? 1 : 0.65,
             }}
           >
             Import Plugin
@@ -272,6 +352,16 @@ export default function PluginsPage() {
 
       {/* Import banner */}
       <ImportBanner status={importStatus} onDismiss={() => setImportStatus(null)} />
+
+      {runtimeNotice && (
+        <div style={{
+          background: "rgba(91,80,232,0.08)", border: "1px solid rgba(139,92,246,0.35)",
+          borderRadius: "8px", padding: "10px 14px", fontSize: "12px", color: "var(--fg-muted)",
+          marginBottom: "12px",
+        }}>
+          {runtimeNotice}
+        </div>
+      )}
 
       {loading && (
         <p style={{ fontSize: "13px", color: "var(--fg-subtle)" }}>Loading…</p>
@@ -338,7 +428,13 @@ export default function PluginsPage() {
                   update={updates[plugin.name]}
                   index={i}
                   isLast={i === filtered.length - 1}
-                  onClick={() => navigate(`/harness/plugins/${encodeURIComponent(plugin.name)}`)}
+                  onClick={() => {
+                    if (!tauriAvailable) {
+                      showDesktopOnlyNotice();
+                      return;
+                    }
+                    navigate(`/harness/plugins/${encodeURIComponent(plugin.name)}`);
+                  }}
                   onContextMenu={(e) => {
                     setContextMenu({ x: e.clientX, y: e.clientY, plugin });
                   }}

--- a/apps/desktop/src/pages/marketplace/MarketplacePage.tsx
+++ b/apps/desktop/src/pages/marketplace/MarketplacePage.tsx
@@ -25,6 +25,60 @@ const COMPONENT_TYPES: ComponentType[] = [
   "rules",
 ];
 
+const LOCAL_COMPONENTS: Component[] = [
+  {
+    id: "local-explain",
+    slug: "explain",
+    name: "Explain",
+    type: "skill",
+    description: "Layered code explanations for files, directories, and concepts.",
+    trust_tier: "official",
+    version: "0.2.0",
+    author: { name: "harnessprotocol" },
+    license: "Apache-2.0",
+    skill_md: null,
+    readme_md: "## Usage\n\nInstall with `/plugin install explain@harness-kit`, then run `/explain src/auth/`.",
+    repo_url: "https://github.com/harnessprotocol/harness-kit",
+    install_count: 0,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+  {
+    id: "local-research",
+    slug: "research",
+    name: "Research",
+    type: "skill",
+    description: "Process sources into a structured, compounding knowledge base.",
+    trust_tier: "official",
+    version: "0.3.0",
+    author: { name: "harnessprotocol" },
+    license: "Apache-2.0",
+    skill_md: null,
+    readme_md: "## Usage\n\nInstall with `/plugin install research@harness-kit`, then run `/research https://...`.",
+    repo_url: "https://github.com/harnessprotocol/harness-kit",
+    install_count: 0,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+  {
+    id: "local-review",
+    slug: "review",
+    name: "Review",
+    type: "skill",
+    description: "Comprehensive code review with severity labels and cross-file analysis.",
+    trust_tier: "official",
+    version: "0.2.0",
+    author: { name: "harnessprotocol" },
+    license: "Apache-2.0",
+    skill_md: null,
+    readme_md: "## Usage\n\nInstall with `/plugin install review@harness-kit`, then run `/review`.",
+    repo_url: "https://github.com/harnessprotocol/harness-kit",
+    install_count: 0,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+];
+
 export default function MarketplacePage() {
   const navigate = useNavigate();
   const { slug: selectedSlug } = useParams<{ slug?: string }>();
@@ -69,7 +123,7 @@ export default function MarketplacePage() {
   const [componentCategories, setComponentCategories] = useState<ComponentCategory[]>([]);
   const [componentTags, setComponentTags] = useState<ComponentTag[]>([]);
   const [tags, setTags] = useState<TagRow[]>([]);
-  const [listLoading, setListLoading] = useState(true);
+  const [listLoading, setListLoading] = useState(() => Boolean(supabase));
   const [listError, setListError] = useState<string | null>(null);
 
   // ── Detail panel state ──────────────────────────────────────
@@ -82,6 +136,7 @@ export default function MarketplacePage() {
   // ── Load list data ──────────────────────────────────────────
   useEffect(() => {
     if (!supabase) {
+      setComponents(LOCAL_COMPONENTS);
       setListLoading(false);
       return;
     }
@@ -120,6 +175,12 @@ export default function MarketplacePage() {
     }
 
     if (!supabase) {
+      const local = LOCAL_COMPONENTS.find((c) => c.slug === selectedSlug);
+      setDetail(local ?? null);
+      setDetailTags([]);
+      setRelated(LOCAL_COMPONENTS.filter((c) => c.slug !== selectedSlug).slice(0, 5));
+      setNotFound(!local);
+      setDetailLoading(false);
       return;
     }
 
@@ -277,36 +338,6 @@ export default function MarketplacePage() {
       })
     : null;
 
-  // ── No Supabase ─────────────────────────────────────────────
-  if (!supabase) {
-    return (
-      <div style={{ display: "flex", height: "100%", overflow: "hidden" }}>
-        <div style={{ width: "40%", borderRight: "1px solid var(--border-base)", padding: "20px 20px", overflowY: "auto" }}>
-          <PageHeader />
-          <div style={{
-            background: "var(--bg-surface)",
-            border: "1px solid var(--border-base)",
-            borderRadius: "8px",
-            padding: "32px 16px",
-            textAlign: "center",
-          }}>
-            <p style={{ fontSize: "13px", color: "var(--fg-muted)", margin: 0 }}>
-              Supabase not configured.
-            </p>
-            <p style={{ fontSize: "11px", color: "var(--fg-subtle)", margin: "4px 0 0" }}>
-              Add <code style={{ fontFamily: "ui-monospace, monospace" }}>VITE_SUPABASE_URL</code> and{" "}
-              <code style={{ fontFamily: "ui-monospace, monospace" }}>VITE_SUPABASE_ANON_KEY</code> to{" "}
-              <code style={{ fontFamily: "ui-monospace, monospace" }}>apps/desktop/.env</code>.
-            </p>
-          </div>
-        </div>
-        <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center" }}>
-          <p style={{ fontSize: "13px", color: "var(--fg-subtle)" }}>Select a plugin to view details</p>
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div style={{ display: "flex", height: "100%", overflow: "hidden" }}>
       {/* ── Master panel ── */}
@@ -321,6 +352,24 @@ export default function MarketplacePage() {
         {/* Fixed header + filters */}
         <div style={{ padding: "20px 20px 0", flexShrink: 0 }}>
           <PageHeader />
+
+          {!supabase && (
+            <div style={{
+              background: "var(--warning-light)",
+              border: "1px solid rgba(217,119,6,0.22)",
+              borderRadius: "8px",
+              padding: "9px 10px",
+              marginBottom: "12px",
+              fontSize: "11px",
+              lineHeight: 1.45,
+              color: "var(--fg-muted)",
+            }}>
+              <strong style={{ color: "var(--fg-base)" }}>Supabase not configured.</strong>{" "}
+              Showing a local demo catalog. Add{" "}
+              <code style={{ fontFamily: "ui-monospace, monospace" }}>VITE_SUPABASE_URL</code> and{" "}
+              <code style={{ fontFamily: "ui-monospace, monospace" }}>VITE_SUPABASE_ANON_KEY</code> to use the live marketplace.
+            </div>
+          )}
 
           {/* Active tag filter banner */}
           {selectedTag && (


### PR DESCRIPTION
## Summary
This PR moves the desktop app closer to an enterprise-ready demo by tightening the first-run story, navigation model, and core empty states around Configure, Operate, and Govern. It also makes browser preview mode safer by avoiding raw Tauri runtime errors on the Plugins page and providing useful demo fallback data where live desktop APIs are unavailable.

## Changes
- Reframed the welcome screen and sidebar taxonomy around Configure / Operate / Govern, including a real Terminals route and clearer Comparator placement.
- Added a create-project flow to the Board empty state so the first Board interaction is actionable instead of static.
- Added agent staging from Agents into Comparator and preselection support when entering Comparator setup.
- Added a local Marketplace fallback catalog for no-Supabase/browser-preview mode.
- Added a Plugins browser-preview fallback with a reusable Tauri runtime availability helper and desktop-only gating for plugin filesystem actions.

## Test Plan
- [x] Local tests pass: `pnpm test:desktop`
- [x] Browser preview verified at `http://127.0.0.1:1422/harness/plugins` with no raw `invoke` error
- [ ] CI checks pass

## Notes
- The first sandboxed `pnpm test:desktop` run failed only in Rust local port-binding tests with `PermissionDenied`; rerunning the same command with local socket permission passed.
- `pnpm test:desktop` intentionally excludes e2e and prints `Run test:desktop:e2e separately (requires dev server)`.
