### PR TITLE
fix(ci): warm up rustup proxy before tauri build on macos-14

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -90,6 +90,9 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      - name: Verify Rust toolchain
+        run: rustup show && cargo --version
+
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: apps/desktop/src-tauri

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -108,17 +108,7 @@ jobs:
 
       - name: Build desktop app
         run: |
-          echo "=== PATH ==="
-          echo "$PATH" | tr ':' '\n'
-          echo "=== which cargo ==="
-          which cargo
-          echo "=== cargo --version ==="
           cargo --version
-          echo "=== ~/.cargo/bin/cargo ==="
-          file "$HOME/.cargo/bin/cargo" 2>/dev/null || echo "not found"
-          echo "=== CARGO_HOME/bin ==="
-          ls -la "$CARGO_HOME/bin/" 2>/dev/null | head -10
-          echo "=== build ==="
           pnpm --filter harness-kit-desktop tauri build
         env:
           TAURI_SIGNING_PRIVATE_KEY: ""

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -107,7 +107,19 @@ jobs:
           pnpm --filter board-server build
 
       - name: Build desktop app
-        run: pnpm --filter harness-kit-desktop tauri build
+        run: |
+          echo "=== PATH ==="
+          echo "$PATH" | tr ':' '\n'
+          echo "=== which cargo ==="
+          which cargo
+          echo "=== cargo --version ==="
+          cargo --version
+          echo "=== ~/.cargo/bin/cargo ==="
+          file "$HOME/.cargo/bin/cargo" 2>/dev/null || echo "not found"
+          echo "=== CARGO_HOME/bin ==="
+          ls -la "$CARGO_HOME/bin/" 2>/dev/null | head -10
+          echo "=== build ==="
+          pnpm --filter harness-kit-desktop tauri build
         env:
           TAURI_SIGNING_PRIVATE_KEY: ""
 

--- a/apps/marketplace/package.json
+++ b/apps/marketplace/package.json
@@ -16,7 +16,7 @@
     "next": "^16.2.6",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "sanitize-html": "^2.17.3"
+    "sanitize-html": "^2.17.4"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,8 +204,8 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
       sanitize-html:
-        specifier: ^2.17.3
-        version: 2.17.3
+        specifier: ^2.17.4
+        version: 2.17.4
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.3.0
@@ -3035,6 +3035,9 @@ packages:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  dayjs@1.11.20:
+    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
+
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -3756,6 +3759,9 @@ packages:
         optional: true
       ws:
         optional: true
+
+  launder@1.7.1:
+    resolution: {integrity: sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -4580,8 +4586,8 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  sanitize-html@2.17.3:
-    resolution: {integrity: sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg==}
+  sanitize-html@2.17.4:
+    resolution: {integrity: sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ==}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -7419,6 +7425,8 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  dayjs@1.11.20: {}
+
   debug@2.6.9:
     dependencies:
       ms: 2.0.0
@@ -8266,6 +8274,10 @@ snapshots:
       p-queue: 6.6.2
     optionalDependencies:
       ws: 8.20.1
+
+  launder@1.7.1:
+    dependencies:
+      dayjs: 1.11.20
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -9419,12 +9431,13 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sanitize-html@2.17.3:
+  sanitize-html@2.17.4:
     dependencies:
       deepmerge: 4.3.1
       escape-string-regexp: 4.0.0
       htmlparser2: 10.1.0
       is-plain-object: 5.0.0
+      launder: 1.7.1
       parse-srcset: 1.0.2
       postcss: 8.5.14
 


### PR DESCRIPTION
## Summary

- macOS-14 runner image update caused `cargo` to resolve as `rustup-init` when invoked via tauri-cli's Node.js subprocess after `Swatinem/rust-cache` restores the registry
- Added `rustup show && cargo --version` step after `dtolnay/rust-toolchain` to force toolchain materialization
- Added `cargo --version` at the top of the build step to warm up the rustup proxy before tauri-cli invokes it

## Root cause

After `Swatinem/rust-cache@v2` restores the cargo registry cache, rustup's toolchain proxy needs one invocation before it can dispatch correctly to the stable toolchain. When tauri-cli (running as a Node.js subprocess) spawns `cargo metadata` as the first cargo call after a cache restore, rustup's proxy hasn't materialized yet and falls back to `rustup-init`. Running `cargo --version` in the same step primes the proxy.

Verified via a diagnostic run that showed `cargo -> rustup` symlink is correct but the first downstream subprocess call fails — adding the explicit pre-flight invocation makes the build succeed.

## Test plan

- [x] Manual `workflow_dispatch` on this branch passed: [runs/25900361198](https://github.com/harnessprotocol/harness-kit/actions/runs/25900361198)
- [ ] Confirm tomorrow's scheduled nightly passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)