### PR TITLE
fix(ci): build design-tokens and ui before Tauri desktop build in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,10 +184,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Mirrors validate.yml's desktop-build-test job — the desktop frontend
+      # imports @harness-kit/design-tokens and @harness-kit/ui directly.
       - name: Build workspace dependencies
         run: |
           pnpm --filter @harness-kit/shared build
           pnpm --filter @harness-kit/core build
+          pnpm --filter @harness-kit/design-tokens build
+          pnpm --filter @harness-kit/ui build
 
       # The desktop Marketplace page imports a static marketplace JSON generated
       # from git (gitignored build output) — same pattern as the website.


### PR DESCRIPTION
## Summary

Fourth release.yml gap in this release attempt, this time in `build-desktop` rather than `gate`: its "Build workspace dependencies" step only built `shared` and `core`, but `apps/desktop` imports `@harness-kit/design-tokens` and `@harness-kit/ui` directly. `validate.yml`'s `desktop-build-test` job already builds both — but its checks (TypeScript, unit tests, Playwright smoke against a `vite build`) don't exercise the actual `tauri build` command the release job runs, which is where this surfaced (`Cannot find module '@harness-kit/ui'`).

The gate job itself now passed cleanly (confirmed by the 4th tag attempt: gate ✓, build-cli-standalone ✓, build-desktop ✗ here).

## Test plan

- [x] Reproduced locally: cleared `packages/design-tokens/dist` and `packages/ui/dist`, ran `vite build` on the desktop frontend — same `Cannot find module '@harness-kit/ui'` error as CI
- [x] Built both packages, re-ran `vite build` — passes
- [x] Full `pnpm turbo run build test` — 18/18 tasks (desktop 444/444)

🤖 Generated with [Claude Code](https://claude.com/claude-code)