### PR TITLE
fix(ci): generate capability matrix data in release.yml's gate job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,13 @@ jobs:
           pnpm --filter @harness-kit/shared --filter @harness-kit/core build
           pnpm --filter @harness-kit/marketplace-data generate --strict
 
+      # The website also imports a static capability matrix generated straight
+      # from @harness-kit/core's adapter registry (gitignored build output).
+      # Mirrors validate.yml's test-all job — without this the website build
+      # fails on a missing module.
+      - name: Generate capability matrix data
+        run: pnpm --filter @harness-kit/website-data generate
+
       - name: Build and test all packages
         run: pnpm turbo run build test
 


### PR DESCRIPTION
## Summary

The second v0.11.0 release attempt (after #321's dependency audit fix) failed at the gate job's "Build and test all packages" step: `website/components/site/CapabilityMatrix.tsx` imports a gitignored, generated JSON file (`@/lib/capability-matrix.generated.json`) that `release.yml`'s gate job never generates.

`validate.yml`'s `test-all` job already has this step (and has for a while — it's what every PR in this session's CI ran against successfully). `release.yml`'s gate job — which explicitly comments that it "mirrors the Validate workflow so a tag can never ship code that wouldn't pass CI" — was never updated to match when the capability matrix generator shipped. This is a latent gap that only surfaces on an actual tag push, and there hadn't been one since v0.10.0 (2026-06-06).

## Fix

Added the missing "Generate capability matrix data" step to the gate job, identical to `validate.yml`'s and `docs-build`'s equivalent steps.

## Test plan

- [x] Reproduced locally: deleted `website/lib/capability-matrix.generated.json`, ran `pnpm turbo run build test` — same `Module not found` error as the CI failure
- [x] Ran the fix step (`pnpm --filter @harness-kit/website-data generate`), re-ran the website build — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)