### PR TITLE
fix(desktop): deterministic port_in_use free-port tests

### DIFF
--- a/apps/desktop/src-tauri/src/agent_server.rs
+++ b/apps/desktop/src-tauri/src/agent_server.rs
@@ -227,11 +227,19 @@ mod tests {
 
     #[test]
     fn port_in_use_returns_false_for_free_port() {
-        // Bind to 0 to get an ephemeral port, then drop to free it
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let port = listener.local_addr().unwrap().port();
-        drop(listener);
-        assert!(!port_in_use(port));
+        // No port is guaranteed free across an arbitrary window: the OS can hand a
+        // just-released ephemeral port to another process (or a sibling test running
+        // concurrently in this binary) before we check it. So retry — a lost race is
+        // expected, but a port that never reads as free is a real bug.
+        for _ in 0..50 {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let port = listener.local_addr().unwrap().port();
+            drop(listener);
+            if !port_in_use(port) {
+                return;
+            }
+        }
+        panic!("no freshly-released ephemeral port read as free after 50 attempts");
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/board_server.rs
+++ b/apps/desktop/src-tauri/src/board_server.rs
@@ -215,11 +215,19 @@ mod tests {
 
     #[test]
     fn port_in_use_returns_false_for_free_port() {
-        // Bind to 0 to get an ephemeral port, then drop to free it
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let port = listener.local_addr().unwrap().port();
-        drop(listener);
-        assert!(!port_in_use(port));
+        // No port is guaranteed free across an arbitrary window: the OS can hand a
+        // just-released ephemeral port to another process (or a sibling test running
+        // concurrently in this binary) before we check it. So retry — a lost race is
+        // expected, but a port that never reads as free is a real bug.
+        for _ in 0..50 {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let port = listener.local_addr().unwrap().port();
+            drop(listener);
+            if !port_in_use(port) {
+                return;
+            }
+        }
+        panic!("no freshly-released ephemeral port read as free after 50 attempts");
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/membrain_commands.rs
+++ b/apps/desktop/src-tauri/src/membrain_commands.rs
@@ -101,10 +101,19 @@ mod tests {
 
     #[test]
     fn port_in_use_returns_false_for_free_port() {
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let port = listener.local_addr().unwrap().port();
-        drop(listener);
-        assert!(!port_in_use(port));
+        // No port is guaranteed free across an arbitrary window: the OS can hand a
+        // just-released ephemeral port to another process (or a sibling test running
+        // concurrently in this binary) before we check it. So retry — a lost race is
+        // expected, but a port that never reads as free is a real bug.
+        for _ in 0..50 {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let port = listener.local_addr().unwrap().port();
+            drop(listener);
+            if !port_in_use(port) {
+                return;
+            }
+        }
+        panic!("no freshly-released ephemeral port read as free after 50 attempts");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
The `port_in_use_returns_false_for_free_port` unit tests in the desktop Tauri backend intermittently failed CI with `assertion failed: !port_in_use(port)`. They picked an ephemeral port, dropped its listener, then asserted the port read as free — a race the OS could lose at any moment. This makes those tests deterministic without losing coverage.

## Changes
- **`board_server.rs`, `agent_server.rs`, `membrain_commands.rs`** — the `_false_for_free_port` test now retries acquiring a freshly-released ephemeral port up to 50 times. A single lost race (the OS handing the port to another process or a sibling test running concurrently in the same test binary) is expected and tolerated; a port that *never* reads as free panics with a clear message.
- The `_true_for_occupied_port` tests were already deterministic (listener held open → port genuinely occupied) and are unchanged.

## Why it was flaky
There is no real OS port guaranteed free across an arbitrary window. `cargo test` runs all tests in one binary on multiple threads, so the three `_false_for_free_port` tests plus the three `_true_for_occupied_port` tests all do ephemeral binds simultaneously — a just-dropped port can be reassigned before the assert runs.

## Test Plan
- [x] Local tests pass — `cargo test` in `apps/desktop/src-tauri`: 70 passed, 0 failed
- [x] All six `port_in_use` tests green across 20 consecutive repeat runs (0 flakes)
- [ ] CI checks pass

## Notes
- `relay_server` was checked for the same pattern — it has no `port_in_use` function and its tests cover broadcast logic, not port-freeness, so nothing to fix there.
- Scope is limited to the three test functions; no production code changed. Regenerated `gen/schemas/*.json` build artifacts (unrelated Tauri permission-set bump) were deliberately left out of this PR.