### PR TITLE
fix(release): remove build-cli-npm until NPM_TOKEN is configured

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,37 +62,8 @@ jobs:
       - name: Build and test all packages
         run: pnpm turbo run build test
 
-  build-cli-npm:
-    needs: [prepare, gate]
-    if: secrets.NPM_TOKEN != ''
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: pnpm/action-setup@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: pnpm
-          registry-url: https://registry.npmjs.org
-
-      - name: Stamp version
-        run: bash scripts/stamp-version.sh ${{ needs.prepare.outputs.version }}
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build packages
-        run: pnpm turbo run build --filter=@harness-kit/cli...
-
-      - name: Publish to npm
-        run: |
-          pnpm --filter @harness-kit/shared publish --no-git-checks
-          pnpm --filter @harness-kit/core publish --no-git-checks
-          pnpm --filter @harness-kit/cli publish --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  # build-cli-npm is omitted until NPM_TOKEN is configured in repo secrets.
+  # To re-enable: add the job back with needs: [prepare, gate] and set NPM_TOKEN.
 
   build-cli-standalone:
     needs: [prepare, gate]


### PR DESCRIPTION
## What

Remove the `build-cli-npm` job from `release.yml`.

## Why

PR #228 tried `if: secrets.NPM_TOKEN != ''` on the job — but GitHub Actions doesn't allow `secrets` context in job-level `if` conditions. This caused a workflow parse failure on the v0.8.1 release run.

Simplest fix: remove the job until `NPM_TOKEN` is configured. The comment in the file marks where to restore it.

## To re-enable npm publishing later

Add `NPM_TOKEN` to repo secrets, then restore the job (needs `[prepare, gate]`) with the standard `actions/setup-node` + `pnpm publish` steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)