### PR TITLE
feat(marketplace): profiles-first redesign + harness profile support

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -49,6 +49,8 @@ jobs:
           pnpm install --filter "@harness-kit/marketplace-data..." --frozen-lockfile
           pnpm --filter @harness-kit/shared --filter @harness-kit/core build
           pnpm --filter @harness-kit/marketplace-data generate --strict
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
         working-directory: website

--- a/packages/marketplace-data/__tests__/generate.test.ts
+++ b/packages/marketplace-data/__tests__/generate.test.ts
@@ -3,8 +3,10 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { findRepoRoot, generateMarketplaceData } from "../src/generate.js";
 import { parseSkillMarkdown } from "../src/read-skills.js";
+import { buildHarnessYaml } from "../src/profiles.js";
 import { trustFromStatus } from "../src/trust.js";
 import { StaticSource } from "../src/source.js";
+import { validateHarnessYaml } from "@harness-kit/core";
 import type { MarketplaceData } from "../src/types.js";
 
 const repoRoot = findRepoRoot(dirname(fileURLToPath(import.meta.url)));
@@ -114,4 +116,158 @@ describe("StaticSource", () => {
 
 it("finds the repo root from a nested directory", () => {
   expect(findRepoRoot(join(repoRoot, "packages", "marketplace-data", "src"))).toBe(repoRoot);
+});
+
+// ── Profile tests ─────────────────────────────────────────────
+
+describe("profiles", () => {
+  it("emits 3 profiles (data-engineer, full-stack-engineer, research-knowledge)", async () => {
+    const data = await getData();
+    expect(data.profiles).toBeDefined();
+    expect(data.profiles.length).toBe(3);
+    const slugs = data.profiles.map((p) => p.slug).sort();
+    expect(slugs).toEqual(["data-engineer", "full-stack-engineer", "research-knowledge"]);
+  });
+
+  it("resolves all profile components against marketplace plugins", async () => {
+    const data = await getData();
+    for (const profile of data.profiles) {
+      for (const ref of profile.plugins) {
+        expect(
+          ref.resolved,
+          `Profile "${profile.name}": component "${ref.name}" should resolve`,
+        ).toBe(true);
+        expect(ref.slug).toBeDefined();
+        expect(ref.category).toBeDefined();
+        expect(ref.trust).toBeDefined();
+      }
+    }
+  });
+
+  it("sets liveVersion from marketplace plugins (not stale profile pin)", async () => {
+    const data = await getData();
+    for (const profile of data.profiles) {
+      for (const ref of profile.plugins) {
+        if (!ref.resolved) continue;
+        const livePlugin = data.plugins.find((p) => p.name === ref.name);
+        expect(ref.liveVersion).toBe(livePlugin?.version);
+      }
+    }
+  });
+
+  it("computes aggregateTrust as worst-case across resolved plugins", async () => {
+    const data = await getData();
+    const severityOf = (t: string) =>
+      ({ warning: 3, caution: 2, unscanned: 1, verified: 0 })[t] ?? -1;
+
+    for (const profile of data.profiles) {
+      const maxSeverity = profile.plugins
+        .filter((r) => r.resolved && r.trust)
+        .reduce((max, r) => Math.max(max, severityOf(r.trust!)), 0);
+      const expectedSeverity = severityOf(profile.aggregateTrust);
+      expect(
+        expectedSeverity,
+        `Profile "${profile.name}" aggregateTrust severity should be >= per-plugin max`,
+      ).toBeGreaterThanOrEqual(maxSeverity);
+    }
+  });
+
+  it("emits a valid v1 harness.yaml for every profile", async () => {
+    const data = await getData();
+    for (const profile of data.profiles) {
+      const result = validateHarnessYaml(profile.harnessYaml);
+      expect(
+        result.valid,
+        `Profile "${profile.name}" harnessYaml validation errors: ${result.errors
+          .map((e) => `${e.path}: ${e.message}`)
+          .join("; ")}`,
+      ).toBe(true);
+    }
+  });
+
+  it("harnessYaml includes only resolved plugins with live versions", async () => {
+    const data = await getData();
+    for (const profile of data.profiles) {
+      // Every resolved component appears in the harnessYaml
+      const resolved = profile.plugins.filter((r) => r.resolved);
+      for (const ref of resolved) {
+        expect(profile.harnessYaml).toContain(`name: ${ref.name}`);
+        expect(profile.harnessYaml).toContain(`source: harnessprotocol/harness-kit`);
+        // Uses live version, not profile-pinned version
+        if (ref.liveVersion) {
+          expect(profile.harnessYaml).toContain(`version: "${ref.liveVersion}"`);
+        }
+      }
+    }
+  });
+
+  it("derives a human-readable persona from the profile name", async () => {
+    const data = await getData();
+    const byName = Object.fromEntries(data.profiles.map((p) => [p.name, p.persona]));
+    expect(byName["data-engineer"]).toBe("Data Engineer");
+    expect(byName["full-stack-engineer"]).toBe("Full Stack Engineer");
+    expect(byName["research-knowledge"]).toBe("Research Knowledge");
+  });
+
+  it("preserves knowledge and rules from profile YAML", async () => {
+    const data = await getData();
+    const fullStack = data.profiles.find((p) => p.name === "full-stack-engineer");
+    expect(fullStack?.knowledge?.backend).toBe("memory-md");
+    expect(fullStack?.rules.length).toBeGreaterThan(0);
+
+    const dataEngineer = data.profiles.find((p) => p.name === "data-engineer");
+    expect(dataEngineer?.knowledge?.backend).toBe("memory-md");
+    expect(dataEngineer?.knowledge?.seedDocs.length).toBeGreaterThan(0);
+    expect(dataEngineer?.rules.length).toBeGreaterThan(0);
+  });
+
+  it("profiles are sorted by name", async () => {
+    const data = await getData();
+    const names = data.profiles.map((p) => p.name);
+    expect(names).toEqual([...names].sort());
+  });
+
+  it("tags all profiles as first-party", async () => {
+    const data = await getData();
+    expect(data.profiles.every((p) => p.sourceId === "first-party")).toBe(true);
+  });
+});
+
+describe("buildHarnessYaml (unit)", () => {
+  const PROFILE_YAML = {
+    name: "test-profile",
+    description: "A minimal test profile for unit testing the YAML builder.",
+    author: { name: "testauthor" },
+    components: [],
+    rules: ["Always write tests first", "Review before merging"],
+  };
+
+  it("produces YAML that validates against the v1 schema", () => {
+    const yaml = buildHarnessYaml(PROFILE_YAML, [
+      { name: "review", version: "0.3.0" },
+    ]);
+    const result = validateHarnessYaml(yaml);
+    expect(result.valid, result.errors.map((e) => e.message).join("; ")).toBe(true);
+  });
+
+  it("includes rules in instructions.behavioral", () => {
+    const yaml = buildHarnessYaml(PROFILE_YAML, []);
+    expect(yaml).toContain("instructions:");
+    expect(yaml).toContain("behavioral:");
+    expect(yaml).toContain("- Always write tests first");
+    expect(yaml).toContain("- Review before merging");
+  });
+
+  it("truncates description to 256 chars max", () => {
+    const longDesc = "x".repeat(300);
+    const yaml = buildHarnessYaml({ ...PROFILE_YAML, description: longDesc }, []);
+    const result = validateHarnessYaml(yaml);
+    expect(result.valid, result.errors.map((e) => e.message).join("; ")).toBe(true);
+  });
+
+  it("omits plugins block when no resolved plugins passed", () => {
+    const yaml = buildHarnessYaml({ ...PROFILE_YAML, rules: [] }, []);
+    expect(yaml).not.toContain("plugins:");
+    expect(yaml).not.toContain("instructions:");
+  });
 });

--- a/packages/marketplace-data/__tests__/generate.test.ts
+++ b/packages/marketplace-data/__tests__/generate.test.ts
@@ -233,6 +233,42 @@ describe("profiles", () => {
   });
 });
 
+describe("readProfiles — unresolved component handling", () => {
+  it("marks missing components as resolved: false and degrades aggregateTrust", async () => {
+    // Simulate a plugin set that is missing some components from a profile
+    const { readProfiles } = await import("../src/profiles.js");
+    const repoRoot = findRepoRoot(dirname(fileURLToPath(import.meta.url)));
+
+    // Pass a plugin list that only contains one of the data-engineer components
+    const partialPlugins = (await getData()).plugins.filter((p) => p.name === "review");
+
+    const profiles = await readProfiles(repoRoot, partialPlugins);
+    const de = profiles.find((p) => p.name === "data-engineer");
+    expect(de).toBeDefined();
+
+    // All non-"review" components should be unresolved
+    const unresolvedRefs = de!.plugins.filter((r) => !r.resolved);
+    expect(unresolvedRefs.length).toBeGreaterThan(0);
+
+    // Unresolved refs should push aggregate trust to at least caution
+    const severity = { warning: 3, caution: 2, unscanned: 1, verified: 0 };
+    expect(severity[de!.aggregateTrust]).toBeGreaterThanOrEqual(severity["caution"]);
+
+    // Trust breakdown: unresolved refs counted under cautionCount (not unscannedCount)
+    expect(de!.security.cautionCount).toBeGreaterThanOrEqual(unresolvedRefs.length);
+  });
+
+  it("throws in strict mode when a component is unresolved", async () => {
+    const { readProfiles } = await import("../src/profiles.js");
+    const repoRoot = findRepoRoot(dirname(fileURLToPath(import.meta.url)));
+
+    // Empty plugin list — every component will be unresolved
+    await expect(readProfiles(repoRoot, [], /* strict */ true)).rejects.toThrow(
+      /not found in marketplace\.json/,
+    );
+  });
+});
+
 describe("buildHarnessYaml (unit)", () => {
   const PROFILE_YAML = {
     name: "test-profile",

--- a/packages/marketplace-data/package.json
+++ b/packages/marketplace-data/package.json
@@ -19,7 +19,8 @@
   },
   "dependencies": {
     "@harness-kit/core": "workspace:*",
-    "@harness-kit/shared": "workspace:*"
+    "@harness-kit/shared": "workspace:*",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@types/node": "^22.19.19",

--- a/packages/marketplace-data/src/generate.ts
+++ b/packages/marketplace-data/src/generate.ts
@@ -4,6 +4,7 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { readPluginSkills } from "./read-skills.js";
 import { scanForMarketplace } from "./scan.js";
+import { readProfiles, fetchRepoStars } from "./profiles.js";
 import type { MarketplaceCategory, MarketplaceData, MarketplaceMcp, MarketplacePlugin } from "./types.js";
 
 // ── marketplace.json shape (input) ──────────────────────────────
@@ -83,7 +84,7 @@ function toMcp(manifest: RawPluginManifest): MarketplaceMcp | null {
 }
 
 /** Builds the full marketplace data blob from the git repo at `repoRoot`. */
-export async function generateMarketplaceData(repoRoot: string): Promise<MarketplaceData> {
+export async function generateMarketplaceData(repoRoot: string, strict = false): Promise<MarketplaceData> {
   const marketplace = await readJson<RawMarketplace>(
     join(repoRoot, ".claude-plugin", "marketplace.json"),
   );
@@ -130,12 +131,22 @@ export async function generateMarketplaceData(repoRoot: string): Promise<Marketp
     });
   }
 
+  // Profiles are generated AFTER plugins so component refs can resolve
+  const profiles = await readProfiles(repoRoot, plugins, strict);
+
+  // GitHub stars — single fetch for the first-party repo; optional
+  const repoStars = await fetchRepoStars(
+    `${marketplace.owner?.name ?? "harnessprotocol"}/${marketplaceName}`,
+  );
+
   return {
     generatedAt: new Date().toISOString(),
     marketplaceName,
     owner: marketplace.owner?.name ?? "unknown",
     categories,
     plugins,
+    profiles,
+    ...(repoStars !== undefined ? { repoStars } : {}),
   };
 }
 
@@ -160,21 +171,35 @@ async function main(): Promise<void> {
   const repoRoot = findRepoRoot(dirname(fileURLToPath(import.meta.url)));
   const { strict, outPath } = parseArgs(process.argv.slice(2), repoRoot);
 
-  const data = await generateMarketplaceData(repoRoot);
+  const data = await generateMarketplaceData(repoRoot, strict);
 
   await mkdir(dirname(outPath), { recursive: true });
   await writeFile(outPath, `${JSON.stringify(data, null, 2)}\n`, "utf-8");
 
-  const failed = data.plugins.filter((p) => p.security.status === "failed");
-  console.log(
-    `Generated ${data.plugins.length} plugins → ${outPath}` +
-      (failed.length ? ` (${failed.length} failed security scan)` : ""),
+  const failedPlugins = data.plugins.filter((p) => p.security.status === "failed");
+  const unresolvedProfiles = data.profiles.filter((pr) =>
+    pr.plugins.some((ref) => !ref.resolved),
   );
 
-  if (strict && failed.length > 0) {
+  console.log(
+    `Generated ${data.plugins.length} plugins + ${data.profiles.length} profiles → ${outPath}` +
+      (data.repoStars !== undefined ? ` (⭐ ${data.repoStars})` : "") +
+      (failedPlugins.length ? ` (${failedPlugins.length} failed security scan)` : ""),
+  );
+
+  if (strict && failedPlugins.length > 0) {
     console.error(
-      `Strict mode: ${failed.length} plugin(s) failed the security scan: ${failed
+      `Strict mode: ${failedPlugins.length} plugin(s) failed the security scan: ${failedPlugins
         .map((p) => p.name)
+        .join(", ")}`,
+    );
+    process.exitCode = 1;
+  }
+
+  if (strict && unresolvedProfiles.length > 0) {
+    console.error(
+      `Strict mode: ${unresolvedProfiles.length} profile(s) have unresolved components: ${unresolvedProfiles
+        .map((pr) => pr.name)
         .join(", ")}`,
     );
     process.exitCode = 1;

--- a/packages/marketplace-data/src/index.ts
+++ b/packages/marketplace-data/src/index.ts
@@ -6,10 +6,15 @@ export type {
   MarketplaceMcp,
   MarketplacePermissions,
   MarketplacePlugin,
+  MarketplaceProfile,
   MarketplaceSecurity,
   MarketplaceSkill,
   MarketplaceSource,
   PluginSourceId,
+  ProfileKnowledge,
+  ProfilePluginRef,
+  ProfileSecurity,
+  ProfileSeedDoc,
   TrustTier,
 } from "./types.js";
 

--- a/packages/marketplace-data/src/profiles.ts
+++ b/packages/marketplace-data/src/profiles.ts
@@ -149,9 +149,12 @@ export async function readProfiles(
   try {
     const entries = await readdir(profilesDir);
     files = entries.filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"));
-  } catch {
-    // profiles/ directory absent — not an error
-    return [];
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      // profiles/ directory absent — not an error
+      return [];
+    }
+    throw err; // Permission denied, I/O error, etc. — surface it
   }
 
   const pluginMap = new Map(plugins.map((p) => [p.name, p]));
@@ -220,9 +223,11 @@ export async function readProfiles(
       trust: aggregateTrust,
       pluginCount: refs.length,
       verifiedCount: refs.filter((r) => r.trust === "verified").length,
-      cautionCount: refs.filter((r) => r.trust === "caution").length,
+      // Unresolved refs degrade the aggregate to "caution" (see aggregateTrust logic above),
+      // so count them under cautionCount to keep the headline and breakdown consistent.
+      cautionCount: refs.filter((r) => r.trust === "caution" || !r.resolved).length,
       warningCount: refs.filter((r) => r.trust === "warning").length,
-      unscannedCount: refs.filter((r) => r.trust === "unscanned" || !r.resolved).length,
+      unscannedCount: refs.filter((r) => r.trust === "unscanned").length,
     };
 
     profiles.push({

--- a/packages/marketplace-data/src/profiles.ts
+++ b/packages/marketplace-data/src/profiles.ts
@@ -1,0 +1,245 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { validateHarnessYaml } from "@harness-kit/core";
+import type { ProfileYaml } from "@harness-kit/shared";
+import type {
+  MarketplacePlugin,
+  MarketplaceProfile,
+  ProfileKnowledge,
+  ProfilePluginRef,
+  TrustTier,
+} from "./types.js";
+
+// ── Trust severity ordering ──────────────────────────────────
+
+const TRUST_SEVERITY: Record<TrustTier, number> = {
+  warning: 3,
+  caution: 2,
+  unscanned: 1,
+  verified: 0,
+};
+
+function worstTrust(tiers: TrustTier[]): TrustTier {
+  if (tiers.length === 0) return "unscanned";
+  return tiers.reduce((worst, tier) =>
+    TRUST_SEVERITY[tier] > TRUST_SEVERITY[worst] ? tier : worst,
+  );
+}
+
+// ── Helpers ──────────────────────────────────────────────────
+
+/** Title-cases a kebab-case profile name (e.g. "full-stack-engineer" → "Full Stack Engineer"). */
+function toPersona(name: string): string {
+  return name
+    .split("-")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+/** Normalises whitespace and truncates to the schema maxLength (256 chars). */
+function normaliseDescription(raw: string, max = 256): string {
+  const s = raw.replace(/\s+/g, " ").trim();
+  if (s.length <= max) return s;
+  // Trim to max - 1 chars then append ellipsis (U+2026, 1 code point)
+  return s.slice(0, max - 1).trimEnd() + "…";
+}
+
+// ── Valid v1 harness.yaml builder ────────────────────────────
+
+/**
+ * Builds a valid Harness Protocol v1 `harness.yaml` string from a legacy
+ * profile YAML (the `components`/`knowledge`/`rules` shape used in profiles/).
+ * Uses resolved plugins so the emitted version strings are always the live
+ * marketplace version, not a potentially stale pinned version.
+ */
+export function buildHarnessYaml(
+  profile: ProfileYaml,
+  resolvedPlugins: Array<{ name: string; version: string }>,
+): string {
+  const desc = normaliseDescription(profile.description);
+  const authorName = profile.author?.name ?? "harnessprotocol";
+
+  const lines: string[] = [
+    `version: "1"`,
+    `kind: profile`,
+    `metadata:`,
+    `  name: ${profile.name}`,
+    `  description: >-`,
+    `    ${desc}`,
+    `  author:`,
+    `    name: ${authorName}`,
+  ];
+
+  if (resolvedPlugins.length > 0) {
+    lines.push("plugins:");
+    for (const ref of resolvedPlugins) {
+      lines.push(`  - name: ${ref.name}`);
+      lines.push(`    source: harnessprotocol/harness-kit`);
+      lines.push(`    version: "${ref.version}"`);
+    }
+  }
+
+  const rules = (profile.rules ?? []).filter((r) => r.trim());
+  if (rules.length > 0) {
+    lines.push("instructions:");
+    lines.push("  behavioral: |");
+    for (const rule of rules) {
+      lines.push(`    - ${rule}`);
+    }
+  }
+
+  return lines.join("\n") + "\n";
+}
+
+// ── GitHub stars fetch ────────────────────────────────────────
+
+/**
+ * Fetches the GitHub star count for an `owner/repo`.
+ * Returns `undefined` on any error (rate-limit, missing token, offline).
+ */
+export async function fetchRepoStars(ownerRepo: string): Promise<number | undefined> {
+  const token = process.env.GITHUB_TOKEN;
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github.v3+json",
+    "User-Agent": "harness-kit-marketplace-data/1.0",
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 3_000);
+
+  try {
+    const res = await fetch(`https://api.github.com/repos/${ownerRepo}`, {
+      headers,
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      console.warn(`[marketplace-data] GitHub stars fetch failed (${res.status}) for ${ownerRepo}`);
+      return undefined;
+    }
+    const json = (await res.json()) as { stargazers_count?: number };
+    return typeof json.stargazers_count === "number" ? json.stargazers_count : undefined;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[marketplace-data] GitHub stars fetch error for ${ownerRepo}: ${msg}`);
+    return undefined;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+// ── Profile reader ────────────────────────────────────────────
+
+/**
+ * Reads all profile YAML files from `<repoRoot>/profiles/`, resolves each
+ * component against the live plugin set, and emits a validated
+ * `MarketplaceProfile[]` sorted by name.
+ *
+ * @param strict - When true, throws on unresolved components or invalid YAML.
+ *                 When false (default), emits console warnings and continues.
+ */
+export async function readProfiles(
+  repoRoot: string,
+  plugins: MarketplacePlugin[],
+  strict = false,
+): Promise<MarketplaceProfile[]> {
+  const profilesDir = join(repoRoot, "profiles");
+  let files: string[];
+  try {
+    const entries = await readdir(profilesDir);
+    files = entries.filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"));
+  } catch {
+    // profiles/ directory absent — not an error
+    return [];
+  }
+
+  const pluginMap = new Map(plugins.map((p) => [p.name, p]));
+  const profiles: MarketplaceProfile[] = [];
+
+  for (const file of files) {
+    const content = await readFile(join(profilesDir, file), "utf-8");
+    const raw = parseYaml(content) as ProfileYaml;
+
+    // ── Resolve components against live plugin set ───────────
+    const refs: ProfilePluginRef[] = (raw.components ?? []).map((c) => {
+      const plugin = pluginMap.get(c.name);
+      if (!plugin) {
+        const msg = `Profile "${raw.name}": component "${c.name}" not found in marketplace.json`;
+        if (strict) throw new Error(msg);
+        console.warn(`[marketplace-data] Warning: ${msg}`);
+        return { name: c.name, version: c.version, resolved: false };
+      }
+      return {
+        name: c.name,
+        version: c.version,
+        liveVersion: plugin.version,
+        resolved: true,
+        slug: plugin.slug,
+        category: plugin.category,
+        trust: plugin.security.trust,
+      };
+    });
+
+    // ── Compute aggregate security trust ─────────────────────
+    const resolvedTrusts: TrustTier[] = refs
+      .filter((r): r is ProfilePluginRef & { trust: TrustTier } => r.resolved && r.trust !== undefined)
+      .map((r) => r.trust);
+
+    // An unresolved ref degrades the aggregate to at least "caution"
+    if (refs.some((r) => !r.resolved)) resolvedTrusts.push("caution");
+
+    const aggregateTrust = worstTrust(resolvedTrusts.length > 0 ? resolvedTrusts : ["unscanned"]);
+
+    // ── Build the downloadable v1 harness.yaml ───────────────
+    const resolvedForYaml = refs
+      .filter((r) => r.resolved)
+      .map((r) => ({ name: r.name, version: r.liveVersion ?? r.version }));
+
+    const harnessYaml = buildHarnessYaml(raw, resolvedForYaml);
+    const validation = validateHarnessYaml(harnessYaml);
+    if (!validation.valid) {
+      const errors = validation.errors.map((e) => `${e.path}: ${e.message}`).join("; ");
+      const msg = `Profile "${raw.name}": generated harness.yaml is invalid: ${errors}`;
+      if (strict) throw new Error(msg);
+      console.warn(`[marketplace-data] Warning: ${msg}`);
+    }
+
+    // ── Build knowledge and security rollup ──────────────────
+    const knowledge: ProfileKnowledge | null = raw.knowledge
+      ? {
+          backend: raw.knowledge.backend,
+          seedDocs: (raw.knowledge.seed_docs ?? []).map((d) => ({
+            topic: d.topic,
+            description: d.description,
+          })),
+        }
+      : null;
+
+    const security = {
+      trust: aggregateTrust,
+      pluginCount: refs.length,
+      verifiedCount: refs.filter((r) => r.trust === "verified").length,
+      cautionCount: refs.filter((r) => r.trust === "caution").length,
+      warningCount: refs.filter((r) => r.trust === "warning").length,
+      unscannedCount: refs.filter((r) => r.trust === "unscanned" || !r.resolved).length,
+    };
+
+    profiles.push({
+      name: raw.name,
+      slug: raw.name,
+      description: normaliseDescription(raw.description),
+      author: raw.author?.name ?? "harnessprotocol",
+      persona: toPersona(raw.name),
+      plugins: refs,
+      knowledge,
+      rules: raw.rules ?? [],
+      harnessYaml,
+      aggregateTrust,
+      security,
+      sourceId: "first-party",
+    });
+  }
+
+  return profiles.sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/packages/marketplace-data/src/types.ts
+++ b/packages/marketplace-data/src/types.ts
@@ -93,12 +93,76 @@ export interface MarketplacePlugin {
   security: MarketplaceSecurity;
 }
 
+// ── Profile types ────────────────────────────────────────────
+
+export interface ProfileSeedDoc {
+  topic: string;
+  description: string;
+}
+
+export interface ProfileKnowledge {
+  backend: string;
+  seedDocs: ProfileSeedDoc[];
+}
+
+/**
+ * A plugin bundled inside a profile, resolved against the live plugin set.
+ * `resolved: false` means the component name was not found in marketplace.json
+ * (version drift, plugin removed). `liveVersion` tracks the current plugin
+ * version separately from the `version` the profile originally pinned.
+ */
+export interface ProfilePluginRef {
+  name: string;
+  /** Version pinned in the profile YAML. */
+  version: string;
+  /** Current live version from marketplace.json; undefined when unresolved. */
+  liveVersion?: string;
+  resolved: boolean;
+  slug?: string;
+  category?: string;
+  trust?: TrustTier;
+}
+
+export interface ProfileSecurity {
+  trust: TrustTier;
+  pluginCount: number;
+  verifiedCount: number;
+  cautionCount: number;
+  warningCount: number;
+  unscannedCount: number;
+}
+
+export interface MarketplaceProfile {
+  name: string;
+  slug: string;
+  description: string;
+  author: string;
+  /** Human-readable persona label derived from the profile name (title-cased). */
+  persona: string;
+  plugins: ProfilePluginRef[];
+  knowledge: ProfileKnowledge | null;
+  rules: string[];
+  /** A valid v1 harness.yaml string suitable for download and running with the CLI. */
+  harnessYaml: string;
+  /** Worst-case security trust across all resolved plugins. */
+  aggregateTrust: TrustTier;
+  security: ProfileSecurity;
+  /** GitHub repo stars at build time; undefined when fetch fails or is skipped. */
+  stars?: number;
+  /** Install count from telemetry; undefined until Phase 6 telemetry is live. */
+  installs?: number;
+  sourceId: PluginSourceId;
+}
+
 export interface MarketplaceData {
   generatedAt: string;
   marketplaceName: string;
   owner: string;
   categories: MarketplaceCategory[];
   plugins: MarketplacePlugin[];
+  profiles: MarketplaceProfile[];
+  /** GitHub repo stars at build time; undefined when fetch fails. */
+  repoStars?: number;
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -379,6 +379,9 @@ importers:
       '@harness-kit/shared':
         specifier: workspace:*
         version: link:../shared
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@types/node':
         specifier: ^22.19.19
@@ -6979,7 +6982,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@25.5.0)(@vitest/coverage-v8@4.1.8)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@6.4.3(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@6.4.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/expect@4.1.8':
     dependencies:

--- a/website/app/marketplace/[slug]/page.tsx
+++ b/website/app/marketplace/[slug]/page.tsx
@@ -7,7 +7,6 @@ import { MarkdownViewer } from '@/components/markdown-viewer';
 import { InstallWidget } from '@/components/marketplace/InstallWidget';
 import { SecurityPanel } from '@/components/marketplace/SecurityPanel';
 import { RankingBadges } from '@/components/marketplace/RankingBadges';
-import { TrustBadge } from '@/components/marketplace/TrustBadge';
 import { categoryAccent } from '@/lib/marketplace/category';
 import { getAllPlugins, getCategoryName, getPlugin, getRepoStars } from '@/lib/marketplace/data';
 

--- a/website/app/marketplace/[slug]/page.tsx
+++ b/website/app/marketplace/[slug]/page.tsx
@@ -4,11 +4,12 @@ import { notFound } from 'next/navigation';
 import { SiteNav } from '@/components/site/SiteNav';
 import { SiteFooter } from '@/components/site/SiteFooter';
 import { MarkdownViewer } from '@/components/markdown-viewer';
-import { InstallCommand } from '@/components/marketplace/InstallCommand';
+import { InstallWidget } from '@/components/marketplace/InstallWidget';
 import { SecurityPanel } from '@/components/marketplace/SecurityPanel';
+import { RankingBadges } from '@/components/marketplace/RankingBadges';
 import { TrustBadge } from '@/components/marketplace/TrustBadge';
 import { categoryAccent } from '@/lib/marketplace/category';
-import { getAllPlugins, getCategoryName, getPlugin } from '@/lib/marketplace/data';
+import { getAllPlugins, getCategoryName, getPlugin, getRepoStars } from '@/lib/marketplace/data';
 
 export function generateStaticParams() {
   return getAllPlugins().map((p) => ({ slug: p.slug }));
@@ -30,6 +31,7 @@ export default async function PluginDetailPage(props: { params: Promise<{ slug: 
   if (!plugin) notFound();
 
   const accent = categoryAccent(plugin.category);
+  const stars = getRepoStars();
   const repoUrl = `https://github.com/harnessprotocol/harness-kit/tree/main/${plugin.repoPath.replace(/^\.\//, '')}`;
 
   return (
@@ -50,7 +52,6 @@ export default async function PluginDetailPage(props: { params: Promise<{ slug: 
             >
               {getCategoryName(plugin.category)}
             </span>
-            <TrustBadge tier={plugin.security.trust} />
             {plugin.mcp && (
               <span
                 className="rounded px-1.5 py-0.5 text-xs font-medium"
@@ -65,17 +66,20 @@ export default async function PluginDetailPage(props: { params: Promise<{ slug: 
             <span className="font-mono text-base font-normal text-fd-muted-foreground">v{plugin.version}</span>
           </h1>
           <p className="text-base leading-relaxed text-fd-muted-foreground">{plugin.description}</p>
-          <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-fd-muted-foreground">
+          <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-fd-muted-foreground">
             <span>By {plugin.author}</span>
             <span>{plugin.license}</span>
             <a href={repoUrl} className="underline" target="_blank" rel="noreferrer">Source ↗</a>
+          </div>
+          <div className="mt-3">
+            <RankingBadges sourceId={plugin.sourceId} trust={plugin.security.trust} stars={stars} />
           </div>
         </header>
 
         {/* Install */}
         <section className="mb-10">
-          <h2 className="font-display mb-2 text-lg font-semibold text-fd-foreground">Install</h2>
-          <InstallCommand command={plugin.installCommand} />
+          <h2 className="font-display mb-3 text-lg font-semibold text-fd-foreground">Install</h2>
+          <InstallWidget kind="plugin" plugin={plugin} />
         </section>
 
         {/* Tags */}

--- a/website/app/marketplace/page.tsx
+++ b/website/app/marketplace/page.tsx
@@ -3,36 +3,96 @@ import { SiteNav } from '@/components/site/SiteNav';
 import { SiteFooter } from '@/components/site/SiteFooter';
 import { HeroGlow } from '@/components/site/HeroGlow';
 import { MarketplaceBrowser } from '@/components/marketplace/MarketplaceBrowser';
-import { getAllPlugins, getAllTags, getCategories } from '@/lib/marketplace/data';
+import { ProfileCard } from '@/components/marketplace/ProfileCard';
+import { SupportedAgents } from '@/components/marketplace/SupportedAgents';
+import { getAllPlugins, getAllProfiles, getAllTags, getCategories, getRepoStars } from '@/lib/marketplace/data';
 
 export const metadata: Metadata = {
   title: 'Marketplace — Harness Kit',
-  description: 'Browse and install harness-kit plugins by name. Every plugin is security-scanned at build time.',
+  description: 'Curated harness profiles and security-scanned plugins for Claude Code, Cursor, Copilot, and more.',
 };
 
 export default function MarketplacePage() {
   const plugins = getAllPlugins();
+  const profiles = getAllProfiles();
   const categories = getCategories();
   const tags = getAllTags();
+  const stars = getRepoStars();
 
   return (
     <main className="min-h-screen">
       <SiteNav />
 
+      {/* Hero */}
       <section className="relative overflow-hidden">
         <HeroGlow />
-        <div className="relative mx-auto max-w-4xl px-6 pb-10 pt-20 text-center">
+        <div className="relative mx-auto max-w-4xl px-6 pb-8 pt-20 text-center">
+          <div
+            className="mb-4 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium"
+            style={{ color: 'var(--accent)', background: 'var(--accent-light)' }}
+          >
+            Harness Protocol
+          </div>
           <h1 className="font-display mb-4 text-4xl font-bold tracking-tight text-fd-foreground sm:text-5xl">
             Plugin Marketplace
           </h1>
-          <p className="mx-auto max-w-xl text-base leading-relaxed text-fd-muted-foreground">
-            {plugins.length} plugins, installable by name. Each one is security-scanned at build time —
-            no clone, no path juggling.
+          <p className="mx-auto mb-6 max-w-xl text-base leading-relaxed text-fd-muted-foreground">
+            Curated profiles for how you work, and {plugins.length} security-scanned plugins — all
+            installable by name. No clone, no path juggling.
           </p>
+          {typeof stars === 'number' && (
+            <div className="mb-6 flex items-center justify-center gap-1.5 text-sm text-fd-muted-foreground">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+              </svg>
+              {stars.toLocaleString()} stars on GitHub
+            </div>
+          )}
+          <SupportedAgents />
         </div>
       </section>
 
+      {/* Profiles — the standout feature, leads the page */}
+      <section className="mx-auto max-w-5xl px-6 pb-16">
+        <div className="mb-6">
+          <h2 className="font-display mb-1.5 text-2xl font-bold tracking-tight text-fd-foreground">
+            Harness Profiles
+          </h2>
+          <p className="text-sm text-fd-muted-foreground">
+            Pre-configured plugin bundles for your role. Download a{' '}
+            <code className="font-mono text-xs">harness.yaml</code> and you&apos;re set.
+          </p>
+        </div>
+
+        {profiles.length === 0 ? (
+          <p className="text-sm text-fd-muted-foreground">No profiles yet.</p>
+        ) : (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {profiles.map((profile) => (
+              <ProfileCard key={profile.slug} profile={{ ...profile, stars }} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Divider */}
+      <div className="mx-auto max-w-5xl px-6">
+        <div
+          className="mb-12 border-t"
+          style={{ borderColor: 'color-mix(in srgb, var(--fg-subtle) 15%, transparent)' }}
+        />
+      </div>
+
+      {/* Plugin browser */}
       <section className="mx-auto max-w-5xl px-6 pb-24">
+        <div className="mb-6">
+          <h2 className="font-display mb-1.5 text-2xl font-bold tracking-tight text-fd-foreground">
+            Browse Plugins
+          </h2>
+          <p className="text-sm text-fd-muted-foreground">
+            {plugins.length} plugins, each security-scanned at build time.
+          </p>
+        </div>
         <MarketplaceBrowser plugins={plugins} categories={categories} tags={tags} />
       </section>
 

--- a/website/app/marketplace/profiles/[slug]/page.tsx
+++ b/website/app/marketplace/profiles/[slug]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from 'next/navigation';
 import { SiteNav } from '@/components/site/SiteNav';
 import { SiteFooter } from '@/components/site/SiteFooter';
 import { ProfileDetail } from '@/components/marketplace/ProfileDetail';
-import { getAllProfiles, getProfile } from '@/lib/marketplace/data';
+import { getAllProfiles, getProfile, getRepoStars } from '@/lib/marketplace/data';
 
 export function generateStaticParams() {
   return getAllProfiles().map((p) => ({ slug: p.slug }));
@@ -24,10 +24,15 @@ export default async function ProfileDetailPage(props: { params: Promise<{ slug:
   const profile = getProfile(slug);
   if (!profile) notFound();
 
+  // Inject repo-level stars onto the profile, same as the landing page does for cards.
+  // The generator writes repoStars at the MarketplaceData level, not per-profile.
+  const stars = getRepoStars();
+  const profileWithStars = stars !== undefined ? { ...profile, stars } : profile;
+
   return (
     <main className="min-h-screen">
       <SiteNav />
-      <ProfileDetail profile={profile} />
+      <ProfileDetail profile={profileWithStars} />
       <SiteFooter />
     </main>
   );

--- a/website/app/marketplace/profiles/[slug]/page.tsx
+++ b/website/app/marketplace/profiles/[slug]/page.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { SiteNav } from '@/components/site/SiteNav';
+import { SiteFooter } from '@/components/site/SiteFooter';
+import { ProfileDetail } from '@/components/marketplace/ProfileDetail';
+import { getAllProfiles, getProfile } from '@/lib/marketplace/data';
+
+export function generateStaticParams() {
+  return getAllProfiles().map((p) => ({ slug: p.slug }));
+}
+
+export async function generateMetadata(props: { params: Promise<{ slug: string }> }): Promise<Metadata> {
+  const { slug } = await props.params;
+  const profile = getProfile(slug);
+  if (!profile) return { title: 'Profile not found — Harness Kit' };
+  return {
+    title: `${profile.persona} Profile — Harness Kit Marketplace`,
+    description: profile.description,
+  };
+}
+
+export default async function ProfileDetailPage(props: { params: Promise<{ slug: string }> }) {
+  const { slug } = await props.params;
+  const profile = getProfile(slug);
+  if (!profile) notFound();
+
+  return (
+    <main className="min-h-screen">
+      <SiteNav />
+      <ProfileDetail profile={profile} />
+      <SiteFooter />
+    </main>
+  );
+}

--- a/website/components/marketplace/InstallWidget.tsx
+++ b/website/components/marketplace/InstallWidget.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import { useState } from 'react';
+import { InstallCommand } from './InstallCommand';
+import { cursorDeepLink } from '@/lib/marketplace/deeplinks';
+import type { MarketplaceMcp, MarketplacePlugin, MarketplaceProfile } from '@/lib/marketplace/types';
+
+// ── Tab types ────────────────────────────────────────────────
+
+type Tab = 'claude' | 'cli' | 'cursor';
+
+const TABS: { id: Tab; label: string }[] = [
+  { id: 'claude', label: 'Claude Code' },
+  { id: 'cli', label: 'npx / CLI' },
+  { id: 'cursor', label: 'Cursor' },
+];
+
+// ── Download button (profile harness.yaml) ───────────────────
+
+function DownloadYaml({ slug, yaml }: { slug: string; yaml: string }) {
+  const handleDownload = () => {
+    const url = `data:text/yaml;charset=utf-8,${encodeURIComponent(yaml)}`;
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${slug}.harness.yaml`;
+    a.click();
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleDownload}
+      className="flex w-full cursor-pointer items-center gap-2 rounded-xl bg-fd-card px-4 py-2.5 text-sm text-fd-foreground transition-colors hover:bg-fd-card/80 sm:px-5 sm:py-3"
+    >
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M12 2v13M5 9l7 7 7-7" />
+        <path d="M5 20h14" />
+      </svg>
+      <code className="font-mono text-[12px] sm:text-sm">{slug}.harness.yaml</code>
+    </button>
+  );
+}
+
+// ── Cursor deep-link button ──────────────────────────────────
+
+function CursorButton({ pluginName, mcp }: { pluginName: string; mcp: MarketplaceMcp }) {
+  const href = cursorDeepLink(pluginName, mcp);
+  return (
+    <a
+      href={href}
+      className="inline-flex cursor-pointer items-center gap-2 rounded-xl px-4 py-2.5 text-sm font-medium text-fd-foreground transition-all hover:opacity-90 sm:px-5 sm:py-3"
+      style={{ background: 'var(--accent)', color: '#fff' }}
+    >
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+        <polyline points="15 3 21 3 21 9" />
+        <line x1="10" y1="14" x2="21" y2="3" />
+      </svg>
+      Add to Cursor
+    </a>
+  );
+}
+
+// ── Plugin install content ────────────────────────────────────
+
+function PluginClaudeTab({ plugin }: { plugin: MarketplacePlugin }) {
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-sm text-fd-muted-foreground">
+        Add the marketplace once, then install the plugin:
+      </p>
+      <InstallCommand command="/plugin marketplace add harnessprotocol/harness-kit" />
+      <InstallCommand command={plugin.installCommand} />
+    </div>
+  );
+}
+
+function PluginCliTab({ plugin }: { plugin: MarketplacePlugin }) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <p className="mb-2 text-sm text-fd-muted-foreground">Run ephemerally (no install):</p>
+        <InstallCommand command={`npx @harness-kit/cli run ${plugin.name}@harnessprotocol/harness-kit`} />
+      </div>
+      <details className="rounded-xl bg-fd-card/40 px-4 py-3 text-sm">
+        <summary className="cursor-pointer text-fd-muted-foreground select-none">
+          Add permanently to a project harness
+        </summary>
+        <div className="mt-3 flex flex-col gap-3">
+          <p className="text-xs text-fd-muted-foreground">
+            1. Add to your <code className="font-mono">harness.yaml</code> plugins list, then:
+          </p>
+          <InstallCommand command="npx @harness-kit/cli sync" />
+          <InstallCommand command="npx @harness-kit/cli compile" />
+        </div>
+      </details>
+    </div>
+  );
+}
+
+function PluginCursorTab({ plugin }: { plugin: MarketplacePlugin }) {
+  if (!plugin.mcp) {
+    return (
+      <p className="text-sm text-fd-muted-foreground">
+        This plugin doesn&apos;t expose an MCP server — the Cursor deep-link is only available for
+        plugins that include an MCP server configuration.
+      </p>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-sm text-fd-muted-foreground">
+        One click to add the MCP server to Cursor:
+      </p>
+      <CursorButton pluginName={plugin.name} mcp={plugin.mcp} />
+    </div>
+  );
+}
+
+// ── Profile install content ───────────────────────────────────
+
+function ProfileClaudeTab({ profile }: { profile: MarketplaceProfile }) {
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-sm text-fd-muted-foreground">
+        Add the marketplace once, then install each plugin in the profile:
+      </p>
+      <InstallCommand command="/plugin marketplace add harnessprotocol/harness-kit" />
+      {profile.plugins
+        .filter((r) => r.resolved)
+        .map((ref) => (
+          <InstallCommand key={ref.name} command={`/plugin install ${ref.name}@harness-kit`} />
+        ))}
+    </div>
+  );
+}
+
+function ProfileCliTab({ profile }: { profile: MarketplaceProfile }) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <p className="mb-2 text-sm text-fd-muted-foreground">
+          Download the profile&apos;s <code className="font-mono text-xs">harness.yaml</code>, then
+          sync and compile for all your AI tools:
+        </p>
+        <DownloadYaml slug={profile.slug} yaml={profile.harnessYaml} />
+      </div>
+      <div className="flex flex-col gap-3">
+        <InstallCommand command="npx @harness-kit/cli sync" />
+        <InstallCommand command="npx @harness-kit/cli compile" />
+      </div>
+      <p className="text-xs text-fd-muted-foreground">
+        <code className="font-mono">compile</code> writes native config for Claude Code, Cursor, and
+        Copilot automatically based on what&apos;s installed.
+      </p>
+    </div>
+  );
+}
+
+function ProfileCursorTab({ profile }: { profile: MarketplaceProfile }) {
+  const mcpPlugins = profile.plugins.filter((r) => r.resolved);
+  // We can only generate Cursor deep-links for plugins that have MCP config. Since
+  // we don't carry mcp config on the ProfilePluginRef, show the CLI path here.
+  if (mcpPlugins.length === 0) {
+    return (
+      <p className="text-sm text-fd-muted-foreground">
+        No plugins in this profile expose MCP servers. Use the npx / CLI tab to apply this profile.
+      </p>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-sm text-fd-muted-foreground">
+        For plugins in this profile that include MCP servers, use their individual install pages for
+        one-click Cursor deep-links. Or use the npx / CLI tab to apply the full profile at once.
+      </p>
+    </div>
+  );
+}
+
+// ── Main widget ───────────────────────────────────────────────
+
+type InstallWidgetProps =
+  | { kind: 'plugin'; plugin: MarketplacePlugin }
+  | { kind: 'profile'; profile: MarketplaceProfile };
+
+export function InstallWidget(props: InstallWidgetProps) {
+  const [tab, setTab] = useState<Tab>('claude');
+
+  const hasMcp = props.kind === 'plugin' ? Boolean(props.plugin.mcp) : false;
+  const visibleTabs = TABS.filter((t) => t.id !== 'cursor' || hasMcp || props.kind === 'profile');
+
+  const chip = (active: boolean) =>
+    `cursor-pointer rounded-full px-3 py-1 text-sm font-medium transition-colors ${
+      active
+        ? 'bg-fd-primary/15 text-fd-foreground'
+        : 'bg-fd-card/60 text-fd-muted-foreground hover:bg-fd-card hover:text-fd-foreground'
+    }`;
+
+  return (
+    <div>
+      {/* Tab bar */}
+      <div className="mb-4 flex flex-wrap gap-2">
+        {visibleTabs.map((t) => (
+          <button key={t.id} type="button" className={chip(tab === t.id)} onClick={() => setTab(t.id)}>
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab content */}
+      <div>
+        {tab === 'claude' && (
+          props.kind === 'plugin'
+            ? <PluginClaudeTab plugin={props.plugin} />
+            : <ProfileClaudeTab profile={props.profile} />
+        )}
+        {tab === 'cli' && (
+          props.kind === 'plugin'
+            ? <PluginCliTab plugin={props.plugin} />
+            : <ProfileCliTab profile={props.profile} />
+        )}
+        {tab === 'cursor' && (
+          props.kind === 'plugin'
+            ? <PluginCursorTab plugin={props.plugin} />
+            : <ProfileCursorTab profile={props.profile} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/website/components/marketplace/ProfileCard.tsx
+++ b/website/components/marketplace/ProfileCard.tsx
@@ -1,0 +1,65 @@
+import Link from 'next/link';
+import type { MarketplaceProfile } from '@/lib/marketplace/types';
+import { TrustBadge } from './TrustBadge';
+import { categoryAccent } from '@/lib/marketplace/category';
+
+export function ProfileCard({ profile }: { profile: MarketplaceProfile }) {
+  return (
+    <Link
+      href={`/marketplace/profiles/${profile.slug}`}
+      className="group flex cursor-pointer flex-col rounded-xl bg-fd-card/50 p-5 no-underline backdrop-blur-sm transition-all duration-300 hover:bg-fd-card/80 hover:shadow-lg"
+      style={{ borderTop: '2px solid var(--accent)' }}
+    >
+      {/* Header row */}
+      <div className="mb-2.5 flex items-center justify-between gap-2">
+        <span
+          className="rounded-full px-2 py-0.5 text-[11px] font-semibold"
+          style={{ color: 'var(--accent)', background: 'var(--accent-light)' }}
+        >
+          Profile
+        </span>
+        <TrustBadge tier={profile.aggregateTrust} title={`Aggregate security trust: ${profile.aggregateTrust}`} />
+      </div>
+
+      {/* Name */}
+      <h3 className="font-display mb-1 font-semibold text-fd-foreground">{profile.persona}</h3>
+
+      {/* Description */}
+      <p className="mb-3 line-clamp-3 flex-1 text-sm leading-relaxed text-fd-muted-foreground">
+        {profile.description}
+      </p>
+
+      {/* Footer: plugin category dots + count */}
+      <div className="flex items-center gap-2">
+        {/* Mini category colour dots for bundled plugins */}
+        <div className="flex items-center -space-x-0.5">
+          {[...new Set(profile.plugins.filter((r) => r.resolved && r.category).map((r) => r.category!))]
+            .slice(0, 5)
+            .map((cat) => (
+              <span
+                key={cat}
+                className="size-2.5 rounded-full ring-1 ring-fd-card/80"
+                style={{ background: categoryAccent(cat) }}
+                title={cat}
+              />
+            ))}
+        </div>
+        <span className="text-[11px] text-fd-muted-foreground">
+          {profile.plugins.filter((r) => r.resolved).length} plugin
+          {profile.plugins.filter((r) => r.resolved).length === 1 ? '' : 's'}
+        </span>
+        {profile.stars !== undefined && (
+          <>
+            <span className="text-fd-muted-foreground/40">·</span>
+            <span className="inline-flex items-center gap-0.5 text-[11px] text-fd-muted-foreground">
+              <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+              </svg>
+              {profile.stars}
+            </span>
+          </>
+        )}
+      </div>
+    </Link>
+  );
+}

--- a/website/components/marketplace/ProfileDetail.tsx
+++ b/website/components/marketplace/ProfileDetail.tsx
@@ -1,0 +1,176 @@
+import Link from 'next/link';
+import type { MarketplaceProfile } from '@/lib/marketplace/types';
+import { TrustBadge } from './TrustBadge';
+import { RankingBadges } from './RankingBadges';
+import { InstallWidget } from './InstallWidget';
+import { categoryAccent } from '@/lib/marketplace/category';
+
+function PluginRefRow({ name, slug, category, trust, liveVersion }: {
+  name: string;
+  slug?: string;
+  category?: string;
+  trust?: MarketplaceProfile['plugins'][0]['trust'];
+  liveVersion?: string;
+}) {
+  const accent = category ? categoryAccent(category) : 'var(--fg-subtle)';
+  const inner = (
+    <div className="flex items-center justify-between gap-3 px-4 py-3">
+      <div className="flex items-center gap-2.5 min-w-0">
+        {category && (
+          <span
+            className="size-2 shrink-0 rounded-full"
+            style={{ background: accent }}
+          />
+        )}
+        <span className="font-mono text-sm text-fd-foreground truncate">{name}</span>
+        {liveVersion && (
+          <span className="font-mono text-[11px] text-fd-muted-foreground shrink-0">v{liveVersion}</span>
+        )}
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        {trust && <TrustBadge tier={trust} />}
+        {slug && (
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-fd-muted-foreground/50" aria-hidden="true">
+            <polyline points="9 18 15 12 9 6" />
+          </svg>
+        )}
+      </div>
+    </div>
+  );
+
+  if (slug) {
+    return (
+      <Link
+        href={`/marketplace/${slug}`}
+        className="block no-underline transition-colors hover:bg-fd-card/80"
+      >
+        {inner}
+      </Link>
+    );
+  }
+  return <div className="opacity-50">{inner}</div>;
+}
+
+export function ProfileDetail({ profile }: { profile: MarketplaceProfile }) {
+  return (
+    <article className="mx-auto max-w-3xl px-6 pb-24 pt-12">
+      <Link href="/marketplace" className="text-sm text-fd-muted-foreground no-underline hover:text-fd-foreground">
+        ← Marketplace
+      </Link>
+
+      {/* Header */}
+      <header className="mb-8 mt-4">
+        <div className="mb-3">
+          <RankingBadges
+            sourceId={profile.sourceId}
+            trust={profile.aggregateTrust}
+            stars={profile.stars}
+            installs={profile.installs}
+          />
+        </div>
+        <div className="mb-1 flex items-center gap-2.5">
+          <span
+            className="rounded-full px-2.5 py-0.5 text-xs font-semibold"
+            style={{ color: 'var(--accent)', background: 'var(--accent-light)' }}
+          >
+            Harness Profile
+          </span>
+        </div>
+        <h1 className="font-display mb-2 text-3xl font-bold tracking-tight text-fd-foreground">
+          {profile.persona}
+        </h1>
+        <p className="text-base leading-relaxed text-fd-muted-foreground">{profile.description}</p>
+        <div className="mt-3 text-xs text-fd-muted-foreground">
+          By {profile.author} · {profile.plugins.filter((r) => r.resolved).length} plugins bundled
+        </div>
+      </header>
+
+      {/* Install */}
+      <section className="mb-10">
+        <h2 className="font-display mb-3 text-lg font-semibold text-fd-foreground">Install</h2>
+        <InstallWidget kind="profile" profile={profile} />
+      </section>
+
+      {/* What's inside */}
+      <section className="mb-10">
+        <h2 className="font-display mb-3 text-lg font-semibold text-fd-foreground">
+          What&apos;s inside
+        </h2>
+        <div className="flex flex-col divide-y divide-fd-border overflow-hidden rounded-xl bg-fd-card/50">
+          {profile.plugins.map((ref) => (
+            <PluginRefRow
+              key={ref.name}
+              name={ref.name}
+              slug={ref.resolved ? ref.slug : undefined}
+              category={ref.category}
+              trust={ref.trust}
+              liveVersion={ref.liveVersion ?? ref.version}
+            />
+          ))}
+        </div>
+        <p className="mt-2 text-xs text-fd-muted-foreground">
+          Click any plugin to view its full documentation and security scan.
+        </p>
+      </section>
+
+      {/* Rules */}
+      {profile.rules.length > 0 && (
+        <section className="mb-10">
+          <h2 className="font-display mb-3 text-lg font-semibold text-fd-foreground">
+            Workflow rules
+          </h2>
+          <ul className="flex flex-col gap-2">
+            {profile.rules.map((rule, i) => (
+              <li
+                key={i}
+                className="flex items-start gap-2.5 rounded-lg bg-fd-card/40 px-4 py-2.5 text-sm leading-relaxed text-fd-muted-foreground"
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="mt-0.5 shrink-0" aria-hidden="true">
+                  <path d="M20 6 9 17l-5-5" />
+                </svg>
+                {rule}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {/* Knowledge */}
+      {profile.knowledge && (
+        <section className="mb-10">
+          <h2 className="font-display mb-3 text-lg font-semibold text-fd-foreground">
+            Knowledge seeding
+          </h2>
+          <div className="rounded-xl bg-fd-card/50 p-4">
+            <p className="mb-3 text-sm text-fd-muted-foreground">
+              Memory backend:{' '}
+              <code className="font-mono text-xs text-fd-foreground">{profile.knowledge.backend}</code>
+            </p>
+            {profile.knowledge.seedDocs.length > 0 && (
+              <div className="flex flex-col gap-1.5">
+                {profile.knowledge.seedDocs.map((doc) => (
+                  <div key={doc.topic} className="flex items-start gap-2 text-sm">
+                    <code className="font-mono text-xs text-fd-foreground shrink-0 mt-0.5">{doc.topic}</code>
+                    <span className="text-fd-muted-foreground">— {doc.description}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </section>
+      )}
+
+      {/* Raw harness.yaml */}
+      <section>
+        <details className="group rounded-xl bg-fd-card/40 px-4 py-3">
+          <summary className="cursor-pointer text-sm font-medium text-fd-muted-foreground transition-colors hover:text-fd-foreground select-none">
+            View harness.yaml
+          </summary>
+          <pre className="mt-3 overflow-x-auto rounded-lg bg-fd-card p-4 font-mono text-[12px] leading-relaxed text-fd-foreground">
+            {profile.harnessYaml}
+          </pre>
+        </details>
+      </section>
+    </article>
+  );
+}

--- a/website/components/marketplace/RankingBadges.tsx
+++ b/website/components/marketplace/RankingBadges.tsx
@@ -1,0 +1,72 @@
+import type { TrustTier } from '@/lib/marketplace/types';
+import { TrustBadge } from './TrustBadge';
+
+interface RankingBadgesProps {
+  sourceId: string;
+  trust: TrustTier;
+  stars?: number;
+  installs?: number;
+  /** Whether to show the security TrustBadge inline. Default true. */
+  showTrust?: boolean;
+}
+
+/**
+ * Composes provenance (official/first-party) + security trust + optional metrics
+ * into a single inline row. Used on plugin/profile cards and detail page headers.
+ */
+export function RankingBadges({
+  sourceId,
+  trust,
+  stars,
+  installs,
+  showTrust = true,
+}: RankingBadgesProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {sourceId === 'first-party' && (
+        <span
+          className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-semibold"
+          style={{
+            color: 'var(--accent)',
+            background: 'var(--accent-light)',
+          }}
+          title="First-party plugin — maintained by harnessprotocol"
+        >
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+          </svg>
+          Official
+        </span>
+      )}
+
+      {showTrust && <TrustBadge tier={trust} />}
+
+      {typeof stars === 'number' && (
+        <span
+          className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] text-fd-muted-foreground"
+          style={{ background: 'var(--bg-surface)' }}
+          title={`${stars.toLocaleString()} GitHub stars`}
+        >
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+          </svg>
+          {stars >= 1000 ? `${(stars / 1000).toFixed(1)}k` : stars}
+        </span>
+      )}
+
+      {typeof installs === 'number' && (
+        <span
+          className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] text-fd-muted-foreground"
+          style={{ background: 'var(--bg-surface)' }}
+          title={`${installs.toLocaleString()} installs`}
+        >
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M12 2v13M5 9l7 7 7-7" />
+            <path d="M5 20h14" />
+          </svg>
+          {installs >= 1000 ? `${(installs / 1000).toFixed(1)}k` : installs}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/website/components/marketplace/SupportedAgents.tsx
+++ b/website/components/marketplace/SupportedAgents.tsx
@@ -1,0 +1,32 @@
+const AGENTS = [
+  { name: 'Claude Code', abbr: 'CC' },
+  { name: 'Cursor', abbr: 'CUR' },
+  { name: 'GitHub Copilot', abbr: 'COP' },
+  { name: 'Codex CLI', abbr: 'CDX' },
+  { name: 'Gemini CLI', abbr: 'GEM' },
+] as const;
+
+/**
+ * A static row of supported AI coding agent badges — signals cross-platform
+ * compatibility to engineers evaluating the marketplace.
+ */
+export function SupportedAgents() {
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-2">
+      <span className="mr-1 text-xs text-fd-muted-foreground">Works with</span>
+      {AGENTS.map((agent) => (
+        <span
+          key={agent.name}
+          className="inline-flex items-center rounded-full px-2.5 py-1 text-[11px] font-medium text-fd-muted-foreground transition-colors"
+          style={{
+            background: 'var(--bg-surface)',
+            border: '1px solid color-mix(in srgb, var(--fg-subtle) 20%, transparent)',
+          }}
+          title={agent.name}
+        >
+          {agent.name}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/website/lib/marketplace/data.ts
+++ b/website/lib/marketplace/data.ts
@@ -3,6 +3,7 @@ import type {
   MarketplaceCategory,
   MarketplaceData,
   MarketplacePlugin,
+  MarketplaceProfile,
   MarketplaceSource,
 } from './types';
 
@@ -50,6 +51,19 @@ export function getCategoryName(slug: string): string {
 
 export function getAllTags(): string[] {
   return [...new Set(data.plugins.flatMap((p) => p.tags))].sort();
+}
+
+export function getAllProfiles(): MarketplaceProfile[] {
+  // Defensive ?? [] so a stale generated JSON (no profiles key) never crashes the build
+  return (data.profiles ?? []);
+}
+
+export function getProfile(slug: string): MarketplaceProfile | undefined {
+  return (data.profiles ?? []).find((p) => p.slug === slug);
+}
+
+export function getRepoStars(): number | undefined {
+  return data.repoStars;
 }
 
 export function getMarketplaceMeta(): Pick<MarketplaceData, 'marketplaceName' | 'owner' | 'generatedAt'> {

--- a/website/lib/marketplace/deeplinks.ts
+++ b/website/lib/marketplace/deeplinks.ts
@@ -1,0 +1,18 @@
+import type { MarketplaceMcp } from './types';
+
+/**
+ * Generates a Cursor one-click MCP install deep-link.
+ * Format: cursor://anysphere.cursor-deeplink/mcp/install?name=<name>&config=<base64>
+ * Config is base64(JSON({ type, command, args })) — Cursor's expected MCP server shape.
+ *
+ * Only call when plugin.mcp is non-null.
+ */
+export function cursorDeepLink(pluginName: string, mcp: MarketplaceMcp): string {
+  const config = JSON.stringify({
+    type: mcp.transport,
+    command: mcp.command,
+    args: mcp.args.length > 0 ? mcp.args : undefined,
+  });
+  const encoded = btoa(config);
+  return `cursor://anysphere.cursor-deeplink/mcp/install?name=${encodeURIComponent(pluginName)}&config=${encoded}`;
+}

--- a/website/lib/marketplace/types.ts
+++ b/website/lib/marketplace/types.ts
@@ -86,12 +86,70 @@ export interface MarketplacePlugin {
   security: MarketplaceSecurity;
 }
 
+// ── Profile types (keep in sync with packages/marketplace-data/src/types.ts) ──
+
+export interface ProfileSeedDoc {
+  topic: string;
+  description: string;
+}
+
+export interface ProfileKnowledge {
+  backend: string;
+  seedDocs: ProfileSeedDoc[];
+}
+
+export interface ProfilePluginRef {
+  name: string;
+  /** Version pinned in the profile YAML. */
+  version: string;
+  /** Current live version from marketplace.json; undefined when unresolved. */
+  liveVersion?: string;
+  resolved: boolean;
+  slug?: string;
+  category?: string;
+  trust?: TrustTier;
+}
+
+export interface ProfileSecurity {
+  trust: TrustTier;
+  pluginCount: number;
+  verifiedCount: number;
+  cautionCount: number;
+  warningCount: number;
+  unscannedCount: number;
+}
+
+export interface MarketplaceProfile {
+  name: string;
+  slug: string;
+  description: string;
+  author: string;
+  /** Human-readable persona label derived from the profile name (title-cased). */
+  persona: string;
+  plugins: ProfilePluginRef[];
+  knowledge: ProfileKnowledge | null;
+  rules: string[];
+  /** A valid v1 harness.yaml string suitable for download and running with the CLI. */
+  harnessYaml: string;
+  /** Worst-case security trust across all resolved plugins. */
+  aggregateTrust: TrustTier;
+  security: ProfileSecurity;
+  /** GitHub repo stars at build time; undefined when fetch fails or is skipped. */
+  stars?: number;
+  /** Install count from telemetry; undefined until Phase 6 telemetry is live. */
+  installs?: number;
+  sourceId: string;
+}
+
 export interface MarketplaceData {
   generatedAt: string;
   marketplaceName: string;
   owner: string;
   categories: MarketplaceCategory[];
   plugins: MarketplacePlugin[];
+  profiles: MarketplaceProfile[];
+  /** GitHub repo stars at build time; undefined when fetch fails. */
+  repoStars?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

Makes harness profiles first-class citizens in the marketplace: the generator now reads `profiles/*.yaml`, resolves all components against the live plugin set, and emits a validated Harness Protocol v1 `harness.yaml` per profile. The website marketplace is redesigned to lead with profiles (the standout feature), followed by the plugin browser. Plugin detail pages now carry a multi-tab install widget covering Claude Code, npx/CLI, and Cursor deep-links.

This also fixes the production 404 at `/marketplace` — that's a release-gate issue (the route exists on preview but was never released to prod). Cutting a release after this merges will deploy it.

## Changes

- **`packages/marketplace-data/src/profiles.ts`** (new): reads `profiles/*.yaml` via the `ProfileYaml` type from `@harness-kit/shared`, resolves each component against the live plugin set, computes worst-case aggregate security trust, builds a validated v1 `harness.yaml` string (legacy shape → `version/kind/metadata/plugins/instructions`), and emits `MarketplaceProfile[]` sorted by name
- **`packages/marketplace-data`**: added `yaml` as a direct dep; `generate.ts` calls `readProfiles` after the plugins loop and `fetchRepoStars` for the first-party repo; new `MarketplaceProfile`, `ProfilePluginRef`, `ProfileSecurity`, `ProfileKnowledge`, `ProfileSeedDoc` types; `MarketplaceData` gains `profiles[]` + `repoStars?`
- **`website/lib/marketplace/`**: mirrored new types in `types.ts`; added `getAllProfiles`, `getProfile`, `getRepoStars` to `data.ts`; new `deeplinks.ts` (Cursor `cursor://` MCP install deep-link builder)
- **`website/app/marketplace/page.tsx`**: rewritten — hero with stars badge + `SupportedAgents` row → profiles grid (leads) → divider → plugin browser
- **`website/app/marketplace/profiles/[slug]/page.tsx`** (new): SSG route, 3 profiles statically generated
- **`website/app/marketplace/[slug]/page.tsx`**: swaps `InstallCommand` for `InstallWidget`; adds `RankingBadges` to header
- **New components**: `ProfileCard`, `ProfileDetail`, `InstallWidget` (multi-tab: Claude Code / npx/CLI / Cursor), `RankingBadges` (official badge + trust + stars/installs), `SupportedAgents`
- **`.github/workflows/deploy-docs.yml`**: wires `GITHUB_TOKEN` into the generate step for star count fetch

## Test Plan

- [x] 26/26 generator tests pass (`pnpm --filter @harness-kit/marketplace-data test`) — all 3 profiles resolve, aggregate trust correct, every `harnessYaml` passes `validateHarnessYaml`
- [x] Website build clean (`pnpm run build`) — 83 static pages including the 3 new `/marketplace/profiles/*` routes
- [ ] CI passes
- [ ] Preview URL verified: `/marketplace`, `/marketplace/profiles/full-stack-engineer`, `/marketplace/research` all render correctly
- [ ] After release: `harnesskit.ai/marketplace` resolves (fixes prod 404)

## Notes

- **Prod 404 fix**: `deploy-docs.yml` only deploys to `--branch=main` (production) on a GitHub `release` event. The marketplace code has been on `main` since before the last release. Once this PR merges, run `/go-live` to cut a release and deploy to prod.
- **Install paths**: only `npx @harness-kit/cli run` is a real ephemeral path — there's no single-plugin `add` command. The "persistent" install shows the correct harness.yaml → sync → compile flow. Cursor deep-links are only rendered for plugins with `mcp != null`.
- **Profile harness.yaml**: emits the **live** plugin version (not the profile-pinned version) so downloaded configs don't pin stale/yanked versions.
- Task 3 (shared view-model promotion to `@harness-kit/shared`) is deferred to Phase 4 alongside the desktop alignment — the current mirrored types are guarded with `?? []` to survive stale JSON.