### PR TITLE
fix(desktop): wire Monaco loader to local package instead of CDN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@
 - **Desktop: Observatory typography** — stat and chart card headers use `font-variant-caps: all-small-caps` instead of `text-transform: uppercase`, matching the sidebar and other labels. Area chart fill gradients are subtler (top stop halved); grid lines use `--separator` instead of `--border-base` so data pops more.
 - **Desktop: Permissions layout** — Tools, Paths, and Network sections merged into a single unified card with inset section dividers. Allow/Deny/Ask tool rows are stacked vertically with color-coded labels. Preset cards display a colored left border (green for Strict, blue for Standard, amber for Permissive) for at-a-glance identity.
 
+### Fixed
+
+- **Desktop: Monaco editor stuck on "Loading editor..."** — the MCP Servers, Hooks, CLAUDE.md, and harness.yaml Editor tab pages all embed Monaco via `@monaco-editor/react`, whose default loader fetches its AMD bootstrap script from a CDN at runtime. The app's CSP (`script-src 'self'`) has always blocked that cross-origin script, so the editor never mounted in the packaged app. It now loads the already-bundled `monaco-editor` package directly instead of reaching for the CDN.
+
 ### Security
 
 - **Dependencies** — Resolved 8 Dependabot medium-severity alerts: Next.js upgraded to 16.1.7 (fixes HTTP request smuggling in rewrites and unbounded `next/image` disk cache growth), DOMPurify upgraded to 3.3.3 in the desktop app (fixes XSS bypass). Website fumadocs stack updated to core/ui v16.6.17 and mdx v14.2.10 to satisfy Next 16 peer deps.

--- a/apps/desktop/src/components/plugin-explorer/MonacoEditor.tsx
+++ b/apps/desktop/src/components/plugin-explorer/MonacoEditor.tsx
@@ -1,5 +1,12 @@
 import { useRef, useEffect, useCallback } from "react";
-import Editor, { type OnMount, type Monaco } from "@monaco-editor/react";
+import Editor, { loader, type OnMount, type Monaco } from "@monaco-editor/react";
+import * as monacoEditor from "monaco-editor";
+
+// @monaco-editor/react defaults to fetching its AMD loader from the jsdelivr CDN
+// at runtime. Tauri's CSP (script-src 'self') blocks that cross-origin <script>
+// tag, so the editor would hang forever on "Loading editor...". Pointing the
+// loader at the already-bundled monaco-editor package avoids the CDN entirely.
+loader.config({ monaco: monacoEditor });
 
 // Monaco loads language workers via `new Worker(new URL(..., import.meta.url), { type: 'module' })`.
 // Tauri's WKWebView rejects these module worker imports with "Importing a module script failed."


### PR DESCRIPTION
## Summary
Monaco's code editor (`/harness/file` → Editor tab, and anywhere `MonacoEditor` is used) has been permanently stuck on "Loading editor..." in the packaged desktop app. `@monaco-editor/react`'s default loader fetches its AMD `loader.js` from `cdn.jsdelivr.net` at runtime via an injected `<script src>` tag, and the app's CSP (`script-src 'self'`) has never allowed that CDN origin — in dev or prod, before or after PR #284. This predates #284's `unsafe-eval` removal and is unrelated to it; the CDN domain was never in the CSP allowlist either way.

## Changes
- [MonacoEditor.tsx](apps/desktop/src/components/plugin-explorer/MonacoEditor.tsx): call `loader.config({ monaco })` with the already-installed local `monaco-editor` package (ESM import) instead of letting `@monaco-editor/loader` reach for the CDN. Monaco is now bundled locally and never touches the network.

## Test Plan
- [x] Local unit tests pass (`pnpm --filter harness-kit-desktop test` — 474/474)
- [x] Verified in the **real packaged `.app`** (built via `pnpm install:desktop`, not `vite preview`, since preview doesn't enforce the same Tauri CSP):
  - Relaunched the app, navigated to Configure → harness.yaml → Editor tab
  - Monaco now mounts fully: YAML syntax highlighting renders, line numbers show, no more stuck "Loading editor..."
  - Typed a test edit — comment-token coloring applied correctly and the Save button activated, confirming full read/write interactivity
  - Inspected the WebView console: the jsdelivr CDN CSP violation is gone
- [ ] CI checks pass

## Notes
- Bundling Monaco locally instead of fetching from a CDN grows the `MonacoEditor` chunk to ~3.79MB (974KB gzip) — an expected tradeoff for a previously completely non-functional feature, and it doesn't touch the CSP.
- One pre-existing, non-blocking observation surfaced now that execution reaches further into Monaco's init path: the existing no-op `MonacoEnvironment.getWorker` blob-worker workaround (added for a separate WKWebView module-worker restriction) trips a `worker-src` CSP warning. Monaco catches this and falls back to main-thread tokenization gracefully — the same degraded-but-functional mode the file's own comments already describe — so the editor still works, this is just console noise. Left CSP untouched since the stub worker is a no-op anyway; flagging for awareness, not fixing here.