### PR TITLE
fix(release): make npm publish opt-in, decouple from github release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,7 @@ jobs:
 
   build-cli-npm:
     needs: [prepare, gate]
+    if: secrets.NPM_TOKEN != ''
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -233,7 +234,7 @@ jobs:
           retention-days: 1
 
   release:
-    needs: [prepare, build-cli-npm, build-cli-standalone, build-desktop]
+    needs: [prepare, build-cli-standalone, build-desktop]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## What

- `build-cli-npm` now runs only when `NPM_TOKEN` secret is set (`if: secrets.NPM_TOKEN != ''`)
- Removed `build-cli-npm` from `release`'s `needs` — GitHub Release + Homebrew tap update are independent of npm publishing

## Why

v0.8.1 release was blocked because `NPM_TOKEN` isn't configured. The GitHub release (binaries + Homebrew) and npm are separate distribution channels; one shouldn't gate the other.

When `NPM_TOKEN` is added to repo secrets later, the job resumes automatically on the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)