### PR TITLE
fix(ci): generate desktop marketplace JSON in nightly build

### DIFF
--- a/.github/actions/prepare-desktop-frontend/action.yml
+++ b/.github/actions/prepare-desktop-frontend/action.yml
@@ -1,0 +1,38 @@
+name: Prepare desktop frontend
+description: >-
+  Builds the workspace packages the desktop frontend imports and generates its
+  gitignored marketplace JSON. Every job that runs tsc, vite, or `tauri build`
+  against apps/desktop must call this first — keeping it in one place is what
+  stops validate/release/nightly from drifting apart.
+
+inputs:
+  strict:
+    description: Pass --strict to the marketplace generator (fail on plugin data errors).
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    # The desktop frontend imports @harness-kit/design-tokens and
+    # @harness-kit/ui directly, which in turn need shared + core built.
+    - name: Build workspace dependencies
+      shell: bash
+      run: |
+        pnpm --filter @harness-kit/shared build
+        pnpm --filter @harness-kit/core build
+        pnpm --filter @harness-kit/design-tokens build
+        pnpm --filter @harness-kit/ui build
+
+    # The desktop Marketplace page imports a static marketplace JSON generated
+    # from git (gitignored build output) — same pattern as the website. Without
+    # this, `tsc` fails with TS2307 on ./marketplace.generated.json.
+    - name: Generate marketplace data
+      shell: bash
+      run: |
+        STRICT=""
+        if [[ "${{ inputs.strict }}" == "true" ]]; then
+          STRICT="--strict"
+        fi
+        pnpm --filter @harness-kit/marketplace-data generate $STRICT -- \
+          --out ../../apps/desktop/src/lib/marketplace/marketplace.generated.json

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -101,12 +101,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build workspace dependencies
-        run: |
-          pnpm --filter @harness-kit/shared build
-          pnpm --filter @harness-kit/core build
-          pnpm --filter @harness-kit/design-tokens build
-          pnpm --filter @harness-kit/ui build
+      - uses: ./.github/actions/prepare-desktop-frontend
 
       - name: Build desktop app
         run: |
@@ -208,4 +203,42 @@ jobs:
           git commit -m "chore: nightly build $(date +%Y-%m-%d) (${GITHUB_SHA:0:7})"
           git push
         env:
+          GITHUB_SHA: ${{ github.sha }}
+
+  # A scheduled workflow fails where nobody is looking — this one was red for
+  # four nights before anyone noticed. Surface it as an issue instead.
+  report-failure:
+    needs: [build-cli-standalone, build-desktop, publish]
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update the nightly failure issue
+        run: |
+          # --label fails hard if the label doesn't exist yet.
+          gh label create nightly-failure \
+            --color B60205 \
+            --description "Automated: the nightly build is red" 2>/dev/null || true
+
+          RUN_URL="https://github.com/${GH_REPO}/actions/runs/${GH_RUN_ID}"
+          BODY="Nightly build failed on \`main\` (commit \`${GITHUB_SHA:0:7}\`).
+
+          Run: $RUN_URL"
+
+          EXISTING=$(gh issue list --state open --label nightly-failure \
+            --json number --jq '.[0].number')
+
+          if [[ -n "$EXISTING" ]]; then
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            gh issue create \
+              --title "Nightly build failing" \
+              --label nightly-failure \
+              --body "$BODY"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          GH_RUN_ID: ${{ github.run_id }}
           GITHUB_SHA: ${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,19 +184,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # Mirrors validate.yml's desktop-build-test job — the desktop frontend
-      # imports @harness-kit/design-tokens and @harness-kit/ui directly.
-      - name: Build workspace dependencies
-        run: |
-          pnpm --filter @harness-kit/shared build
-          pnpm --filter @harness-kit/core build
-          pnpm --filter @harness-kit/design-tokens build
-          pnpm --filter @harness-kit/ui build
-
-      # The desktop Marketplace page imports a static marketplace JSON generated
-      # from git (gitignored build output) — same pattern as the website.
-      - name: Generate marketplace data
-        run: pnpm --filter @harness-kit/marketplace-data generate --strict -- --out ../../apps/desktop/src/lib/marketplace/marketplace.generated.json
+      - uses: ./.github/actions/prepare-desktop-frontend
 
       - name: Build desktop app
         run: pnpm --filter harness-kit-desktop tauri build

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -194,18 +194,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build workspace dependencies
-        run: |
-          pnpm --filter @harness-kit/shared build
-          pnpm --filter @harness-kit/core build
-          pnpm --filter @harness-kit/design-tokens build
-          pnpm --filter @harness-kit/ui build
-
-      # The desktop Marketplace page imports a static marketplace JSON generated
-      # from git (gitignored build output) — same pattern as the website. Generate
-      # it before anything that touches the desktop frontend runs below.
-      - name: Generate marketplace data
-        run: pnpm --filter @harness-kit/marketplace-data generate -- --out ../../apps/desktop/src/lib/marketplace/marketplace.generated.json
+      - uses: ./.github/actions/prepare-desktop-frontend
+        with:
+          strict: 'false'
 
       - name: TypeScript check (desktop)
         run: pnpm --filter harness-kit-desktop exec tsc --noEmit


### PR DESCRIPTION
## Problem

The nightly build has failed every night since 2026-07-28 (4 consecutive runs). `nightly.yml`'s `build-desktop` job never generated `apps/desktop/src/lib/marketplace/marketplace.generated.json` — a gitignored build output — so `tsc` died:

```
src/lib/marketplace/data.ts(8,23): error TS2307: Cannot find module
'./marketplace.generated.json' or its corresponding type declarations.
```

This is the same class of bug #323/#324 fixed in `release.yml` and `validate.yml`. Those two workflows got the fix; `nightly.yml` was a third hand-rolled copy of the same recipe and was missed. Nightly is the only one of the three not exercised on PRs, so the drift went unnoticed.

## Changes

1. **New composite action** `.github/actions/prepare-desktop-frontend` — builds `shared`/`core`/`design-tokens`/`ui` and generates the desktop marketplace JSON. Takes a `strict` input, since `validate.yml` intentionally runs the generator non-strict.
2. **All three desktop-building jobs call it** instead of duplicating the steps (`nightly.yml`, `release.yml`, `validate.yml`). One place to change means the copies can't drift apart again.
3. **New `report-failure` job in `nightly.yml`** — on a scheduled failure it opens (or comments on) a `nightly-failure` issue. This is the part that stops a silent recurrence: the breakage was visible in Actions for four days and nobody was told.

## Verification

Deleted `marketplace.generated.json` locally, ran the composite action's exact steps, then `pnpm --filter harness-kit-desktop build` — the `tsc && vite build` that failed in CI. Passes, built in 13.9s. All four YAML files parse.

The real proof is a `workflow_dispatch` run of Nightly off this branch once CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)