### PR TITLE
fix(ci): repair Dependabot auto-merge + drop broken /website ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,27 +12,16 @@ updates:
         patterns:
           - "*"
 
-  # Root pnpm workspace — covers all workspace packages via shared lockfile
-  # (apps/cli, apps/desktop, packages/*, evals/fixtures, etc.)
+  # Root pnpm workspace — covers ALL workspace packages via the shared root lockfile,
+  # including website/ (a member of pnpm-workspace.yaml: apps/*, packages/*, website).
+  # website/pnpm-lock.yaml is vestigial — pnpm resolves website against the root
+  # lockfile — so website is intentionally NOT a separate npm ecosystem. Adding one
+  # produces broken PRs that touch website/package.json without updating the root lock.
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 3
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-    groups:
-      npm_and_yarn:
-        patterns:
-          - "*"
-
-  # website — standalone pnpm-lock.yaml, must be listed separately
-  - package-ecosystem: "npm"
-    directory: "/website"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 2
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,8 +1,25 @@
 name: Dependabot Auto-Merge
 
+# Auto-merges Dependabot PRs using GitHub's native auto-merge, queued via
+# `gh pr merge --auto`. GitHub holds the merge until the base branch's REQUIRED
+# status checks pass (configured in branch protection), so CI is always enforced.
+#
+# Scope is gated on the Dependabot update type:
+#   • patch + minor → auto-merge (squash, delete branch)
+#   • major         → left open, labelled `needs-manual-review`, flagged for a human
+#
+# Prerequisites (one-time):
+#   • Repo setting "Allow auto-merge" (allow_auto_merge) must be enabled.
+#   • Base branch protection must define required status checks.
+#   • A `needs-manual-review` label must exist.
+
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
 
 concurrency:
   group: dependabot-auto-merge-${{ github.event.pull_request.number }}
@@ -12,109 +29,31 @@ jobs:
   auto-merge:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
-    permissions:
-      checks: read
-      contents: write
-      pull-requests: write
-
     steps:
-      - name: Post opening comment
-        if: github.event.action == 'opened' || github.event.action == 'reopened'
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch & minor updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
         run: |
-          gh pr comment "$PR_NUMBER" --body \
-            "🤖 **Dependabot Auto-Merge** detected this PR. Requesting a Copilot review and waiting for CI checks before merging."
+          gh pr merge --auto --squash --delete-branch "$PR_URL"
+          gh pr comment "$PR_URL" --body \
+            "🤖 **Auto-merge enabled** (\`${UPDATE_TYPE#version-update:semver-}\` update). GitHub will squash-merge this automatically once the required CI checks pass."
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
 
-      - name: Request Copilot review
-        if: github.event.action == 'opened' || github.event.action == 'reopened'
+      - name: Flag major updates for manual review
+        if: steps.meta.outputs.update-type == 'version-update:semver-major'
         run: |
-          gh pr comment "$PR_NUMBER" --body \
-            "@copilot please review this dependency update"
+          gh pr edit "$PR_URL" --add-label "needs-manual-review"
+          gh pr comment "$PR_URL" --body \
+            "⚠️ **Major version update** (\`${DEP}\`) — auto-merge skipped. A human should review the changelog before merging."
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-
-      - name: Wait for CI checks to pass
-        id: wait-checks
-        run: |
-          echo "Waiting for all CI checks to complete (max 30 minutes)..."
-          DEADLINE=$(( $(date +%s) + 1800 ))
-          # Give the CI system a moment to register checks before the first poll.
-          sleep 20
-
-          while true; do
-            NOW=$(date +%s)
-            if [ "$NOW" -ge "$DEADLINE" ]; then
-              echo "::error::Timed out waiting for CI checks after 30 minutes."
-              exit 1
-            fi
-
-            # Exclude this workflow's own check to avoid a self-referential wait.
-            # The filter value is "<workflow name> / <job name>" — update if either is renamed.
-            STATUS=$(gh pr checks "$PR_NUMBER" --json name,state,conclusion \
-              --jq '[.[] | select(.name != "Dependabot Auto-Merge / auto-merge")] | {
-                total: length,
-                pending: [.[] | select(.state == "PENDING" or .state == "IN_PROGRESS" or .state == "QUEUED" or .conclusion == "")] | length,
-                failed: [.[] | select(.conclusion != "" and (.conclusion != "SUCCESS" and .conclusion != "SKIPPED" and .conclusion != "NEUTRAL"))] | length,
-                passed: [.[] | select(.conclusion == "SUCCESS" or .conclusion == "SKIPPED" or .conclusion == "NEUTRAL")] | length
-              }')
-
-            TOTAL=$(echo "$STATUS" | jq -r '.total')
-            PENDING=$(echo "$STATUS" | jq -r '.pending')
-            FAILED=$(echo "$STATUS" | jq -r '.failed')
-            PASSED=$(echo "$STATUS" | jq -r '.passed')
-
-            echo "Checks — total: $TOTAL, pending: $PENDING, passed: $PASSED, failed: $FAILED"
-
-            if [ "$FAILED" -gt 0 ]; then
-              echo "::error::One or more CI checks failed. Aborting auto-merge."
-              exit 1
-            fi
-
-            # PENDING == 0 covers both "all checks passed" and "no checks defined".
-            if [ "$PENDING" -eq 0 ]; then
-              echo "No pending checks. Proceeding with merge."
-              break
-            fi
-
-            sleep 30
-          done
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-
-      - name: Post pre-merge comment
-        run: |
-          gh pr comment "$PR_NUMBER" --body \
-            "✅ All CI checks passed. Squash-merging now and deleting the branch."
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-
-      - name: Squash merge and delete branch
-        run: |
-          PR_TITLE=$(gh pr view "$PR_NUMBER" --json title --jq '.title')
-          gh pr merge "$PR_NUMBER" \
-            --squash \
-            --delete-branch \
-            --subject "$PR_TITLE"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-
-      - name: Post failure comment
-        if: failure()
-        run: |
-          gh pr comment "$PR_NUMBER" --body \
-            "❌ **Auto-merge failed.** Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details. Manual intervention may be required."
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          DEP: ${{ steps.meta.outputs.dependency-names }}


### PR DESCRIPTION
## What

Two related CI fixes so Dependabot PRs flow cleanly and merge themselves.

### 1. Auto-merge actually works now
The existing `dependabot-auto-merge.yml` has **never** worked. It polled:

```
gh pr checks --json name,state,conclusion
```

but `gh pr checks` has no `conclusion` field, so the step errored on the first poll of every PR — the red `auto-merge` check you've seen on every Dependabot PR.

Replaced the 30-minute polling loop with **GitHub-native auto-merge** (`gh pr merge --auto --squash`), gated by update type via [`dependabot/fetch-metadata`](https://github.com/dependabot/fetch-metadata):

| Update type | Behaviour |
|---|---|
| patch + minor | auto-merge (squash, delete branch) once required checks pass |
| **major** | labelled `needs-manual-review`, left open for a human |

GitHub holds the queued merge until the base branch's **required status checks** (`validate`, `test-all`, `desktop-build-test`, `security-scan`) pass — CI is still fully enforced. No more fragile polling.

### 2. Dropped the misconfigured `/website` Dependabot ecosystem
`website` is a member of the root `pnpm-workspace.yaml`, so its deps are governed by the **root** `pnpm-lock.yaml`. The standalone `website/pnpm-lock.yaml` is vestigial — pnpm resolves `website` against the root lock (CI proves this: the `docs-build` website install runs from `working-directory: website` but pulls from `..`).

The separate `/website` npm ecosystem only produced **broken PRs** that bumped `website/package.json` without updating the root lock — e.g. the now-closed #242, whose entire diff was already shipped correctly by #243.

## One-time setup already applied
- ✅ Enabled repo setting **Allow auto-merge** (`allow_auto_merge`)
- ✅ Created the `needs-manual-review` label
- ✅ Branch protection already defines the required checks this relies on

## Notes
- Dropped the old `@copilot` review-request step — auto-merged patch/minor PRs merge before a review would complete; majors get a human anyway.
- npm majors are still `ignore`d in `dependabot.yml`; cargo/github-actions majors now get caught by the `needs-manual-review` gate instead of silently auto-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)