### PR TITLE
feat(core): compile architectural-constraints into agent instructions

### DIFF
--- a/packages/core/__tests__/architectural-constraints.test.ts
+++ b/packages/core/__tests__/architectural-constraints.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from "vitest";
+import { renderArchitecturalConstraints } from "../src/compile/architectural-constraints.js";
+import { compile } from "../src/compile/compile.js";
+import { checkCompiled } from "../src/compile/check.js";
+import { parseHarness } from "../src/parser/parse-harness.js";
+import { MockFsProvider } from "./helpers/mock-fs.js";
+import type { ArchitecturalConstraints } from "../src/types.js";
+
+const HEADER = `version: "1"
+kind: profile
+metadata:
+  name: demo
+  description: Demo harness exercising architectural constraints.
+`;
+
+const CONSTRAINTS = `architectural-constraints:
+  linters:
+    - name: module-boundary
+      description: No imports across layer boundaries.
+  structural-tests:
+    - name: layering
+      description: The dependency graph stays acyclic.
+      entrypoint: pnpm test:arch
+  review-policy:
+    patterns:
+      - name: no-queries-in-loops
+        rule: Never issue a database query inside a loop.
+        severity: error
+`;
+
+describe("renderArchitecturalConstraints", () => {
+  it("returns null when there is nothing to say", () => {
+    expect(renderArchitecturalConstraints(undefined)).toBeNull();
+    expect(renderArchitecturalConstraints({})).toBeNull();
+    expect(renderArchitecturalConstraints({ "review-policy": {} })).toBeNull();
+    expect(
+      renderArchitecturalConstraints({ linters: [], "structural-tests": [] }),
+    ).toBeNull();
+  });
+
+  it("groups patterns by severity, most severe first", () => {
+    const out = renderArchitecturalConstraints({
+      "review-policy": {
+        patterns: [
+          { name: "c", rule: "Info rule.", severity: "info" },
+          { name: "a", rule: "Error rule.", severity: "error" },
+          { name: "b", rule: "Warning rule.", severity: "warning" },
+        ],
+      },
+    })!;
+    const order = ["Must not violate", "Should follow", "Worth considering"].map((h) =>
+      out.indexOf(h),
+    );
+    expect(order.every((i) => i >= 0)).toBe(true);
+    expect(order).toEqual([...order].sort((x, y) => x - y));
+  });
+
+  // The schema declares default: "warning"; an author who omits it should land
+  // in the same group as one who spells it out.
+  it("defaults a pattern with no severity to warning", () => {
+    const out = renderArchitecturalConstraints({
+      "review-policy": { patterns: [{ name: "p", rule: "A rule." }] },
+    })!;
+    expect(out).toContain("### Should follow");
+    expect(out).toContain("- **p** — A rule.");
+    expect(out).not.toContain("Must not violate");
+  });
+
+  it("renders enforcement and the runnable entrypoint for deterministic gates", () => {
+    const out = renderArchitecturalConstraints({
+      linters: [{ name: "l", description: "Lint rule.", enforcement: "warn" }],
+      "structural-tests": [
+        { name: "t", description: "Test rule.", entrypoint: "pnpm test:arch" },
+      ],
+    })!;
+    expect(out).toContain("- **l** — linter, warns. Lint rule.");
+    // enforcement defaults to block per the schema
+    expect(out).toContain("- **t** — structural test, blocks. Test rule. Run: `pnpm test:arch`");
+  });
+
+  // enabled:false turns off the LLM review layer. The CI gates run regardless of
+  // what the agent is told, so suppressing them would hide real blockers.
+  it("suppresses review patterns when disabled but keeps the CI gates", () => {
+    const constraints: ArchitecturalConstraints = {
+      linters: [{ name: "l", description: "Lint rule." }],
+      "review-policy": {
+        enabled: false,
+        guidance: "Philosophy.",
+        patterns: [{ name: "p", rule: "A rule." }],
+      },
+    };
+    const out = renderArchitecturalConstraints(constraints)!;
+    expect(out).toContain("- **l** — linter, blocks. Lint rule.");
+    expect(out).not.toContain("A rule.");
+    expect(out).not.toContain("Philosophy.");
+  });
+
+  it("never renders review-policy.model — it configures the reviewer, not the agent", () => {
+    const out = renderArchitecturalConstraints({
+      "review-policy": { model: "claude-opus", patterns: [{ name: "p", rule: "A rule." }] },
+    })!;
+    expect(out).not.toContain("claude-opus");
+  });
+});
+
+describe("compiling architectural-constraints", () => {
+  it("emits its own marker block, separate from instructions.operational", async () => {
+    const fs = new MockFsProvider();
+    const result = await compile(
+      HEADER + "instructions:\n  operational: |\n    ## Commands\n" + CONSTRAINTS,
+      ["claude-code"],
+      fs,
+      { dryRun: true },
+    );
+
+    const slots = result.files.filter((f) => f.path === "CLAUDE.md").map((f) => f.slot);
+    expect(slots).toEqual(["constraints", "operational"]);
+
+    // Last write wins on a shared path, so the final CLAUDE.md must carry both.
+    const final = [...result.files].reverse().find((f) => f.path === "CLAUDE.md")!;
+    expect(final.content).toContain("<!-- BEGIN harness:demo:constraints -->");
+    expect(final.content).toContain("<!-- BEGIN harness:demo:operational -->");
+    expect(final.content).toContain("## Commands");
+  });
+
+  // Regression: each adapter's appendPermissionsToInstructions() mutates the
+  // FileAction whose slot is "operational". If constraints were emitted after it,
+  // constraints would be the last write for the path and silently drop permissions.
+  it("keeps appended permissions on a shared file", async () => {
+    const fs = new MockFsProvider();
+    const result = await compile(
+      HEADER +
+        "instructions:\n  operational: |\n    ## Commands\n" +
+        CONSTRAINTS +
+        "permissions:\n  tools:\n    allow: [\"Bash(pnpm build)\"]\n",
+      ["copilot"],
+      fs,
+      { dryRun: true },
+    );
+
+    const path = ".github/copilot-instructions.md";
+    const final = [...result.files].reverse().find((f) => f.path === path)!;
+    expect(final.content).toContain("Bash(pnpm build)");
+    expect(final.content).toContain("<!-- BEGIN harness:demo:constraints -->");
+  });
+
+  it("compiles with no instructions section at all", async () => {
+    const fs = new MockFsProvider();
+    const result = await compile(HEADER + CONSTRAINTS, ["claude-code"], fs, {
+      dryRun: true,
+    });
+    const claudeMd = result.files.filter((f) => f.path === "CLAUDE.md");
+    expect(claudeMd).toHaveLength(1);
+    expect(claudeMd[0].slot).toBe("constraints");
+    expect(claudeMd[0].content).toContain("no-queries-in-loops");
+  });
+
+  // The whole reason the block rides the operational FILE: behavioral is null on
+  // five of eight targets, and constraints reaching three of eight is worse than none.
+  it("reaches every target platform", async () => {
+    const fs = new MockFsProvider();
+    const targets = ["claude-code", "cursor", "copilot", "codex"] as const;
+    const result = await compile(HEADER + CONSTRAINTS, [...targets], fs, {
+      dryRun: true,
+    });
+    const paths = result.files.filter((f) => f.slot === "constraints").map((f) => f.path);
+    expect(paths).toEqual(
+      expect.arrayContaining([
+        "CLAUDE.md",
+        ".cursor/rules/harness.mdc",
+        ".github/copilot-instructions.md",
+        "AGENTS.md",
+      ]),
+    );
+  });
+
+  // An .mdc without frontmatter is not loaded as a cursor rule, so the block
+  // needs its own when it is the only thing in the file.
+  it("gives cursor frontmatter when constraints stands alone", async () => {
+    const fs = new MockFsProvider();
+    const result = await compile(HEADER + CONSTRAINTS, ["cursor"], fs, { dryRun: true });
+    const mdc = result.files.find((f) => f.path === ".cursor/rules/harness.mdc")!;
+    expect(mdc.content.startsWith("---\n")).toBe(true);
+    expect(mdc.content).toContain("alwaysApply: true");
+  });
+
+  it("is suppressed by instructions.import-mode: skip", async () => {
+    const fs = new MockFsProvider();
+    const result = await compile(
+      HEADER + 'instructions:\n  import-mode: skip\n  operational: |\n    ## Commands\n' + CONSTRAINTS,
+      ["claude-code"],
+      fs,
+      { dryRun: true },
+    );
+    expect(result.files.some((f) => f.slot === "constraints")).toBe(false);
+  });
+
+  it("reports drift when the deployed constraints block is missing", async () => {
+    const fs = new MockFsProvider();
+    const { config } = parseHarness(HEADER + CONSTRAINTS);
+    const result = await checkCompiled(config, ["claude-code"], fs);
+    const entry = result.entries.find((e) => e.name === "constraints");
+    expect(entry).toBeDefined();
+    expect(entry!.path).toBe("CLAUDE.md");
+    expect(entry!.status).toBe("missing");
+    expect(result.hasDrift).toBe(true);
+  });
+});

--- a/packages/core/src/compile/architectural-constraints.ts
+++ b/packages/core/src/compile/architectural-constraints.ts
@@ -1,0 +1,138 @@
+import type {
+  ArchitecturalConstraints,
+  ArchitecturalLinter,
+  ArchitecturalReviewPattern,
+  ArchitecturalStructuralTest,
+} from "../types.js";
+
+/**
+ * Render an `architectural-constraints` section (HEP-3) as the prose an agent
+ * reads before completing a task.
+ *
+ * Rendered into its OWN marker block rather than merged into the operational
+ * slot, so it never collides with a user's `instructions.operational` and can
+ * be updated or removed cleanly. It is written to the operational *file* on
+ * each platform because that is the only slot mapped on every target — the
+ * behavioral slot is null for codex/opencode/windsurf/gemini/junie, and
+ * constraints that silently reach three of eight targets would be worse than
+ * none at all.
+ *
+ * Returns null when there is nothing worth writing, so callers can skip the
+ * block entirely rather than emit an empty heading.
+ */
+
+// Schema defaults, applied here so the rendering is stable whether or not the
+// author spelled them out.
+const DEFAULT_SEVERITY = "warning";
+const DEFAULT_ENFORCEMENT = "block";
+
+const SEVERITY_HEADINGS: Record<string, string> = {
+  error: "Must not violate",
+  warning: "Should follow",
+  info: "Worth considering",
+};
+
+// Most severe first — an agent skimming reads the top of the block.
+const SEVERITY_ORDER = ["error", "warning", "info"] as const;
+
+function renderPatternGroup(
+  severity: string,
+  patterns: ArchitecturalReviewPattern[],
+): string[] {
+  if (patterns.length === 0) return [];
+  const lines = [`### ${SEVERITY_HEADINGS[severity]}`, ""];
+  for (const p of patterns) {
+    // Rules are prose and may already end in a period; don't double it.
+    lines.push(`- **${p.name}** — ${p.rule.trim()}`);
+  }
+  lines.push("");
+  return lines;
+}
+
+function renderDeterministic(
+  linters: ArchitecturalLinter[],
+  tests: ArchitecturalStructuralTest[],
+): string[] {
+  if (linters.length === 0 && tests.length === 0) return [];
+
+  const lines = [
+    "### Enforced outside the agent",
+    "",
+    "These gates run in CI, not in the conversation. `blocks` means a violation",
+    "prevents merge — treat it as a hard requirement while working.",
+    "",
+  ];
+
+  for (const l of linters) {
+    const enforcement = l.enforcement ?? DEFAULT_ENFORCEMENT;
+    const verb = enforcement === "block" ? "blocks" : "warns";
+    lines.push(`- **${l.name}** — linter, ${verb}. ${l.description.trim()}`);
+  }
+
+  for (const t of tests) {
+    const enforcement = t.enforcement ?? DEFAULT_ENFORCEMENT;
+    const verb = enforcement === "block" ? "blocks" : "warns";
+    // The entrypoint is the useful part: it is the command the agent can run
+    // itself rather than waiting for CI to tell it what it broke.
+    const run = t.entrypoint ? ` Run: \`${t.entrypoint.trim()}\`` : "";
+    lines.push(
+      `- **${t.name}** — structural test, ${verb}. ${t.description.trim()}${run}`,
+    );
+  }
+
+  lines.push("");
+  return lines;
+}
+
+export function renderArchitecturalConstraints(
+  constraints: ArchitecturalConstraints | undefined,
+): string | null {
+  if (!constraints) return null;
+
+  const linters = constraints.linters ?? [];
+  const tests = constraints["structural-tests"] ?? [];
+  const reviewPolicy = constraints["review-policy"];
+
+  // `enabled: false` turns off the LLM review layer only. The deterministic
+  // gates still run in CI regardless of what the agent is told, so they stay
+  // in the block — the agent should know what will fail on it.
+  const reviewActive = (reviewPolicy?.enabled ?? true) && reviewPolicy !== undefined;
+  const patterns = reviewActive ? (reviewPolicy?.patterns ?? []) : [];
+  const guidance = reviewActive ? reviewPolicy?.guidance?.trim() : undefined;
+
+  if (patterns.length === 0 && !guidance && linters.length === 0 && tests.length === 0) {
+    return null;
+  }
+
+  const lines: string[] = ["## Architectural constraints", ""];
+
+  if (patterns.length > 0) {
+    lines.push(
+      "Check these before completing a task in this project.",
+      "",
+    );
+    for (const severity of SEVERITY_ORDER) {
+      lines.push(
+        ...renderPatternGroup(
+          severity,
+          patterns.filter((p) => (p.severity ?? DEFAULT_SEVERITY) === severity),
+        ),
+      );
+    }
+  }
+
+  if (guidance) {
+    lines.push("### Architectural philosophy", "", guidance, "");
+  }
+
+  lines.push(...renderDeterministic(linters, tests));
+
+  // Trailing blank lines are an artifact of section assembly; the marker block
+  // supplies its own terminator.
+  while (lines[lines.length - 1] === "") lines.pop();
+
+  return lines.join("\n");
+}
+
+/** `review-policy.model` is deliberately not rendered — it configures whichever
+ *  harness runs the review, and is not guidance the agent should read as a rule. */

--- a/packages/core/src/compile/check.ts
+++ b/packages/core/src/compile/check.ts
@@ -5,6 +5,7 @@ import type { HarnessConfig, TargetPlatform } from "../types.js";
 import { findMarkerBlock } from "./markers.js";
 import { compileSkills } from "./skills.js";
 import { getSlotMappings } from "./instructions.js";
+import { renderArchitecturalConstraints } from "./architectural-constraints.js";
 import { TARGETS } from "./targets.js";
 
 // ── Low-level utilities ──────────────────────────────────────
@@ -173,6 +174,42 @@ export async function checkCompiled(
       path: file.path,
       status,
     });
+  }
+
+  // ── Architectural constraints check ──────────────────────
+  // Compiled into its own marker block in the operational FILE (see
+  // compile/architectural-constraints.ts), so it needs its own drift pass —
+  // the loop below reads slot content out of `instructions`, where a
+  // constraints block has no entry and would be skipped silently.
+  const constraintsContent = renderArchitecturalConstraints(
+    config["architectural-constraints"],
+  );
+  if (constraintsContent) {
+    const operationalFiles = getSlotMappings().find((m) => m.slot === "operational")!.file;
+    const seenPaths = new Set<string>();
+
+    for (const target of targets) {
+      const filePath = operationalFiles[target];
+      if (!filePath) continue;
+      if (seenPaths.has(filePath)) continue;
+      seenPaths.add(filePath);
+
+      const status = await instructionDrift(
+        constraintsContent,
+        fs.joinPath(cwd, filePath),
+        harnessName,
+        "constraints",
+        fs,
+      );
+
+      entries.push({
+        kind: "instruction",
+        name: "constraints",
+        target,
+        path: filePath,
+        status,
+      });
+    }
   }
 
   // ── Instruction checks ───────────────────────────────────

--- a/packages/core/src/compile/instructions.ts
+++ b/packages/core/src/compile/instructions.ts
@@ -10,10 +10,20 @@ import {
   findMarkerBlock,
   replaceMarkerBlock,
 } from "./markers.js";
+import { renderArchitecturalConstraints } from "./architectural-constraints.js";
 
 // ── Slot → file mapping ─────────────────────────────────────
 
 type InstructionSlot = "operational" | "behavioral" | "identity";
+
+/**
+ * `architectural-constraints` (HEP-3) compiles into its own marker block rather
+ * than any instruction slot, so it never collides with a user's
+ * instructions.operational. It rides the operational slot's FILE map because
+ * that is the only mapping present on every target — see
+ * architectural-constraints.ts for why that matters.
+ */
+const CONSTRAINTS_SLOT = "constraints";
 
 interface SlotMapping {
   slot: InstructionSlot;
@@ -79,15 +89,25 @@ description: Harness behavioral preferences
 globs: "**/*"
 alwaysApply: true
 ---`,
+  // The constraints block shares cursor's operational .mdc. It still needs its
+  // own entry for the case where architectural-constraints is the ONLY block in
+  // the file — an .mdc without frontmatter is not loaded as a rule.
+  constraints: `---
+description: Harness architectural constraints
+globs: "**/*"
+alwaysApply: true
+---`,
 };
 
 const COPILOT_FRONTMATTER = `---
 applyTo: "**"
 ---`;
 
+// `slot` is a plain string, not InstructionSlot: the constraints block is not an
+// instruction slot but still needs cursor frontmatter when it stands alone.
 function buildFrontmatter(
   platform: TargetPlatform,
-  slot: InstructionSlot,
+  slot: string,
 ): string | null {
   if (platform === "cursor" && slot in CURSOR_FRONTMATTER) {
     return CURSOR_FRONTMATTER[slot];
@@ -106,11 +126,18 @@ export async function compileInstructions(
   fs: FsProvider,
 ): Promise<{ files: FileAction[]; warnings: string[] }> {
   const instructions = config.instructions;
-  if (!instructions) {
+  const constraintsContent = renderArchitecturalConstraints(
+    config["architectural-constraints"],
+  );
+
+  if (!instructions && !constraintsContent) {
     return { files: [], warnings: [] };
   }
 
-  const importMode = instructions["import-mode"] ?? "merge";
+  // import-mode lives under `instructions`, but it governs whether we touch the
+  // user's instruction files at all — and the constraints block lands in those
+  // same files — so `skip` suppresses both.
+  const importMode = instructions?.["import-mode"] ?? "merge";
   const harnessName = config.metadata?.name ?? "default";
   const cwd = fs.cwd();
   const files: FileAction[] = [];
@@ -120,52 +147,82 @@ export async function compileInstructions(
     return { files, warnings };
   }
 
-  for (const mapping of SLOT_MAPPINGS) {
-    const slotContent = instructions[mapping.slot];
-    if (slotContent === null || slotContent === undefined) {
-      continue;
-    }
+  const operationalFiles = SLOT_MAPPINGS.find((m) => m.slot === "operational")!.file;
 
-    // Deduplicate by output path: multiple targets that share a file (e.g. AGENTS.md)
-    // should produce one FileAction, not N identical ones. Track which paths we've
-    // already processed in this slot pass.
+  // Order matters. `constraints` shares the operational FILE, and the writer
+  // deduplicates by path with last-write-wins, so the operational block must be
+  // emitted AFTER the constraints block: its FileAction carries the fully
+  // accumulated file, and it is also the one each adapter's
+  // appendPermissionsToInstructions() mutates (it matches on slot ===
+  // "operational"). Emitting constraints last would silently drop permissions.
+  const blocks: Array<{ slot: string; content: string; file: SlotMapping["file"] }> = [];
+
+  if (constraintsContent) {
+    blocks.push({
+      slot: CONSTRAINTS_SLOT,
+      content: constraintsContent,
+      file: operationalFiles,
+    });
+  }
+
+  for (const mapping of SLOT_MAPPINGS) {
+    const slotContent = instructions?.[mapping.slot];
+    if (slotContent === null || slotContent === undefined) continue;
+    blocks.push({ slot: mapping.slot, content: slotContent, file: mapping.file });
+  }
+
+  // Accumulated content per output path. Two blocks landing in the same file
+  // must build on each other rather than each re-reading the untouched file on
+  // disk and clobbering the other.
+  const pending = new Map<string, string>();
+
+  for (const block of blocks) {
+    // Deduplicate by output path within a block: several targets share a file
+    // (AGENTS.md serves codex/opencode/windsurf/gemini/junie), and they produce
+    // identical content, so the first target wins.
     const seenPaths = new Set<string>();
 
     for (const target of targets) {
-      const filePath = mapping.file[target];
+      const filePath = block.file[target];
       if (!filePath) continue; // slot not supported on this platform
-      if (seenPaths.has(filePath)) continue; // already processed (shared file)
+      if (seenPaths.has(filePath)) continue;
       seenPaths.add(filePath);
 
       const fullPath = fs.joinPath(cwd, filePath);
-      const frontmatter = buildFrontmatter(target, mapping.slot);
+      const frontmatter = buildFrontmatter(target, block.slot);
 
       if (importMode === "replace") {
-        const markerBlock = buildMarkerBlock(harnessName, mapping.slot, slotContent);
-        const fullContent = frontmatter
-          ? `${frontmatter}\n\n${markerBlock}`
-          : markerBlock;
+        let base = pending.get(filePath);
+        if (base === undefined) {
+          const markerBlock = buildMarkerBlock(harnessName, block.slot, block.content);
+          base = frontmatter ? `${frontmatter}\n\n${markerBlock}` : markerBlock;
+        } else {
+          base = appendMarkerBlock(base, harnessName, block.slot, block.content);
+        }
+        pending.set(filePath, base);
 
         files.push({
           path: filePath,
-          content: fullContent + "\n",
+          content: base + "\n",
           action: "needs-confirmation",
           platform: target,
-          slot: mapping.slot,
-          linesAdded: fullContent.split("\n").length,
+          slot: block.slot,
+          linesAdded: base.split("\n").length,
         });
         continue;
       }
 
-      // merge mode — read directly, default to empty on missing file
-      let existingContent = "";
-      try {
-        existingContent = await fs.readFile(fullPath);
-      } catch {
-        // File doesn't exist yet — start empty
+      // merge mode — read from disk the first time this path is touched
+      let existingContent = pending.get(filePath);
+      if (existingContent === undefined) {
+        try {
+          existingContent = await fs.readFile(fullPath);
+        } catch {
+          existingContent = ""; // File doesn't exist yet — start empty
+        }
       }
 
-      const existing = findMarkerBlock(existingContent, harnessName, mapping.slot);
+      const existing = findMarkerBlock(existingContent, harnessName, block.slot);
       let newFileContent: string;
 
       if (existing) {
@@ -173,12 +230,12 @@ export async function compileInstructions(
         newFileContent = replaceMarkerBlock(
           existingContent,
           harnessName,
-          mapping.slot,
-          slotContent,
+          block.slot,
+          block.content,
         );
       } else if (existingContent.trim() === "") {
         // New file — include frontmatter if needed
-        const markerBlock = buildMarkerBlock(harnessName, mapping.slot, slotContent);
+        const markerBlock = buildMarkerBlock(harnessName, block.slot, block.content);
         newFileContent = frontmatter
           ? `${frontmatter}\n\n${markerBlock}\n`
           : `${markerBlock}\n`;
@@ -187,18 +244,20 @@ export async function compileInstructions(
         newFileContent = appendMarkerBlock(
           existingContent,
           harnessName,
-          mapping.slot,
-          slotContent,
+          block.slot,
+          block.content,
         );
       }
 
-      const linesAdded = slotContent.split("\n").length;
+      pending.set(filePath, newFileContent);
+
+      const linesAdded = block.content.split("\n").length;
       files.push({
         path: filePath,
         content: newFileContent,
         action: existing ? "update" : "create",
         platform: target,
-        slot: mapping.slot,
+        slot: block.slot,
         linesAdded,
       });
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,6 +57,7 @@ export { detectPlatforms } from "./detect/detect-platforms.js";
 // Compile
 export { compile, computeSourceFingerprint } from "./compile/compile.js";
 export { compileInstructions, getAllInstructionFilePaths, getSlotMappings } from "./compile/instructions.js";
+export { renderArchitecturalConstraints } from "./compile/architectural-constraints.js";
 export { compileMcpServers } from "./compile/mcp-servers.js";
 export { compileSkills } from "./compile/skills.js";
 export { compilePermissions, buildPermissionsText } from "./compile/permissions.js";

--- a/packages/core/src/report/report.ts
+++ b/packages/core/src/report/report.ts
@@ -9,6 +9,7 @@ const PLATFORM_ORDER: TargetPlatform[] = ["claude-code", "cursor", "copilot"];
 
 const SLOT_ORDER = [
   "operational",
+  "constraints",
   "behavioral",
   "identity",
   "mcp-servers",

--- a/website/content/docs/concepts/harness-protocol.md
+++ b/website/content/docs/concepts/harness-protocol.md
@@ -5,7 +5,7 @@ title: Harness Protocol
 
 # Harness Protocol
 
-The [Harness Protocol](https://harnessprotocol.ai) is an open specification for portable AI coding harness configuration. It defines a vendor-neutral `harness.yaml` format, validated by [JSON Schema](https://harnessprotocol.ai), that captures the complete operational context for an AI coding agent: plugins, MCP servers, environment requirements, instructions, and permissions.
+The [Harness Protocol](https://harnessprotocol.ai) is an open specification for portable AI coding harness configuration. It defines a vendor-neutral `harness.yaml` format, validated by [JSON Schema](https://harnessprotocol.ai), that captures the complete operational context for an AI coding agent: plugins, skills, MCP servers, environment requirements, instructions, permissions, architectural constraints, and governance policy.
 
 ## How harness-kit relates to it
 
@@ -16,6 +16,50 @@ Conformance does not require harness-kit. Any tool that correctly validates and 
 ## Desktop App
 
 The harness-kit desktop app treats `harness.yaml` as a first-class element. The **Harness File** page (the default landing page under the Harness section) reads `~/.claude/harness.yaml` or `~/harness.yaml` and displays a structured, annotated breakdown of each section — plugins, MCP servers, env declarations, instructions, permissions, and extends — with a raw YAML toggle.
+
+## Architectural constraints
+
+`architectural-constraints` declares the conventions a project expects an agent to
+follow, at three enforcement levels:
+
+```yaml
+architectural-constraints:
+  linters:
+    - name: module-boundary
+      description: No imports across layer boundaries.
+      enforcement: block
+  structural-tests:
+    - name: layering
+      description: The dependency graph stays acyclic.
+      entrypoint: pnpm test:arch
+  review-policy:
+    guidance: Prefer boring, explicit code over clever abstractions.
+    patterns:
+      - name: no-queries-in-loops
+        rule: Never issue a database query inside a loop; batch or join instead.
+        severity: error
+```
+
+harness-kit compiles this into its own marker block in each platform's operational
+instruction file — `CLAUDE.md`, `AGENTS.md`, `.cursor/rules/harness.mdc`,
+`.github/copilot-instructions.md` — separate from anything you write under
+`instructions.operational`, so the two never collide.
+
+Review patterns are grouped by `severity` (`error` → *Must not violate*,
+`warning` → *Should follow*, `info` → *Worth considering*), most severe first.
+`linters` and `structural-tests` are rendered as awareness rather than
+enforcement: harness-kit does not run them, but the agent is told what gates
+exist, which ones block a merge, and — where a `structural-test` declares an
+`entrypoint` — the command it can run itself instead of waiting for CI.
+
+Setting `review-policy.enabled: false` suppresses the review patterns and
+guidance while leaving the deterministic gates in place, since those run in CI
+regardless of what the agent is told. `review-policy.model` is never written into
+the instruction file: it configures whichever harness performs the review, and is
+not guidance the agent should read as a rule.
+
+`harness check` reports drift on the constraints block the same way it does for
+instruction slots.
 
 ## Links
 


### PR DESCRIPTION
Closes #330 (the harness-kit half — see below for what stays upstream).

#350 made `architectural-constraints` **validate**. It didn't make it **do** anything: you could declare a review pattern and no agent would ever see it. This compiles the section into the instruction files agents actually read.

## What it produces

```yaml
architectural-constraints:
  linters:
    - name: module-boundary
      description: No imports across layer boundaries.
  structural-tests:
    - name: layering
      description: The dependency graph stays acyclic.
      entrypoint: pnpm test:arch
  review-policy:
    patterns:
      - name: no-queries-in-loops
        rule: Never issue a database query inside a loop; batch or join instead.
        severity: error
```

becomes, in `CLAUDE.md` / `AGENTS.md` / `.cursor/rules/harness.mdc` / `.github/copilot-instructions.md`:

```markdown
<!-- BEGIN harness:demo:constraints -->
## Architectural constraints

Check these before completing a task in this project.

### Must not violate

- **no-queries-in-loops** — Never issue a database query inside a loop; batch or join instead.

### Enforced outside the agent

These gates run in CI, not in the conversation. `blocks` means a violation
prevents merge — treat it as a hard requirement while working.

- **module-boundary** — linter, blocks. No imports across layer boundaries.
- **layering** — structural test, blocks. The dependency graph stays acyclic. Run: `pnpm test:arch`
<!-- END harness:demo:constraints -->
```

## Decisions I made

The spec defines the section; it leaves placement to the implementation. These are the calls, so they're easy to argue with:

**Own marker block, not merged into `instructions.operational`.** A user's own operational prose and the generated constraints never collide, and the block updates or removes cleanly.

**Written to the operational *file*.** `behavioral` reads like the better semantic fit, but it's `null` for codex/opencode/windsurf/gemini/junie. `operational` is the only slot mapped on every target, and constraints reaching three of eight platforms is worse than reaching none.

**Emitted *before* the instruction slots.** This one is load-bearing and not obvious. The writer dedupes by path with last-write-wins, and each adapter's `appendPermissionsToInstructions()` mutates the FileAction whose slot is `"operational"`. Ordering constraints *last* would make it the final write for the shared file and **silently drop permissions** on copilot/cursor/agents-md/opencode. `compileInstructions` now threads accumulated content per output path so blocks sharing a file build on each other rather than each re-reading the untouched file. There's a regression test for exactly this.

**Deterministic gates render as awareness, not enforcement.** harness-kit doesn't run your linters. But the agent learns which gates block a merge, and gets the `entrypoint` it can run itself instead of waiting for CI to tell it what it broke.

**`enabled: false` keeps the CI gates.** It turns off the LLM review layer; the gates run regardless of what the agent is told, so hiding them would hide real blockers.

**`review-policy.model` is never rendered.** It configures whichever harness performs the review — it isn't guidance the agent should read as a rule.

Severity grouping applies the schema's `warning` default, most severe first.

## Also wired

- **`harness check` drift** — the existing loop sources slot content from `instructions`, where a constraints block has no entry and was skipped silently.
- **Compile report ordering** — `constraints` added to `SLOT_ORDER`.
- **Docs** — a section in `concepts/harness-protocol.md`, whose intro also listed only five of the eight sections the schema now defines.

## Verification

`pnpm turbo run build test` green (18/18). 13 new tests; **the 329 existing core tests pass unchanged**. `validate-manifests.sh` exits 0, validator drift guard is a no-op. Output above is real `compile()` output, not hand-written.

## What this does not close

#330 also asks for a **learning loop** — consolidating repeated corrections out of conversation history into promotable rules. HEP-3 assumes rules are hand-authored and has no provenance story, so that half is upstream spec work in `harness-protocol`, not something this repo can land.

I also did **not** add `architectural-constraints` to harness-kit's own `harness.yaml`. It would dogfood well, but it changes this repo's compiled `CLAUDE.md`, which should be a deliberate choice rather than a side effect of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
