### PR TITLE
fix(release): repair release workflow (exchange build + artifact v8)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,7 @@ jobs:
         run: |
           pnpm --filter @harness-kit/shared build
           pnpm --filter @harness-kit/core build
+          pnpm --filter @harness-kit/exchange build
 
       - name: Build standalone bundle
         working-directory: apps/cli
@@ -142,7 +143,7 @@ jobs:
           rm harness-kit
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v8
         with:
           name: cli-standalone-darwin-arm64
           path: apps/cli/harness-kit-v${{ needs.prepare.outputs.version }}-darwin-arm64.tar.gz
@@ -198,7 +199,7 @@ jobs:
           echo "path=$DEST" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v8
         with:
           name: desktop-darwin-arm64
           path: ${{ steps.dmg.outputs.path }}


### PR DESCRIPTION
## Problem

The release workflow has been failing since v0.9.0, and today's v0.10.0 release run failed too. Two independent bugs:

1. **`build-cli-standalone` could not resolve `@harness-kit/exchange`.** PR #246 added the `@harness-kit/exchange` workspace package as a CLI dependency, but the release job only builds `shared` + `core` before the standalone `tsup` bundle (which inlines workspace deps). The new package's `dist/` never existed → `Could not resolve "@harness-kit/exchange"`.

2. **The `release` job failed with `digest-mismatch`.** Uploads used `actions/upload-artifact@v7` while downloads used `actions/download-artifact@v8` — incompatible major versions. This is why v0.9.0's release job failed (its `build-cli-standalone` succeeded, since exchange didn't exist yet).

## Fix

- Add `pnpm --filter @harness-kit/exchange build` after `core` in `build-cli-standalone` (exchange depends on core).
- Bump both `upload-artifact@v7` → `@v8` to match the `download-artifact@v8` steps.

## Verification

Reproduced bug #1 locally and confirmed the fix: after building shared → core → exchange, `pnpm tsup --config tsup.config.standalone.ts` builds the 1.62 MB standalone bundle successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)