### PR TITLE
feat(core): Phase 1b — resolveExtends so accepted fragments take effect in compile

### DIFF
--- a/packages/core/__tests__/extends.test.ts
+++ b/packages/core/__tests__/extends.test.ts
@@ -1,0 +1,492 @@
+import { describe, it, expect } from "vitest"
+import { resolveExtends } from "../src/compile/extends.js"
+import { compile } from "../src/compile/compile.js"
+import { MockFsProvider } from "./helpers/mock-fs.js"
+import type { HarnessConfig } from "../src/types.js"
+
+// ── YAML helpers ──────────────────────────────────────────────
+
+const BASE_FRAGMENT_YAML = `\
+$schema: https://harnessprotocol.io/schema/v1/harness.schema.json
+version: "1"
+kind: fragment
+metadata:
+  name: postgres-fragment
+  description: Postgres fragment
+mcp-servers:
+  postgres:
+    transport: stdio
+    command: uvx
+    args: [mcp-server-postgres]
+`
+
+const BASE_PROFILE_YAML = `\
+$schema: https://harnessprotocol.io/schema/v1/harness.schema.json
+version: "1"
+kind: profile
+metadata:
+  name: test-profile
+  description: Test profile
+`
+
+// ── Minimal config builder ────────────────────────────────────
+
+function makeConfig(overrides: Partial<HarnessConfig> = {}): HarnessConfig {
+  return {
+    version: "1",
+    kind: "profile",
+    metadata: { name: "test-profile", description: "Test profile" },
+    ...overrides,
+  }
+}
+
+// ── Core behavior ─────────────────────────────────────────────
+
+describe("resolveExtends — no extends field", () => {
+  it("returns config unchanged when no extends field is present", async () => {
+    const fs = new MockFsProvider()
+    const config = makeConfig()
+    const result = await resolveExtends(config, fs, "/project")
+    expect(result).toEqual(config)
+  })
+})
+
+describe("resolveExtends — empty extends array", () => {
+  it("returns config unchanged when extends is empty array", async () => {
+    const fs = new MockFsProvider()
+    const config = makeConfig({ extends: [] })
+    const result = await resolveExtends(config, fs, "/project")
+    expect(result["mcp-servers"]).toBeUndefined()
+  })
+})
+
+describe("resolveExtends — mcp-servers merge", () => {
+  it("adds fragment mcp-servers when profile has none", async () => {
+    const fs = new MockFsProvider({
+      "/project/.harness/exchange/postgres.harness.yaml": BASE_FRAGMENT_YAML,
+    })
+    const config = makeConfig({
+      extends: [{ source: "./.harness/exchange/postgres.harness.yaml" }],
+    })
+
+    const result = await resolveExtends(config, fs, "/project")
+    expect(result["mcp-servers"]).toBeDefined()
+    expect(result["mcp-servers"]!.postgres).toBeDefined()
+  })
+
+  it("child mcp-servers entry wins on conflict", async () => {
+    const fragmentYaml = `\
+$schema: https://harnessprotocol.io/schema/v1/harness.schema.json
+version: "1"
+kind: fragment
+metadata:
+  name: frag
+  description: frag
+mcp-servers:
+  postgres:
+    transport: stdio
+    command: uvx
+    args: [mcp-server-postgres]
+`
+    const fs = new MockFsProvider({
+      "/project/frag.harness.yaml": fragmentYaml,
+    })
+    const config = makeConfig({
+      "mcp-servers": {
+        postgres: {
+          transport: "stdio",
+          command: "pg-custom",
+          args: ["--port", "5433"],
+        },
+      },
+      extends: [{ source: "./frag.harness.yaml" }],
+    })
+
+    const result = await resolveExtends(config, fs, "/project")
+    const server = result["mcp-servers"]!.postgres as { command: string }
+    expect(server.command).toBe("pg-custom")
+  })
+})
+
+// ── Env merge ─────────────────────────────────────────────────
+
+describe("resolveExtends — env union", () => {
+  it("unions env entries from fragment and profile", async () => {
+    const fragmentYaml = `\
+$schema: https://harnessprotocol.io/schema/v1/harness.schema.json
+version: "1"
+kind: fragment
+metadata:
+  name: frag
+  description: frag
+env:
+  - name: DB_CONNECTION_STRING
+    description: PostgreSQL connection string
+    required: true
+`
+    const fs = new MockFsProvider({
+      "/project/frag.harness.yaml": fragmentYaml,
+    })
+    const config = makeConfig({
+      env: [{ name: "LOCAL_PATH", description: "Local path", required: false }],
+      extends: [{ source: "./frag.harness.yaml" }],
+    })
+
+    const result = await resolveExtends(config, fs, "/project")
+    const names = result.env!.map((e) => e.name)
+    expect(names).toContain("DB_CONNECTION_STRING")
+    expect(names).toContain("LOCAL_PATH")
+  })
+
+  it("child env entry wins on name conflict", async () => {
+    const fragmentYaml = `\
+$schema: https://harnessprotocol.io/schema/v1/harness.schema.json
+version: "1"
+kind: fragment
+metadata:
+  name: frag
+  description: frag
+env:
+  - name: DB_URL
+    description: Fragment DB URL
+    required: true
+`
+    const fs = new MockFsProvider({
+      "/project/frag.harness.yaml": fragmentYaml,
+    })
+    const config = makeConfig({
+      env: [{ name: "DB_URL", description: "Profile DB URL", required: false }],
+      extends: [{ source: "./frag.harness.yaml" }],
+    })
+
+    const result = await resolveExtends(config, fs, "/project")
+    const entry = result.env!.find((e) => e.name === "DB_URL")!
+    expect(entry.description).toBe("Profile DB URL")
+  })
+})
+
+// ── Instructions merge ────────────────────────────────────────
+
+describe("resolveExtends — instructions merge", () => {
+  it("import-mode merge: fragment operational instructions appear before profile's", async () => {
+    const fragmentYaml = `\
+$schema: https://harnessprotocol.io/schema/v1/harness.schema.json
+version: "1"
+kind: fragment
+metadata:
+  name: frag
+  description: frag
+instructions:
+  operational: |
+    Fragment operational content
+`
+    const fs = new MockFsProvider({
+      "/project/frag.harness.yaml": fragmentYaml,
+    })
+    const config = makeConfig({
+      instructions: {
+        operational: "Profile operational content",
+        "import-mode": "merge",
+      },
+      extends: [{ source: "./frag.harness.yaml" }],
+    })
+
+    const result = await resolveExtends(config, fs, "/project")
+    const operational = result.instructions!.operational!
+    const fragIdx = operational.indexOf("Fragment operational content")
+    const profileIdx = operational.indexOf("Profile operational content")
+    expect(fragIdx).toBeGreaterThanOrEqual(0)
+    expect(profileIdx).toBeGreaterThan(fragIdx)
+  })
+
+  it("import-mode replace: profile instructions completely replace fragment instructions", async () => {
+    const fragmentYaml = `\
+$schema: https://harnessprotocol.io/schema/v1/harness.schema.json
+version: "1"
+kind: fragment
+metadata:
+  name: frag
+  description: frag
+instructions:
+  operational: |
+    Fragment operational content
+`
+    const fs = new MockFsProvider({
+      "/project/frag.harness.yaml": fragmentYaml,
+    })
+    const config = makeConfig({
+      instructions: {
+        operational: "Profile operational content",
+        "import-mode": "replace",
+      },
+      extends: [{ source: "./frag.harness.yaml" }],
+    })
+
+    const result = await resolveExtends(config, fs, "/project")
+    const operational = result.instructions!.operational!
+    expect(operational).not.toContain("Fragment operational content")
+    expect(operational).toContain("Profile operational content")
+  })
+
+  it("import-mode skip: fragment instructions pass through unchanged, profile contributes nothing", async () => {
+    const fragmentYaml = `\
+$schema: https://harnessprotocol.io/schema/v1/harness.schema.json
+version: "1"
+kind: fragment
+metadata:
+  name: frag
+  description: frag
+instructions:
+  operational: |
+    Fragment operational content
+`
+    const fs = new MockFsProvider({
+      "/project/frag.harness.yaml": fragmentYaml,
+    })
+    const config = makeConfig({
+      instructions: {
+        operational: "Profile operational content",
+        "import-mode": "skip",
+      },
+      extends: [{ source: "./frag.harness.yaml" }],
+    })
+
+    const result = await resolveExtends(config, fs, "/project")
+    const operational = result.instructions!.operational!
+    expect(operational).toContain("Fragment operational content")
+    expect(operational).not.toContain("Profile operational content")
+  })
+})
+
+// ── Permissions ───────────────────────────────────────────────
+
+describe("resolveExtends — permissions", () => {
+  it("tools.allow intersection: resolved allow is subset common to both", async () => {
+    const fragmentYaml = `\
+$schema: https://harnessprotocol.io/schema/v1/harness.schema.json
+version: "1"
+kind: fragment
+metadata:
+  name: frag
+  description: frag
+permissions:
+  tools:
+    allow:
+      - Read
+      - Grep
+      - Write
+`
+    const fs = new MockFsProvider({
+      "/project/frag.harness.yaml": fragmentYaml,
+    })
+    const config = makeConfig({
+      permissions: {
+        tools: { allow: ["Read", "Grep"] },
+      },
+      extends: [{ source: "./frag.harness.yaml" }],
+    })
+
+    const result = await resolveExtends(config, fs, "/project")
+    const allow = result.permissions!.tools!.allow!
+    expect(allow).toContain("Read")
+    expect(allow).toContain("Grep")
+    expect(allow).not.toContain("Write")
+  })
+
+  it("tools.allow: child inherits parent allow unchanged when child has none", async () => {
+    const fragmentYaml = `\
+$schema: https://harnessprotocol.io/schema/v1/harness.schema.json
+version: "1"
+kind: fragment
+metadata:
+  name: frag
+  description: frag
+permissions:
+  tools:
+    allow:
+      - Read
+      - Grep
+      - Write
+`
+    const fs = new MockFsProvider({
+      "/project/frag.harness.yaml": fragmentYaml,
+    })
+    const config = makeConfig({
+      extends: [{ source: "./frag.harness.yaml" }],
+    })
+
+    const result = await resolveExtends(config, fs, "/project")
+    const allow = result.permissions!.tools!.allow!
+    expect(allow).toContain("Read")
+    expect(allow).toContain("Grep")
+    expect(allow).toContain("Write")
+  })
+
+  it("tools.deny union: resolved deny includes entries from both parent and child", async () => {
+    const fragmentYaml = `\
+$schema: https://harnessprotocol.io/schema/v1/harness.schema.json
+version: "1"
+kind: fragment
+metadata:
+  name: frag
+  description: frag
+permissions:
+  tools:
+    deny:
+      - "mcp__*__drop_*"
+`
+    const fs = new MockFsProvider({
+      "/project/frag.harness.yaml": fragmentYaml,
+    })
+    const config = makeConfig({
+      permissions: {
+        tools: { deny: ["Bash"] },
+      },
+      extends: [{ source: "./frag.harness.yaml" }],
+    })
+
+    const result = await resolveExtends(config, fs, "/project")
+    const deny = result.permissions!.tools!.deny!
+    expect(deny).toContain("Bash")
+    expect(deny).toContain("mcp__*__drop_*")
+  })
+
+  it("paths.writable union: resolved writable includes paths from both parent and child", async () => {
+    const fragmentYaml = `\
+$schema: https://harnessprotocol.io/schema/v1/harness.schema.json
+version: "1"
+kind: fragment
+metadata:
+  name: frag
+  description: frag
+permissions:
+  paths:
+    writable:
+      - sql/
+      - migrations/
+`
+    const fs = new MockFsProvider({
+      "/project/frag.harness.yaml": fragmentYaml,
+    })
+    const config = makeConfig({
+      permissions: {
+        paths: { writable: ["src/"] },
+      },
+      extends: [{ source: "./frag.harness.yaml" }],
+    })
+
+    const result = await resolveExtends(config, fs, "/project")
+    const writable = result.permissions!.paths!.writable!
+    expect(writable).toContain("sql/")
+    expect(writable).toContain("migrations/")
+    expect(writable).toContain("src/")
+  })
+})
+
+// ── Error handling ────────────────────────────────────────────
+
+describe("resolveExtends — error handling", () => {
+  it("throws a clear error when a local fragment file does not exist", async () => {
+    const fs = new MockFsProvider()
+    const config = makeConfig({
+      extends: [{ source: "./missing-fragment.harness.yaml" }],
+    })
+
+    await expect(
+      resolveExtends(config, fs, "/project"),
+    ).rejects.toThrow()
+  })
+
+  it("skips without throwing when extends source is a remote (owner/repo) reference", async () => {
+    const fs = new MockFsProvider()
+    const config = makeConfig({
+      extends: [{ source: "owner/repo" }],
+    })
+
+    await expect(resolveExtends(config, fs, "/project")).resolves.toBeDefined()
+  })
+
+  it("throws on circular extends", async () => {
+    const fragmentA = `\
+$schema: https://harnessprotocol.io/schema/v1/harness.schema.json
+version: "1"
+kind: fragment
+metadata:
+  name: fragment-a
+  description: Fragment A
+extends:
+  - source: ./harness.yaml
+`
+    const profileYaml = `\
+$schema: https://harnessprotocol.io/schema/v1/harness.schema.json
+version: "1"
+kind: profile
+metadata:
+  name: test-profile
+  description: Test profile
+extends:
+  - source: ./fragment-a.harness.yaml
+`
+    const fs = new MockFsProvider({
+      "/project/harness.yaml": profileYaml,
+      "/project/fragment-a.harness.yaml": fragmentA,
+    })
+
+    // Parse the profile to get a HarnessConfig with extends
+    const config = makeConfig({
+      extends: [{ source: "./fragment-a.harness.yaml" }],
+    })
+
+    await expect(
+      resolveExtends(config, fs, "/project"),
+    ).rejects.toThrow()
+  })
+})
+
+// ── Integration test ──────────────────────────────────────────
+
+describe("compile reflects accepted fragment", () => {
+  it("compiled output mcp-servers FileAction includes the postgres server from fragment", async () => {
+    const fragmentYaml = `\
+$schema: https://harnessprotocol.io/schema/v1/harness.schema.json
+version: "1"
+kind: fragment
+metadata:
+  name: postgres-fragment
+  description: Postgres fragment
+mcp-servers:
+  postgres:
+    transport: stdio
+    command: uvx
+    args: [mcp-server-postgres]
+`
+
+    const profileYaml = `\
+$schema: https://harnessprotocol.io/schema/v1/harness.schema.json
+version: "1"
+kind: profile
+metadata:
+  name: test-profile
+  description: Test profile
+extends:
+  - source: ./.harness/exchange/postgres-fragment.harness.yaml
+instructions:
+  operational: |
+    Be helpful.
+  import-mode: merge
+`
+
+    const fs = new MockFsProvider({
+      "/project/.harness/exchange/postgres-fragment.harness.yaml": fragmentYaml,
+    })
+
+    const result = await compile(profileYaml, ["claude-code"], fs, { dryRun: true })
+
+    const mcpFile = result.files.find((f) => f.slot === "mcp-servers")
+    expect(mcpFile).toBeDefined()
+
+    const parsed = JSON.parse(mcpFile!.content)
+    expect(parsed.mcpServers.postgres).toBeDefined()
+    expect(parsed.mcpServers.postgres.command).toBe("uvx")
+  })
+})

--- a/packages/core/src/compile/compile.ts
+++ b/packages/core/src/compile/compile.ts
@@ -14,6 +14,7 @@ import { compileMcpServers } from "./mcp-servers.js";
 import { compileSkills } from "./skills.js";
 import { compilePermissions, buildPermissionsText } from "./permissions.js";
 import { appendMarkerBlock, findMarkerBlock, replaceMarkerBlock } from "./markers.js";
+import { resolveExtends } from "./extends.js";
 
 // ── Source fingerprint ────────────────────────────────────────
 
@@ -93,11 +94,15 @@ export async function compile(
     throw new Error(`harness.yaml validation failed:\n${errMsgs}`);
   }
 
-  const harnessName = config.metadata?.name ?? "default";
   const cwd = fs.cwd();
 
+  // Phase 1b: resolve extends fragments into the effective config
+  const resolvedConfig = await resolveExtends(config, fs, cwd);
+
+  const harnessName = resolvedConfig.metadata?.name ?? "default";
+
   // Stage 3: Compute source fingerprint
-  const fingerprint = computeSourceFingerprint(yamlString, config);
+  const fingerprint = computeSourceFingerprint(yamlString, resolvedConfig);
   const targetKey = [...targets].sort().join(",");
 
   // Stage 4: Skip if unchanged (bypass with --force or dry-run)
@@ -122,28 +127,28 @@ export async function compile(
   // Stage 5: Resolve targets (already passed in — future: filter by detected binaries)
 
   // Stage 6: Generate instructions
-  const instrResult = await compileInstructions(config, targets, fs);
+  const instrResult = await compileInstructions(resolvedConfig, targets, fs);
   allFiles.push(...instrResult.files);
   allWarnings.push(...instrResult.warnings);
 
-  if (config.permissions) {
-    const permText = buildPermissionsText(config.permissions);
+  if (resolvedConfig.permissions) {
+    const permText = buildPermissionsText(resolvedConfig.permissions);
     if (permText) {
-      appendPermissionsToInstructions(allFiles, config, permText);
+      appendPermissionsToInstructions(allFiles, resolvedConfig, permText);
     }
   }
 
   // Stage 7: Generate MCP config
-  const mcpResult = await compileMcpServers(config, targets, fs);
+  const mcpResult = await compileMcpServers(resolvedConfig, targets, fs);
   allFiles.push(...mcpResult.files);
   allWarnings.push(...mcpResult.warnings);
 
   // Compile skills + permissions
-  const skillsResult = await compileSkills(config, targets, fs);
+  const skillsResult = await compileSkills(resolvedConfig, targets, fs);
   allFiles.push(...skillsResult.files);
   allSkipped.push(...skillsResult.skippedPlugins);
 
-  const permsResult = await compilePermissions(config, targets, fs);
+  const permsResult = await compilePermissions(resolvedConfig, targets, fs);
   allFiles.push(...permsResult.files);
   allWarnings.push(...permsResult.warnings);
 

--- a/packages/core/src/compile/extends.ts
+++ b/packages/core/src/compile/extends.ts
@@ -1,0 +1,422 @@
+import type { FsProvider } from "../fs-provider.js";
+import type {
+  EnvDeclaration,
+  HarnessConfig,
+  HarnessInstructions,
+  HarnessPermissions,
+  HarnessPlugin,
+  McpServer,
+} from "../types.js";
+import { parseHarness } from "../parser/parse-harness.js";
+import { validateHarness } from "../schema/validate.js";
+
+// ── Constants ─────────────────────────────────────────────────
+
+const MAX_DEPTH = 5;
+
+// ── Internal merge helpers ────────────────────────────────────
+
+/**
+ * Merge two records by key — overlay wins on conflict.
+ */
+function mergeByKey<T>(
+  base: Record<string, T> | undefined,
+  overlay: Record<string, T> | undefined,
+): Record<string, T> | undefined {
+  if (!base && !overlay) return undefined;
+  return { ...(base ?? {}), ...(overlay ?? {}) };
+}
+
+/**
+ * Merge two arrays deduplicating by a string key — overlay entries win on conflict.
+ * Items from base that share a key with an overlay item are dropped.
+ */
+function mergeByName<T extends { name: string }>(
+  base: T[] | undefined,
+  overlay: T[] | undefined,
+): T[] | undefined {
+  if (!base && !overlay) return undefined;
+  const baseItems = base ?? [];
+  const overlayItems = overlay ?? [];
+  const overlayNames = new Set(overlayItems.map((i) => i.name));
+  const filtered = baseItems.filter((i) => !overlayNames.has(i.name));
+  const merged = [...filtered, ...overlayItems];
+  return merged.length > 0 ? merged : undefined;
+}
+
+/**
+ * Merge env declarations — dedup by name, overlay wins on conflict.
+ */
+function mergeEnv(
+  base: EnvDeclaration[] | undefined,
+  overlay: EnvDeclaration[] | undefined,
+): EnvDeclaration[] | undefined {
+  return mergeByName(base, overlay);
+}
+
+/**
+ * Merge plugins — dedup by name, overlay wins on conflict.
+ */
+function mergePlugins(
+  base: HarnessPlugin[] | undefined,
+  overlay: HarnessPlugin[] | undefined,
+): HarnessPlugin[] | undefined {
+  return mergeByName(base, overlay);
+}
+
+/**
+ * Normalize instructions to the structured form for internal processing.
+ * A plain string is treated as operational text with no import-mode set.
+ */
+function normalizeInstructions(
+  raw: HarnessInstructions | string | undefined,
+): HarnessInstructions | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  if (typeof raw === "string") {
+    return { operational: raw };
+  }
+  return raw;
+}
+
+/**
+ * Merge instructions where base is the accumulated parent and overlay is the child.
+ * The overlay's import-mode governs how the two are combined.
+ */
+function mergeInstructions(
+  base: HarnessInstructions | string | undefined,
+  overlay: HarnessInstructions | string | undefined,
+): HarnessInstructions | string | undefined {
+  const normalBase = normalizeInstructions(base);
+  const normalOverlay = normalizeInstructions(overlay);
+
+  if (!normalBase && !normalOverlay) return undefined;
+  if (!normalOverlay) return base; // no child instructions — pass parent through
+  if (!normalBase) return overlay; // no parent instructions — child as-is
+
+  const importMode = normalOverlay["import-mode"] ?? "merge";
+
+  if (importMode === "replace") {
+    // Child replaces parent entirely — return child as-is
+    return overlay;
+  }
+
+  if (importMode === "skip") {
+    // Parent passes through, child adds nothing
+    return base;
+  }
+
+  // merge (default): prepend parent text before child text for each slot
+  const mergeSlot = (
+    parentText: string | null | undefined,
+    childText: string | null | undefined,
+  ): string | null | undefined => {
+    if (!parentText && !childText) return undefined;
+    if (!parentText) return childText;
+    if (!childText) return parentText;
+    return `${parentText}\n\n${childText}`;
+  };
+
+  const merged: HarnessInstructions = {
+    operational: mergeSlot(normalBase.operational, normalOverlay.operational) as
+      | string
+      | null
+      | undefined,
+    behavioral: mergeSlot(normalBase.behavioral, normalOverlay.behavioral) as
+      | string
+      | null
+      | undefined,
+    identity: mergeSlot(normalBase.identity, normalOverlay.identity) as
+      | string
+      | null
+      | undefined,
+  };
+
+  // Preserve import-mode from overlay if set (so downstream passes it along)
+  if (normalOverlay["import-mode"]) {
+    merged["import-mode"] = normalOverlay["import-mode"];
+  }
+
+  // Strip undefined keys for a clean object
+  if (merged.operational === undefined) delete merged.operational;
+  if (merged.behavioral === undefined) delete merged.behavioral;
+  if (merged.identity === undefined) delete merged.identity;
+
+  return merged;
+}
+
+/**
+ * Merge string arrays as a union (no duplicates), overlay additions appended.
+ */
+function mergeStringUnion(
+  base: string[] | undefined,
+  overlay: string[] | undefined,
+): string[] | undefined {
+  if (!base && !overlay) return undefined;
+  const merged = [...(base ?? [])];
+  for (const item of overlay ?? []) {
+    if (!merged.includes(item)) merged.push(item);
+  }
+  return merged.length > 0 ? merged : undefined;
+}
+
+/**
+ * Merge string arrays as an intersection (only items present in both).
+ * If only one side defines the list, that list is used unchanged.
+ */
+function mergeStringIntersection(
+  base: string[] | undefined,
+  overlay: string[] | undefined,
+): string[] | undefined {
+  if (!base && !overlay) return undefined;
+  if (!base) return overlay;
+  if (!overlay) return base;
+  const result = base.filter((item) => overlay.includes(item));
+  return result.length > 0 ? result : undefined;
+}
+
+/**
+ * Merge permissions according to protocol rules:
+ * - tools.allow: intersection when both define it; single side wins otherwise
+ * - tools.deny: union
+ * - tools.ask: union
+ * - paths.writable: union
+ * - paths.readonly: union
+ * - network.allowed-hosts: union
+ */
+function mergePermissions(
+  base: HarnessPermissions | undefined,
+  overlay: HarnessPermissions | undefined,
+): HarnessPermissions | undefined {
+  if (!base && !overlay) return undefined;
+
+  const mergedTools: HarnessPermissions["tools"] = {};
+  const baseTools = base?.tools;
+  const overlayTools = overlay?.tools;
+
+  const allow = mergeStringIntersection(baseTools?.allow, overlayTools?.allow);
+  const deny = mergeStringUnion(baseTools?.deny, overlayTools?.deny);
+  const ask = mergeStringUnion(baseTools?.ask, overlayTools?.ask);
+
+  if (allow !== undefined) mergedTools.allow = allow;
+  if (deny !== undefined) mergedTools.deny = deny;
+  if (ask !== undefined) mergedTools.ask = ask;
+
+  const mergedPaths: HarnessPermissions["paths"] = {};
+  const basePaths = base?.paths;
+  const overlayPaths = overlay?.paths;
+
+  const writable = mergeStringUnion(basePaths?.writable, overlayPaths?.writable);
+  const readonly = mergeStringUnion(basePaths?.readonly, overlayPaths?.readonly);
+
+  if (writable !== undefined) mergedPaths.writable = writable;
+  if (readonly !== undefined) mergedPaths.readonly = readonly;
+
+  const mergedNetwork: HarnessPermissions["network"] = {};
+  const baseNetwork = base?.network;
+  const overlayNetwork = overlay?.network;
+
+  const allowedHosts = mergeStringUnion(
+    baseNetwork?.["allowed-hosts"],
+    overlayNetwork?.["allowed-hosts"],
+  );
+  if (allowedHosts !== undefined) mergedNetwork["allowed-hosts"] = allowedHosts;
+
+  const permissions: HarnessPermissions = {};
+  if (Object.keys(mergedTools).length > 0) permissions.tools = mergedTools;
+  if (Object.keys(mergedPaths).length > 0) permissions.paths = mergedPaths;
+  if (Object.keys(mergedNetwork).length > 0) permissions.network = mergedNetwork;
+
+  return Object.keys(permissions).length > 0 ? permissions : undefined;
+}
+
+/**
+ * Merge two HarnessConfigs where base is lower priority (parent) and
+ * overlay is higher priority (child). Returns a new merged config.
+ * Metadata and kind are always taken from overlay (child).
+ * The extends field is preserved from the overlay as-is.
+ *
+ * policy is intentionally not merged (out of scope for Phase 1b).
+ */
+function mergeSections(
+  base: HarnessConfig,
+  overlay: HarnessConfig,
+): HarnessConfig {
+  const mergedMcpServers = mergeByKey<McpServer>(
+    base["mcp-servers"],
+    overlay["mcp-servers"],
+  );
+  const mergedEnv = mergeEnv(base.env, overlay.env);
+  const mergedPlugins = mergePlugins(base.plugins, overlay.plugins);
+
+  // For skills we need to handle HarnessPlugin[] type (same shape as plugins — has .name)
+  // HarnessConfig.plugins covers both; there's no separate "skills" array in types.ts.
+  // The task description mentions skills — checking if they mean plugins only.
+
+  const mergedInstructions = mergeInstructions(
+    base.instructions,
+    overlay.instructions,
+  );
+  const mergedPermissions = mergePermissions(
+    base.permissions,
+    overlay.permissions,
+  );
+
+  const result: HarnessConfig = {
+    // Structural fields from overlay (child wins)
+    version: overlay.version,
+    ...(overlay.kind !== undefined ? { kind: overlay.kind } : {}),
+    ...(overlay.metadata !== undefined ? { metadata: overlay.metadata } : {}),
+    ...(overlay.$schema !== undefined ? { $schema: overlay.$schema } : {}),
+    // Merged sections
+    ...(mergedMcpServers !== undefined
+      ? { "mcp-servers": mergedMcpServers }
+      : {}),
+    ...(mergedEnv !== undefined ? { env: mergedEnv } : {}),
+    ...(mergedPlugins !== undefined ? { plugins: mergedPlugins } : {}),
+    ...(mergedInstructions !== undefined
+      ? { instructions: mergedInstructions as HarnessInstructions }
+      : {}),
+    ...(mergedPermissions !== undefined ? { permissions: mergedPermissions } : {}),
+    // Preserve extends from child so the field remains in compiled output
+    ...(overlay.extends !== undefined ? { extends: overlay.extends } : {}),
+  };
+
+  return result;
+}
+
+// ── Resolve path for a local extends source ───────────────────
+
+function resolveLocalSource(
+  source: string,
+  cwd: string,
+  joinPath: (...segments: string[]) => string,
+): string {
+  const rel = source.startsWith("./") ? source.slice(2) : source;
+  return joinPath(cwd, rel);
+}
+
+// ── Core recursive resolver ───────────────────────────────────
+
+async function resolveExtendsInner(
+  config: HarnessConfig,
+  fs: FsProvider,
+  cwd: string,
+  visited: Set<string>,
+  depth: number,
+): Promise<HarnessConfig> {
+  if (!config.extends || config.extends.length === 0) {
+    return config;
+  }
+
+  if (depth > MAX_DEPTH) {
+    throw new Error(
+      `resolveExtends: maximum inheritance depth of ${MAX_DEPTH} exceeded. ` +
+        `Check for deeply nested extends chains.`,
+    );
+  }
+
+  // Resolve all parents left-to-right, then merge them in order
+  let accumulated: HarnessConfig | null = null;
+
+  for (const entry of config.extends) {
+    const { source } = entry;
+
+    // Skip remote sources with a warning
+    if (!source.startsWith("./") && !source.startsWith("../")) {
+      console.warn(
+        `resolveExtends: skipping remote source "${source}" — only local sources (starting with "./" or "../") are supported in Phase 1b.`,
+      );
+      continue;
+    }
+
+    const absPath = resolveLocalSource(source, cwd, fs.joinPath.bind(fs));
+
+    // Cycle detection
+    if (visited.has(absPath)) {
+      const chain = [...visited, absPath].join(" → ");
+      throw new Error(
+        `resolveExtends: circular extends detected: ${chain}`,
+      );
+    }
+
+    // Existence check
+    const fileExists = await fs.exists(absPath);
+    if (!fileExists) {
+      throw new Error(
+        `resolveExtends: fragment file not found: ${absPath}`,
+      );
+    }
+
+    // Parse
+    const raw = await fs.readFile(absPath);
+    const { config: parentConfig } = parseHarness(raw);
+
+    // Validate
+    const validation = validateHarness(parentConfig);
+    if (!validation.valid) {
+      const errorSummary = validation.errors
+        .map((e) => `  ${e.path}: ${e.message}`)
+        .join("\n");
+      throw new Error(
+        `resolveExtends: validation failed for fragment "${absPath}":\n${errorSummary}`,
+      );
+    }
+
+    // Compute parent cwd (directory of the fragment file)
+    const parentCwd = fs.dirname(absPath);
+
+    // Recurse into parent's own extends
+    const nextVisited = new Set(visited);
+    nextVisited.add(absPath);
+    const resolvedParent = await resolveExtendsInner(
+      parentConfig,
+      fs,
+      parentCwd,
+      nextVisited,
+      depth + 1,
+    );
+
+    // Merge: accumulated is base (lower priority), resolvedParent is overlay (higher priority
+    // because later entries win over earlier ones, so we accumulate left-to-right where
+    // each new parent overlays the prior accumulation)
+    if (accumulated === null) {
+      accumulated = resolvedParent;
+    } else {
+      accumulated = mergeSections(accumulated, resolvedParent);
+    }
+  }
+
+  if (accumulated === null) {
+    // All entries were remote and skipped
+    return config;
+  }
+
+  // Child (config) wins over all parents
+  return mergeSections(accumulated, config);
+}
+
+// ── Public API ────────────────────────────────────────────────
+
+/**
+ * Resolve the `extends` field in a HarnessConfig by reading, parsing, and
+ * merging all referenced fragment files into the config.
+ *
+ * Only local sources (starting with "./" or "../") are resolved.
+ * Remote sources are skipped with a warning.
+ *
+ * @param config  The parsed harness config whose extends entries should be resolved.
+ * @param fs      Filesystem provider — only FsProvider methods are used.
+ * @param cwd     The directory from which relative source paths are resolved.
+ * @returns       A new HarnessConfig with all local parents merged in. The original
+ *                config.extends field is preserved in the returned object.
+ * @throws        If a cycle is detected, max depth is exceeded, a referenced file
+ *                does not exist, or a fragment fails schema validation.
+ */
+export async function resolveExtends(
+  config: HarnessConfig,
+  fs: FsProvider,
+  cwd: string,
+): Promise<HarnessConfig> {
+  const visited = new Set<string>();
+  return resolveExtendsInner(config, fs, cwd, visited, 0);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -51,6 +51,7 @@ export { compileInstructions, getAllInstructionFilePaths, getSlotMappings } from
 export { compileMcpServers } from "./compile/mcp-servers.js";
 export { compileSkills } from "./compile/skills.js";
 export { compilePermissions, buildPermissionsText } from "./compile/permissions.js";
+export { resolveExtends } from "./compile/extends.js";
 
 // Discovery (manifest-first skill resolution utilities)
 export { findSkillFiles, computeSourceDir } from "./compile/discovery.js";


### PR DESCRIPTION
## Summary

- Adds `resolveExtends(config, fs, cwd)` to `packages/core/src/compile/extends.ts`
- Wires it into `compile()` after parse+validate, before all instruction/MCP/permissions stages
- Exports from `packages/core/src/index.ts`

## What ships

`resolveExtends` reads and merges local `./` and `../` fragment sources declared in a harness's `extends[]` field before compile stages run. Merge semantics per `protocol/inheritance.md`:

| Section | Rule |
|---------|------|
| `mcp-servers`, `env`, `plugins` | Union by name; child wins |
| `instructions` | Child `import-mode` governs (merge/replace/skip) |
| `permissions.tools.allow` | Intersection |
| `permissions.tools.deny` / `.ask` | Union |
| `permissions.paths.*` | Union |
| `metadata`, `kind` | Child only — not inherited |

Remote sources (`owner/repo`) are skipped with a warning. Cycles and depth >5 throw clear errors. Phase 1b scope: local fragment case only.

## Test plan

- [ ] 17 new tests in `packages/core/__tests__/extends.test.ts`
- [ ] Key integration test: `compile()` on a profile whose `extends[]` references a local MCP-server fragment includes that server in compiled `FileAction` output
- [ ] All 218 core tests green
- [ ] CI validate / test-all / build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)