### PR TITLE
fix(ci): build nightly workspace prerequisites

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           pnpm --filter @harness-kit/shared build
           pnpm --filter @harness-kit/core build
+          pnpm --filter @harness-kit/exchange build
 
       - name: Build standalone bundle
         working-directory: apps/cli
@@ -104,6 +105,8 @@ jobs:
         run: |
           pnpm --filter @harness-kit/shared build
           pnpm --filter @harness-kit/core build
+          pnpm --filter @harness-kit/design-tokens build
+          pnpm --filter @harness-kit/ui build
 
       - name: Build desktop app
         run: |


### PR DESCRIPTION
## Summary

Restores Nightly builds from clean macOS checkouts by building the workspace packages required by the CLI standalone bundle and desktop app before those build steps run. The prior workflow relied on locally generated `dist/` output that is absent in GitHub Actions.

## Changes

- build `@harness-kit/exchange` before bundling the standalone CLI
- build `@harness-kit/design-tokens` and `@harness-kit/ui` before the desktop Tauri build

## Test Plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm generate:marketplace`
- [x] `pnpm generate:capability-matrix`
- [x] `pnpm test:all` — 18/18 Turbo tasks pass, including 474 desktop tests
- [x] standalone CLI bundle builds
- [x] Nightly workflow YAML parses
- [ ] GitHub Actions checks pass
- [ ] manually dispatch Nightly after merge

## Notes

The change is intentionally limited to Nightly dependency preparation. It does not alter workflow permissions, release publishing, or Homebrew update behavior.