### PR TITLE
feat: add rubber-ducky plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -88,6 +88,16 @@
       "tags": ["code-review", "pull-request", "static-analysis", "github"]
     },
     {
+      "name": "rubber-ducky",
+      "source": "./plugins/rubber-ducky",
+      "description": "A constructive critic that gives a second opinion on your own plans, designs, code, and tests — spawning independent read-only reviewers on different Claude models than the one driving the session",
+      "version": "0.1.0",
+      "author": { "name": "harnessprotocol" },
+      "license": "Apache-2.0",
+      "category": "code-quality",
+      "tags": ["rubber-duck", "second-opinion", "critique", "debugging", "code-review", "multi-model"]
+    },
+    {
       "name": "docgen",
       "source": "./plugins/docgen",
       "description": "Generate or update README, API docs, architecture overview, or changelog — always confirms before writing",

--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ A few highlights to get started:
 | [`research`](plugins/research/skills/research/README.md) | Process any source into a structured, compounding knowledge base | `/research https://...` |
 | [`review`](plugins/review/skills/review/README.md) | Code review with severity labels and cross-file analysis | `/review` |
 | [`lineage`](plugins/lineage/skills/lineage/README.md) | Column-level data lineage through SQL, Kafka, Spark, and JDBC | `/lineage orders.amount` |
+| [`rubber-ducky`](plugins/rubber-ducky/skills/rubber-ducky/README.md) | Cross-model second opinion on your plans and code before you commit | `/rubber-ducky` |
 
-> 📋 **[Browse all 16 plugins →](.claude-plugin/marketplace.json)** or run `/plugin marketplace browse harness-kit`
+> 📋 **[Browse all 17 plugins →](.claude-plugin/marketplace.json)** or run `/plugin marketplace browse harness-kit`
 
 ### 🌍 Community
 

--- a/packages/marketplace-data/__tests__/generate.test.ts
+++ b/packages/marketplace-data/__tests__/generate.test.ts
@@ -18,7 +18,7 @@ async function getData(): Promise<MarketplaceData> {
 describe("generateMarketplaceData", () => {
   it("emits every plugin from marketplace.json", async () => {
     const data = await getData();
-    expect(data.plugins.length).toBe(16);
+    expect(data.plugins.length).toBe(17);
     expect(data.owner).toBe("harnessprotocol");
     expect(data.marketplaceName).toBe("harness-kit");
   });

--- a/plugins/rubber-ducky/.claude-plugin/plugin.json
+++ b/plugins/rubber-ducky/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "rubber-ducky",
+  "description": "A constructive critic that gives a second opinion on your own plans, designs, code, and tests — spawning independent read-only reviewers on different Claude models than the one driving the session",
+  "version": "0.1.0",
+  "category": "code-quality",
+  "tags": ["rubber-duck", "second-opinion", "critique", "debugging", "code-review", "multi-model"],
+  "x-developed-with": "claude-opus-4-8"
+}

--- a/plugins/rubber-ducky/skills/rubber-ducky/README.md
+++ b/plugins/rubber-ducky/skills/rubber-ducky/README.md
@@ -1,0 +1,54 @@
+# rubber-ducky
+
+A constructive critic that gives a second opinion on your own plans, designs, code, and tests —
+spawning independent read-only reviewers on **different Claude models** than the one driving your
+session.
+
+## Usage
+
+```
+/plugin install rubber-ducky@harness-kit
+```
+
+Then, at a high-leverage moment:
+
+```
+/rubber-ducky                      # critique the current plan / work
+/rubber-ducky what edge cases am I missing?
+"rubber duck this before I build it"
+"poke holes in my approach"
+```
+
+It also fires proactively — after you plan a non-trivial change, mid-way through complex work, after
+writing tests, or when you're stuck on repeated failures.
+
+## What You Get
+
+Two independent critics run in parallel on the two models your session *isn't* using (e.g. on Opus,
+you get Sonnet + Haiku). Their findings are synthesized into three tiers:
+
+- **Blocking** — must fix for the work to succeed
+- **Non-blocking** — should fix to improve quality
+- **Suggestions** — lower-priority but real
+
+Each finding is *issue → impact → concrete fix*. Where both models agree, confidence is high; where
+they diverge, that's surfaced too. "No issues found" is a valid result — it won't invent nitpicks.
+
+## Why different models
+
+A model that didn't produce the work is far more likely to see what's wrong with it. Running the
+critics on different models from the session means you get genuinely independent perspectives rather
+than a re-run of the same reasoning that produced the plan — fewer shared blind spots.
+
+## rubber-ducky vs review
+
+- **rubber-ducky** pressure-tests your *in-progress thinking* (a plan, design, or approach) **before
+  or during** implementation, using cross-model critics.
+- **review** evaluates a *finished* branch diff or PR after the code exists.
+
+Reach for the duck while the decision is still cheap to change; reach for `/review` when the work is done.
+
+## Notes
+
+- Read-only. The critics never modify files or run stateful commands — they review, you decide.
+- Skips trivial changes (one-line fixes, renames) so it doesn't slow down quick edits.

--- a/plugins/rubber-ducky/skills/rubber-ducky/SKILL.md
+++ b/plugins/rubber-ducky/skills/rubber-ducky/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: rubber-ducky
+description: >-
+  Use when you've planned a non-trivial change and are about to implement it, finished a complex
+  or multi-file piece of work, just wrote tests, or are stuck on repeated failures — and any time
+  the user says "rubber duck this", "rubber ducky", "get a second opinion", "sanity-check my plan",
+  "poke holes in this", "what am I missing", "critique my approach", "review this before I build it",
+  or "/rubber-ducky". Spawns independent read-only critics on DIFFERENT Claude models than the one
+  driving the session to catch blind spots, design flaws, and substantive bugs while course
+  corrections are still cheap. Skip it only for small, obvious, well-understood changes. Do NOT use
+  for reviewing a finished diff or PR — use /review for that; rubber-ducky pressure-tests your own
+  in-progress thinking before and during implementation.
+---
+
+# Rubber Ducky
+
+A built-in critic. Before committing to a non-trivial change, you stop, articulate your current
+thinking, and have it scrutinized by independent reviewers running on **different models** than the
+one driving this session. Unlike a real rubber duck, this one talks back: it returns a structured
+critique you can act on.
+
+## Why this works
+
+Rubber-duck debugging works because *articulating* your reasoning forces the gaps into view. This
+version adds two things a desk toy can't:
+
+1. **It talks back.** The reviewers return concrete, categorized feedback — not silence.
+2. **It doesn't share your blind spots.** The reviewers run on the two Claude models you are *not*
+   using right now, with a clean context. A model that didn't produce the work is far more likely
+   to see what's wrong with it. You get genuinely independent perspectives, not a re-run of the same
+   reasoning that produced the plan.
+
+The single highest-leverage moment is **after you've planned a change but before you've written the
+code**. A design flaw caught here costs a paragraph to fix; caught after implementation it costs a
+rewrite.
+
+## rubber-ducky vs /review
+
+Both are read-only critics, but they fire at different stages:
+
+- **rubber-ducky** pressure-tests *your own in-progress thinking* — a plan, a design, an approach,
+  tests you just wrote — usually **before or during** implementation, using cross-model critics.
+- **/review** evaluates a *finished change* — a branch diff or a PR — after the code exists.
+
+Reach for the duck while the decision is still cheap to change; reach for /review when the work is done.
+
+## When to consult the duck
+
+Consult it at high-leverage moments, not only when stuck:
+
+- **After planning a non-trivial change, before implementing it.** Highest leverage. Corrections are
+  cheapest here.
+- **Mid-implementation on complex or multi-file work**, to check for blind spots before you're in too deep.
+- **After writing tests**, to validate the coverage is real and the behavior actually satisfies the
+  original request — not just that the tests pass.
+- **Reactively, when you hit repeated failures or unexpected results.** Get an independent analysis
+  instead of retrying the same approach a fourth time.
+- **Whenever the user explicitly asks** ("rubber duck this", "/rubber-ducky", "poke holes in this").
+
+**Skip it** for small, well-understood changes — a one-line fix, a rename, an obvious bug. The duck
+adds an extra reasoning pass on two other models; that cost is worth it for architecture, multi-file
+changes, and unfamiliar code, and is just friction for trivial edits. If you decide to skip, say so
+in one line and move on.
+
+## How it works
+
+### 1. Decide it's worth it
+
+If the change is trivial or you're highly confident, skip the duck and say why in one line. Otherwise
+continue.
+
+### 2. Pick the two critic models
+
+You know your current session model from your environment (e.g. Opus, Sonnet, or Haiku). Select the
+**two model aliases the session is NOT using** from `{opus, sonnet, haiku}`:
+
+| Session model | Critic 1 | Critic 2 |
+|---------------|----------|----------|
+| Opus          | `sonnet` | `haiku`  |
+| Sonnet        | `opus`   | `haiku`  |
+| Haiku         | `opus`   | `sonnet` |
+
+Two reviewers on different models surface different failure modes; agreement between them is a strong
+signal, disagreement is worth flagging. If only one other model is available in this harness, run one
+critic — the cross-model independence still holds.
+
+### 3. Articulate the work (the brief)
+
+Write a concise brief the reviewers can act on cold — they don't share your conversation. Include:
+
+- **The goal** — what this change is actually trying to accomplish, and why.
+- **The work to review** — the plan, design, diff, or tests. Paste short artifacts inline; for larger
+  ones, give exact file paths (and a diff range or commit) and let the reviewer read them.
+- **Key assumptions** you're making, and anything you're unsure about or want pressure-tested.
+- **Scope boundaries** — what is explicitly out of scope, so the reviewer doesn't flag it.
+
+A vague brief gets a vague critique. Be specific about what "success" means.
+
+### 4. Spawn both critics in parallel
+
+Spawn the two reviewers in a **single message with two subagent calls** so they run concurrently. Use
+a general-purpose subagent, set the `model` to the alias for each critic, and give each the same brief
+wrapped in the critic instructions below. The reviewers are **read-only**: the brief tells them never
+to edit files or run mutating commands. They explore the codebase to understand context, then report
+back. They do not change anything — you decide what to do with the feedback.
+
+### 5. Synthesize the two critiques
+
+- **Where the two models agree** → high confidence; treat it as real.
+- **Where they disagree** → flag it explicitly; use your own judgment, and investigate if it's blocking.
+- **Dedup** overlapping findings. Order by severity: blocking first.
+
+### 6. Decide and report back
+
+Summarize for the user what *mattered* and what you'll do about it — don't dump both critiques verbatim:
+
+> "The duck flagged a blind spot in my plan around concurrent writes to the cache — both models caught
+> it — so I'm adding a lock before I implement. Sonnet also suggested X (non-blocking); I'll skip that
+> for now."
+
+Then act on the blocking items (or let the user decide). The duck reviews; you remain the one who
+changes code.
+
+## The critic instructions
+
+Send each reviewer a prompt built from this template. Fill in the brief from step 3.
+
+```
+You are a rubber-duck critic giving a constructive second opinion. You did NOT write this
+work — that's the point. Your job is to find real problems while they're still cheap to fix.
+
+You are READ-ONLY. Read any files and run any read-only commands you need to understand the
+work in context (how it integrates, what it assumes, what it touches). Never edit files, never
+run a command that changes state. You review; someone else decides.
+
+## The work under review
+
+<GOAL>
+<THE PLAN / DESIGN / DIFF / TESTS, or file paths + diff range to read>
+<KEY ASSUMPTIONS AND OPEN QUESTIONS>
+<WHAT IS OUT OF SCOPE>
+
+## What to look for
+
+Substantive issues that genuinely threaten the success of this work: bugs, logic errors,
+race conditions, security vulnerabilities, design flaws, anti-patterns, performance
+bottlenecks, missing edge cases, tests that pass without actually validating the behavior,
+and assumptions that don't hold.
+
+## What to ignore
+
+Do NOT comment on style, formatting, naming conventions, comment grammar, minor refactors,
+or "best practices" that don't prevent an actual problem. If the work is sound, say so —
+do not invent issues to seem useful.
+
+## How to report
+
+For every issue: state the **issue**, its **impact** (why it matters), and a **concrete
+suggested fix**. Categorize each by severity:
+
+### Blocking
+Issues that must be fixed for the work to succeed.
+
+### Non-blocking
+Issues that should be fixed to improve quality but won't cause failure.
+
+### Suggestions
+Lower-priority improvements that still have real impact.
+
+If you find no issues in a category, write "None." If you find no issues at all, say so
+explicitly and briefly explain why the approach looks sound.
+```
+
+## Output contract (what good looks like)
+
+The reviewers return findings in three severity tiers. When you relay results to the user, preserve
+that structure but stay concise:
+
+- **Blocking** — must fix. Lead with these.
+- **Non-blocking** — should fix.
+- **Suggestions** — nice to have.
+
+Each finding is *issue → impact → fix*. "No issues found" is a valid and valuable result — report it
+plainly rather than manufacturing nitpicks.
+
+## Guardrails
+
+- The duck **never modifies files or runs anything stateful** — it is a critic, not an editor.
+- Don't let the duck slow down trivial work. Triviality is your call; when in doubt on a non-trivial
+  change, consult it.
+- The reviewers see only what's in the brief plus what they read from the codebase — they have no
+  access to this conversation. If the brief omits the goal or a key constraint, the critique will miss it.

--- a/website/content/docs/plugins/code-quality/meta.json
+++ b/website/content/docs/plugins/code-quality/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Code Quality",
-  "pages": ["review", "explain"]
+  "pages": ["review", "explain", "rubber-ducky"]
 }

--- a/website/content/docs/plugins/code-quality/rubber-ducky.mdx
+++ b/website/content/docs/plugins/code-quality/rubber-ducky.mdx
@@ -1,0 +1,88 @@
+---
+sidebar_position: 8
+title: rubber-ducky
+---
+
+> **[View in Marketplace →](#)** for install tracking, related plugins, and profiles.
+
+# rubber-ducky
+
+A constructive critic that gives a second opinion on your own plans, designs, code, and tests —
+spawning independent read-only reviewers on **different Claude models** than the one driving your session.
+
+## Requirements
+
+- **Claude Code** — required (uses subagents with a per-agent model override)
+- No external dependencies
+
+## What It Does
+
+At a high-leverage moment — after planning a non-trivial change, mid-way through complex work, after writing tests, or when stuck on repeated failures — the duck:
+
+1. Decides whether the change is non-trivial enough to be worth a critique (skips trivial edits)
+2. Picks the two model aliases your session is **not** using, from `{opus, sonnet, haiku}`
+3. Articulates the work into a self-contained brief: the goal, the plan/diff/tests, key assumptions, and scope boundaries
+4. Spawns two **read-only** critics in parallel, one per model
+5. Synthesizes their findings — agreement signals high confidence, divergence is surfaced
+6. Reports back what mattered and acts on the blocking items
+
+## Why different models
+
+A model that didn't produce the work is far more likely to see what's wrong with it. Running the critics on the two models your session isn't using means you get genuinely independent perspectives rather than a re-run of the same reasoning that produced the plan — fewer shared blind spots.
+
+| Session model | Critic 1 | Critic 2 |
+|---------------|----------|----------|
+| Opus          | `sonnet` | `haiku`  |
+| Sonnet        | `opus`   | `haiku`  |
+| Haiku         | `opus`   | `sonnet` |
+
+## Output Structure
+
+Findings come back in three severity tiers, each as *issue → impact → concrete fix*:
+
+| Tier | Meaning |
+|------|---------|
+| **Blocking** | Must be fixed for the work to succeed |
+| **Non-blocking** | Should be fixed to improve quality, but won't cause failure |
+| **Suggestions** | Lower-priority improvements that still have real impact |
+
+"No issues found" is a valid and valuable result — the duck won't manufacture nitpicks to seem useful. It deliberately ignores style, formatting, naming, and minor refactors.
+
+## Usage
+
+### Critique the current plan or work
+
+```
+/rubber-ducky
+```
+
+### Focus the critique
+
+```
+/rubber-ducky what edge cases am I missing?
+```
+
+It also fires from natural phrasing — "rubber duck this before I build it", "poke holes in my approach", "sanity-check my plan", "what am I missing here".
+
+## rubber-ducky vs review
+
+Both are read-only critics, but they fire at different stages:
+
+- **rubber-ducky** pressure-tests your *in-progress thinking* — a plan, design, or approach — **before or during** implementation, using cross-model critics.
+- **[review](code-quality/review)** evaluates a *finished* branch diff or PR after the code exists.
+
+Reach for the duck while the decision is still cheap to change; reach for `/review` when the work is done.
+
+## Design Notes
+
+### Why read-only?
+
+The critics review; you decide. They never modify files or run stateful commands, so consulting the duck is always safe — the worst case is spending an extra reasoning pass.
+
+### Why before implementation?
+
+The single highest-leverage moment is after you've planned a change but before you've written the code. A design flaw caught there costs a paragraph to fix; caught after implementation it costs a rewrite.
+
+### Why skip trivial changes?
+
+The duck adds a reasoning pass on two other models. That's worth it for architecture, multi-file changes, and unfamiliar code — and pure friction for a one-line fix or a rename. Triviality is a judgment call; when in doubt on a non-trivial change, consult it.

--- a/website/content/docs/plugins/code-quality/rubber-ducky.mdx
+++ b/website/content/docs/plugins/code-quality/rubber-ducky.mdx
@@ -69,7 +69,7 @@ It also fires from natural phrasing — "rubber duck this before I build it", "p
 Both are read-only critics, but they fire at different stages:
 
 - **rubber-ducky** pressure-tests your *in-progress thinking* — a plan, design, or approach — **before or during** implementation, using cross-model critics.
-- **[review](code-quality/review)** evaluates a *finished* branch diff or PR after the code exists.
+- **[review](review)** evaluates a *finished* branch diff or PR after the code exists.
 
 Reach for the duck while the decision is still cheap to change; reach for `/review` when the work is done.
 

--- a/website/content/docs/plugins/overview.md
+++ b/website/content/docs/plugins/overview.md
@@ -5,7 +5,7 @@ title: Plugin Overview
 
 # Plugins
 
-harness-kit ships 16 plugins across 7 categories. Each packages a proven workflow as a portable prompt template, currently distributed through Claude Code's plugin marketplace.
+harness-kit ships 17 plugins across 7 categories. Each packages a proven workflow as a portable prompt template, currently distributed through Claude Code's plugin marketplace.
 
 ## At a Glance
 
@@ -16,6 +16,7 @@ harness-kit ships 16 plugins across 7 categories. Each packages a proven workflo
 | [capture](research-knowledge/capture) | Capture session information into a staging file for later reflection | None |
 | [review](code-quality/review) | Structured code review for branches, PRs, or paths with severity labels | `gh` CLI (PR review only) |
 | [explain](code-quality/explain) | Layered explanations of files, functions, directories, or concepts | None |
+| [rubber-ducky](code-quality/rubber-ducky) | Cross-model second opinion on your plans, designs, code, and tests before you commit | None |
 | [lineage](data-engineering/lineage) | Column-level lineage tracing through SQL, Kafka, Spark, JDBC | None |
 | [docgen](documentation/docgen) | Generate or update README, API docs, architecture overview, or changelog | None |
 | [open-pr](devops/open-pr) | Pre-flight checks and PR creation: tests, PR, review, CI | `gh` CLI |


### PR DESCRIPTION
## Summary
Adds **rubber-ducky**, a constructive critic that gives a second opinion on your own plans, designs, code, and tests *before* you commit to them. Modeled on the rubber-duck debugging technique and GitHub Copilot's rubber-duck agent: it articulates the in-progress work and has it scrutinized by independent reviewers running on **different Claude models than the one driving the session** — so the critique doesn't share the session model's blind spots. Catches blocking design flaws and substantive bugs while course corrections are still cheap.

## Changes
- **New plugin `plugins/rubber-ducky/`** — `plugin.json` (v0.1.0, code-quality), `SKILL.md`, `README.md`. On a non-trivial change, it spawns two read-only critics on the two model aliases the session isn't using (Opus → Sonnet + Haiku, etc.), each returning findings as *issue → impact → fix* across Blocking / Non-blocking / Suggestion tiers, then synthesizes — agreement signals high confidence, divergence is surfaced.
- **Registered in `marketplace.json`** under code-quality; plugin count bumped 16 → 17.
- **Docs:** new `website/content/docs/plugins/code-quality/rubber-ducky.mdx`, added to `code-quality/meta.json`, plus the overview table/count and the README highlights table + badge.
- Disambiguated from `/review` in both SKILL and docs: rubber-ducky pressure-tests in-progress thinking before/during implementation; `/review` evaluates a finished diff/PR.

## Test Plan
- [x] Manifest checks pass locally: all plugins registered, marketplace↔plugin.json versions aligned, README badge matches count (17), SKILL.md frontmatter present
- [x] `plugin.json` conforms to the Protocol schema (same field set as `review`/`explain`; `x-developed-with` allowed via the `^x-` pattern)
- [x] Manually vibe-checked end-to-end: ran the duck on a deliberately flawed rate-limiter plan — both critics independently caught the three real blockers (per-process state across containers, X-Forwarded-For spoofing, fixed-window burst) and avoided style nitpicks
- [ ] CI checks pass

## Notes
- The jsonschema validation step of `validate-manifests.sh` couldn't run on my machine (system Python 3.14 has a broken `pyexpat`), so I verified schema conformance by inspection against `.github/schema/plugin.schema.json` — CI will run it for real.
- The cross-model mechanism uses Claude Code's per-subagent `model` override. If only one other model is available in a given harness, it runs a single critic — the cross-model independence still holds.