### PR TITLE
fix(ci): generate desktop's own marketplace.generated.json in release.yml gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,12 +52,15 @@ jobs:
         # tracked via Dependabot rather than blocking the release train.
         run: pnpm audit --audit-level=high
 
-      # The website build (part of the turbo graph) consumes a static marketplace
-      # JSON generated from git; generate it before build+test runs.
+      # The website AND the desktop app each import their own static marketplace
+      # JSON generated from git (gitignored build output). This job's turbo graph
+      # builds both, so generate both before "Build and test all packages" runs.
+      # Mirrors validate.yml's test-all job.
       - name: Generate marketplace data
         run: |
           pnpm --filter @harness-kit/shared --filter @harness-kit/core build
           pnpm --filter @harness-kit/marketplace-data generate --strict
+          pnpm --filter @harness-kit/marketplace-data generate --strict -- --out ../../apps/desktop/src/lib/marketplace/marketplace.generated.json
 
       # The website also imports a static capability matrix generated straight
       # from @harness-kit/core's adapter registry (gitignored build output).


### PR DESCRIPTION
## Summary

Third release.yml/validate.yml parity gap in the same area (following #322): `apps/desktop` imports its own copy of the generated marketplace JSON — a separate `--out` target from the website's copy — which the gate job's "Generate marketplace data" step never produced. Only `validate.yml`'s `test-all` job had the second `generate --strict -- --out ../../apps/desktop/...` line.

This time I did a full side-by-side diff of the two jobs' generation steps (rather than fixing one gap and discovering the next via another failed release attempt) and confirmed this was the only remaining difference.

## Test plan

- [x] Reproduced locally: deleted all three generated files (website marketplace, desktop marketplace, capability matrix), ran the gate's exact command sequence — same `Cannot find module './marketplace.generated.json'` error as CI
- [x] Ran the fix step, full `pnpm turbo run build test` — 18/18 tasks pass (desktop 444/444)
- [x] Diffed the two jobs' generation steps line-by-line — now identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)