### PR TITLE
fix(release): pin artifact actions to matching v7 pair

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -140,12 +140,12 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download CLI standalone artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: cli-standalone-darwin-arm64
 
       - name: Download desktop artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: desktop-darwin-arm64
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,7 +143,7 @@ jobs:
           rm harness-kit
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: cli-standalone-darwin-arm64
           path: apps/cli/harness-kit-v${{ needs.prepare.outputs.version }}-darwin-arm64.tar.gz
@@ -199,7 +199,7 @@ jobs:
           echo "path=$DEST" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: desktop-darwin-arm64
           path: ${{ steps.dmg.outputs.path }}
@@ -214,12 +214,12 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download CLI standalone artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: cli-standalone-darwin-arm64
 
       - name: Download desktop artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: desktop-darwin-arm64
 


### PR DESCRIPTION
## Problem

Follow-up to #252. That PR bumped `actions/upload-artifact` to `@v8` to match `download-artifact@v8` — but **`upload-artifact` has no v8** (its latest major is v7). The re-cut v0.10.0 release run failed immediately: `Unable to resolve action actions/upload-artifact@v8, unable to find version v8`.

The two actions are separate repos with independent versioning. The original `digest-mismatch` failure on v0.9.0 came from pairing `upload@v7` with `download@v8` — they must share a major version.

## Fix

Pin both `upload-artifact` and `download-artifact` to **v7** (the only matched pair available, since upload tops out at v7). Applied the same fix to `nightly.yml`, which had the identical `upload@v7` / `download@v8` mismatch and would fail the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)