### PR TITLE
test(desktop): remove process-global HOME mutation from Rust tests

### DIFF
--- a/apps/desktop/src-tauri/src/commands/agents.rs
+++ b/apps/desktop/src-tauri/src/commands/agents.rs
@@ -237,10 +237,17 @@ pub struct HarnessHealthRecord {
 
 // ── Harness health helpers ───────────────────────────────────
 
+/// Path to the health file under a given home directory. The `*_at`
+/// functions below take the file path as a parameter so tests can pass a
+/// tempdir instead of mutating the process-global `HOME`.
+fn health_file_path_in(home: &std::path::Path) -> PathBuf {
+    home.join(".harness-kit").join("harness-health.json")
+}
+
 fn health_file_path() -> Result<PathBuf, String> {
     dirs::home_dir()
         .ok_or_else(|| "Could not resolve home directory".to_string())
-        .map(|h| h.join(".harness-kit").join("harness-health.json"))
+        .map(|h| health_file_path_in(&h))
 }
 
 fn read_health_map(path: &PathBuf) -> HashMap<String, HarnessHealthRecord> {
@@ -272,8 +279,15 @@ fn write_health_map(path: &PathBuf, map: &HashMap<String, HarnessHealthRecord>) 
 /// non-zero exit codes and resets to 0 on success.
 #[tauri::command]
 pub fn record_harness_launch_result(harness_id: String, exit_code: i32) -> Result<(), String> {
-    let path = health_file_path()?;
-    let mut map = read_health_map(&path);
+    record_harness_launch_result_at(&health_file_path()?, harness_id, exit_code)
+}
+
+fn record_harness_launch_result_at(
+    path: &PathBuf,
+    harness_id: String,
+    exit_code: i32,
+) -> Result<(), String> {
+    let mut map = read_health_map(path);
 
     let id = harness_id.clone();
     let record = map.entry(id).or_insert_with(|| HarnessHealthRecord {
@@ -296,18 +310,21 @@ pub fn record_harness_launch_result(harness_id: String, exit_code: i32) -> Resul
         record.consecutive_failures = 0;
     }
 
-    write_health_map(&path, &map)
+    write_health_map(path, &map)
 }
 
 /// Return health records for all known harnesses. Returns empty vec if no
 /// health file exists yet.
 #[tauri::command]
 pub fn get_harness_health() -> Result<Vec<HarnessHealthRecord>, String> {
-    let path = health_file_path()?;
+    get_harness_health_at(&health_file_path()?)
+}
+
+fn get_harness_health_at(path: &PathBuf) -> Result<Vec<HarnessHealthRecord>, String> {
     if !path.exists() {
         return Ok(vec![]);
     }
-    let map = read_health_map(&path);
+    let map = read_health_map(path);
     let mut records: Vec<HarnessHealthRecord> = map.into_values().collect();
     records.sort_by(|a, b| a.harness_id.cmp(&b.harness_id));
     Ok(records)
@@ -318,7 +335,6 @@ pub fn get_harness_health() -> Result<Vec<HarnessHealthRecord>, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env;
 
     // ── detect_agents tests ──────────────────────────────────
 
@@ -358,70 +374,60 @@ mod tests {
 
     // ── harness health tests ─────────────────────────────────
 
-    fn with_temp_home<F: FnOnce()>(f: F) {
-        let _lock = crate::HOME_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    /// Each health test gets its own file path — no global state, so these
+    /// run safely in parallel with everything else in the crate.
+    fn temp_health_file() -> (tempfile::TempDir, PathBuf) {
         let tmp = tempfile::TempDir::new().unwrap();
-        let prev = env::var("HOME").ok();
-        env::set_var("HOME", tmp.path());
-
-        f();
-
-        match prev {
-            Some(h) => env::set_var("HOME", h),
-            None => env::remove_var("HOME"),
-        }
+        let path = health_file_path_in(tmp.path());
+        (tmp, path)
     }
 
     #[test]
     fn get_harness_health_returns_empty_when_no_file() {
-        with_temp_home(|| {
-            let result = get_harness_health().unwrap();
-            assert!(result.is_empty());
-        });
+        let (_tmp, path) = temp_health_file();
+        let result = get_harness_health_at(&path).unwrap();
+        assert!(result.is_empty());
     }
 
     #[test]
     fn record_creates_file_and_increments_on_failure() {
-        with_temp_home(|| {
-            record_harness_launch_result("claude".to_string(), 1).unwrap();
-            let health = get_harness_health().unwrap();
-            assert_eq!(health.len(), 1);
-            let rec = &health[0];
-            assert_eq!(rec.harness_id, "claude");
-            assert_eq!(rec.total_launches, 1);
-            assert_eq!(rec.consecutive_failures, 1);
-            assert_eq!(rec.last_exit_code, Some(1));
-            assert!(rec.last_failure_at.is_some());
-        });
+        let (_tmp, path) = temp_health_file();
+        record_harness_launch_result_at(&path, "claude".to_string(), 1).unwrap();
+        let health = get_harness_health_at(&path).unwrap();
+        assert_eq!(health.len(), 1);
+        let rec = &health[0];
+        assert_eq!(rec.harness_id, "claude");
+        assert_eq!(rec.total_launches, 1);
+        assert_eq!(rec.consecutive_failures, 1);
+        assert_eq!(rec.last_exit_code, Some(1));
+        assert!(rec.last_failure_at.is_some());
     }
 
     #[test]
     fn record_resets_consecutive_failures_on_success() {
-        with_temp_home(|| {
-            record_harness_launch_result("codex".to_string(), 1).unwrap();
-            record_harness_launch_result("codex".to_string(), 1).unwrap();
-            record_harness_launch_result("codex".to_string(), 0).unwrap();
+        let (_tmp, path) = temp_health_file();
+        record_harness_launch_result_at(&path, "codex".to_string(), 1).unwrap();
+        record_harness_launch_result_at(&path, "codex".to_string(), 1).unwrap();
+        record_harness_launch_result_at(&path, "codex".to_string(), 0).unwrap();
 
-            let health = get_harness_health().unwrap();
-            let rec = health.iter().find(|r| r.harness_id == "codex").unwrap();
-            assert_eq!(rec.consecutive_failures, 0);
-            assert_eq!(rec.total_launches, 3);
-            assert_eq!(rec.last_exit_code, Some(0));
-        });
+        let health = get_harness_health_at(&path).unwrap();
+        let rec = health.iter().find(|r| r.harness_id == "codex").unwrap();
+        assert_eq!(rec.consecutive_failures, 0);
+        assert_eq!(rec.total_launches, 3);
+        assert_eq!(rec.last_exit_code, Some(0));
     }
 
     #[test]
     fn record_tracks_multiple_harnesses_independently() {
-        with_temp_home(|| {
-            record_harness_launch_result("claude".to_string(), 0).unwrap();
-            record_harness_launch_result("codex".to_string(), 1).unwrap();
+        let (_tmp, path) = temp_health_file();
+        record_harness_launch_result_at(&path, "claude".to_string(), 0).unwrap();
+        record_harness_launch_result_at(&path, "codex".to_string(), 1).unwrap();
 
-            let health = get_harness_health().unwrap();
-            assert_eq!(health.len(), 2);
-            let claude = health.iter().find(|r| r.harness_id == "claude").unwrap();
-            let codex = health.iter().find(|r| r.harness_id == "codex").unwrap();
-            assert_eq!(claude.consecutive_failures, 0);
-            assert_eq!(codex.consecutive_failures, 1);
-        });
+        let health = get_harness_health_at(&path).unwrap();
+        assert_eq!(health.len(), 2);
+        let claude = health.iter().find(|r| r.harness_id == "claude").unwrap();
+        let codex = health.iter().find(|r| r.harness_id == "codex").unwrap();
+        assert_eq!(claude.consecutive_failures, 0);
+        assert_eq!(codex.consecutive_failures, 1);
     }
 }

--- a/apps/desktop/src-tauri/src/commands/fs_scope.rs
+++ b/apps/desktop/src-tauri/src/commands/fs_scope.rs
@@ -14,6 +14,14 @@ fn expand_tilde(path: &str) -> String {
     path.to_string()
 }
 
+/// The trust check `grant_project_scope` enforces: reject `candidate` when it
+/// is the home directory or an ancestor of it. Both paths must already be
+/// canonicalized. Taking `home` as a parameter keeps this testable without
+/// touching the process-global `HOME`.
+fn is_home_or_ancestor(candidate: &Path, home: &Path) -> bool {
+    home.starts_with(candidate)
+}
+
 /// Grant the webview's Tauri FS plugin scope read/write access to a single,
 /// user-chosen project directory for the rest of this app session.
 ///
@@ -32,14 +40,6 @@ fn expand_tilde(path: &str) -> String {
 /// to enforce. Reject any target that is the home directory or an ancestor
 /// of it (`/`, `/Users`, `~`, etc.) — granting one of those would silently
 /// recreate the `$HOME/**` grant this change removes, or worse.
-/// The trust check `grant_project_scope` enforces: reject `candidate` when it
-/// is the home directory or an ancestor of it. Both paths must already be
-/// canonicalized. Taking `home` as a parameter keeps this testable without
-/// touching the process-global `HOME`.
-fn is_home_or_ancestor(candidate: &Path, home: &Path) -> bool {
-    home.starts_with(candidate)
-}
-
 #[tauri::command]
 pub fn grant_project_scope(app: AppHandle, path: String) -> Result<(), String> {
     let expanded = expand_tilde(&path);

--- a/apps/desktop/src-tauri/src/commands/fs_scope.rs
+++ b/apps/desktop/src-tauri/src/commands/fs_scope.rs
@@ -32,6 +32,14 @@ fn expand_tilde(path: &str) -> String {
 /// to enforce. Reject any target that is the home directory or an ancestor
 /// of it (`/`, `/Users`, `~`, etc.) — granting one of those would silently
 /// recreate the `$HOME/**` grant this change removes, or worse.
+/// The trust check `grant_project_scope` enforces: reject `candidate` when it
+/// is the home directory or an ancestor of it. Both paths must already be
+/// canonicalized. Taking `home` as a parameter keeps this testable without
+/// touching the process-global `HOME`.
+fn is_home_or_ancestor(candidate: &Path, home: &Path) -> bool {
+    home.starts_with(candidate)
+}
+
 #[tauri::command]
 pub fn grant_project_scope(app: AppHandle, path: String) -> Result<(), String> {
     let expanded = expand_tilde(&path);
@@ -45,7 +53,7 @@ pub fn grant_project_scope(app: AppHandle, path: String) -> Result<(), String> {
 
     if let Some(home) = dirs::home_dir() {
         let canonical_home = home.canonicalize().unwrap_or(home);
-        if canonical_home.starts_with(&canonical) {
+        if is_home_or_ancestor(&canonical, &canonical_home) {
             return Err(
                 "Refusing to grant scope over the home directory or one of its ancestors"
                     .to_string(),
@@ -78,13 +86,40 @@ mod tests {
     }
 
     #[test]
-    fn home_dir_is_rejected_as_an_ancestor_of_itself() {
-        let home = dirs::home_dir().unwrap();
-        let canonical_home = home.canonicalize().unwrap_or(home);
-        // Mirrors the guard in grant_project_scope: a directory is rejected
-        // when the home dir starts with it (i.e. it is home, or an ancestor).
-        let root: PathBuf = "/".into();
-        assert!(canonical_home.starts_with(&root));
-        assert!(canonical_home.starts_with(&canonical_home));
+    fn home_dir_itself_is_rejected() {
+        let home: PathBuf = "/Users/example".into();
+        assert!(is_home_or_ancestor(&home, &home));
+    }
+
+    #[test]
+    fn ancestors_of_home_are_rejected() {
+        let home: PathBuf = "/Users/example".into();
+        for ancestor in ["/", "/Users"] {
+            assert!(
+                is_home_or_ancestor(Path::new(ancestor), &home),
+                "{} should be rejected as an ancestor of home",
+                ancestor
+            );
+        }
+    }
+
+    #[test]
+    fn directories_under_home_are_allowed() {
+        let home: PathBuf = "/Users/example".into();
+        for allowed in ["/Users/example/repos/foo", "/Users/example/repos", "/tmp/scratch"] {
+            assert!(
+                !is_home_or_ancestor(Path::new(allowed), &home),
+                "{} should be allowed",
+                allowed
+            );
+        }
+    }
+
+    #[test]
+    fn sibling_with_shared_name_prefix_is_allowed() {
+        // /Users/exampleother must not be treated as an ancestor of
+        // /Users/example — component-wise comparison, not string prefix.
+        let home: PathBuf = "/Users/example".into();
+        assert!(!is_home_or_ancestor(Path::new("/Users/exampleother"), &home));
     }
 }

--- a/apps/desktop/src-tauri/src/commands/harness_file.rs
+++ b/apps/desktop/src-tauri/src/commands/harness_file.rs
@@ -1,3 +1,12 @@
+use std::path::Path;
+
+/// Resolve the user's home directory. The `*_in` functions below take the
+/// home directory as a parameter so tests can pass a tempdir instead of
+/// mutating the process-global `HOME`.
+fn home_dir() -> Result<std::path::PathBuf, String> {
+    dirs::home_dir().ok_or_else(|| "Could not resolve home directory".to_string())
+}
+
 #[derive(serde::Serialize)]
 pub struct HarnessFileResult {
     pub found: bool,
@@ -7,8 +16,11 @@ pub struct HarnessFileResult {
 
 #[tauri::command]
 pub fn read_harness_file() -> Result<HarnessFileResult, String> {
-    let home_raw = dirs::home_dir()
-        .ok_or_else(|| "Could not resolve home directory".to_string())?;
+    read_harness_file_in(&home_dir()?)
+}
+
+fn read_harness_file_in(home_raw: &Path) -> Result<HarnessFileResult, String> {
+    let home_raw = home_raw.to_path_buf();
     // Canonicalize home so symlink-heavy temp paths (e.g. macOS /tmp → /private/tmp)
     // compare correctly against the canonicalized candidate paths below.
     let home = home_raw.canonicalize().unwrap_or(home_raw);
@@ -54,9 +66,10 @@ pub fn read_harness_file() -> Result<HarnessFileResult, String> {
 /// Returns the display path on success.
 #[tauri::command]
 pub fn write_harness_file(content: String) -> Result<String, String> {
-    let home = dirs::home_dir()
-        .ok_or_else(|| "Could not resolve home directory".to_string())?;
+    write_harness_file_in(&home_dir()?, content)
+}
 
+fn write_harness_file_in(home: &Path, content: String) -> Result<String, String> {
     let claude_dir = home.join(".claude");
     if !claude_dir.exists() {
         std::fs::create_dir_all(&claude_dir)
@@ -90,8 +103,10 @@ pub struct ClaudeConfigScan {
 
 #[tauri::command]
 pub fn scan_claude_config() -> Result<ClaudeConfigScan, String> {
-    let home = dirs::home_dir()
-        .ok_or_else(|| "Could not resolve home directory".to_string())?;
+    scan_claude_config_in(&home_dir()?)
+}
+
+fn scan_claude_config_in(home: &Path) -> Result<ClaudeConfigScan, String> {
     let claude_dir = home.join(".claude");
 
     // MCP servers: mcp.json is the current Claude Code location; .mcp.json is a legacy fallback.
@@ -123,30 +138,15 @@ pub fn scan_claude_config() -> Result<ClaudeConfigScan, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env;
     use tempfile::TempDir;
-
-    fn with_home(dir: &TempDir, f: impl FnOnce()) {
-        // Hold the crate-level lock so parallel tests don't race on HOME.
-        let _guard = crate::HOME_LOCK.lock().unwrap();
-        let old = env::var("HOME").ok();
-        env::set_var("HOME", dir.path());
-        f();
-        match old {
-            Some(v) => env::set_var("HOME", v),
-            None => env::remove_var("HOME"),
-        }
-    }
 
     #[test]
     fn read_harness_file_returns_not_found_when_absent() {
         let dir = TempDir::new().unwrap();
-        with_home(&dir, || {
-            let result = read_harness_file().unwrap();
-            assert!(!result.found);
-            assert!(result.content.is_none());
-            assert!(result.path.is_none());
-        });
+        let result = read_harness_file_in(dir.path()).unwrap();
+        assert!(!result.found);
+        assert!(result.content.is_none());
+        assert!(result.path.is_none());
     }
 
     #[test]
@@ -155,45 +155,37 @@ mod tests {
         let claude = dir.path().join(".claude");
         std::fs::create_dir(&claude).unwrap();
         std::fs::write(claude.join("harness.yaml"), "version: \"1\"\n").unwrap();
-        with_home(&dir, || {
-            let result = read_harness_file().unwrap();
-            assert!(result.found);
-            assert_eq!(result.content.unwrap(), "version: \"1\"\n");
-            assert_eq!(result.path.unwrap(), "~/.claude/harness.yaml");
-        });
+        let result = read_harness_file_in(dir.path()).unwrap();
+        assert!(result.found);
+        assert_eq!(result.content.unwrap(), "version: \"1\"\n");
+        assert_eq!(result.path.unwrap(), "~/.claude/harness.yaml");
     }
 
     #[test]
     fn read_harness_file_falls_back_to_home_root() {
         let dir = TempDir::new().unwrap();
         std::fs::write(dir.path().join("harness.yaml"), "version: \"1\"\n").unwrap();
-        with_home(&dir, || {
-            let result = read_harness_file().unwrap();
-            assert!(result.found);
-            assert_eq!(result.path.unwrap(), "~/harness.yaml");
-        });
+        let result = read_harness_file_in(dir.path()).unwrap();
+        assert!(result.found);
+        assert_eq!(result.path.unwrap(), "~/harness.yaml");
     }
 
     #[test]
     fn write_harness_file_creates_claude_dir_and_file() {
         let dir = TempDir::new().unwrap();
-        with_home(&dir, || {
-            let path = write_harness_file("content: test".to_string()).unwrap();
-            assert_eq!(path, "~/.claude/harness.yaml");
-            let written = std::fs::read_to_string(dir.path().join(".claude/harness.yaml")).unwrap();
-            assert_eq!(written, "content: test");
-        });
+        let path = write_harness_file_in(dir.path(), "content: test".to_string()).unwrap();
+        assert_eq!(path, "~/.claude/harness.yaml");
+        let written = std::fs::read_to_string(dir.path().join(".claude/harness.yaml")).unwrap();
+        assert_eq!(written, "content: test");
     }
 
     #[test]
     fn scan_claude_config_returns_none_when_files_absent() {
         let dir = TempDir::new().unwrap();
         std::fs::create_dir(dir.path().join(".claude")).unwrap();
-        with_home(&dir, || {
-            let result = scan_claude_config().unwrap();
-            assert!(result.mcp_servers_json.is_none());
-            assert!(result.settings_json.is_none());
-        });
+        let result = scan_claude_config_in(dir.path()).unwrap();
+        assert!(result.mcp_servers_json.is_none());
+        assert!(result.settings_json.is_none());
     }
 
     #[test]
@@ -203,12 +195,10 @@ mod tests {
         std::fs::create_dir(&claude).unwrap();
         std::fs::write(claude.join("mcp.json"), r#"{"mcpServers":{}}"#).unwrap();
         std::fs::write(claude.join("settings.local.json"), r#"{"permissions":{"allow":[]}}"#).unwrap();
-        with_home(&dir, || {
-            let result = scan_claude_config().unwrap();
-            assert!(result.mcp_servers_json.is_some());
-            assert_eq!(result.mcp_source.unwrap(), "~/.claude/mcp.json");
-            assert!(result.settings_json.is_some());
-            assert_eq!(result.settings_source.unwrap(), "~/.claude/settings.local.json");
-        });
+        let result = scan_claude_config_in(dir.path()).unwrap();
+        assert!(result.mcp_servers_json.is_some());
+        assert_eq!(result.mcp_source.unwrap(), "~/.claude/mcp.json");
+        assert!(result.settings_json.is_some());
+        assert_eq!(result.settings_source.unwrap(), "~/.claude/settings.local.json");
     }
 }

--- a/apps/desktop/src-tauri/src/commands/mcp.rs
+++ b/apps/desktop/src-tauri/src/commands/mcp.rs
@@ -1,3 +1,12 @@
+use std::path::Path;
+
+/// Resolve the user's home directory. The `*_in` functions below take the
+/// home directory as a parameter so tests can pass a tempdir instead of
+/// mutating the process-global `HOME`.
+fn home_dir() -> Result<std::path::PathBuf, String> {
+    dirs::home_dir().ok_or_else(|| "Could not resolve home directory".to_string())
+}
+
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct McpConfigResult {
@@ -12,8 +21,11 @@ pub struct McpConfigResult {
 /// return just the `mcpServers` object as a JSON string.
 #[tauri::command]
 pub fn read_mcp_config() -> Result<McpConfigResult, String> {
-    let home_raw = dirs::home_dir()
-        .ok_or_else(|| "Could not resolve home directory".to_string())?;
+    read_mcp_config_in(&home_dir()?)
+}
+
+fn read_mcp_config_in(home_raw: &Path) -> Result<McpConfigResult, String> {
+    let home_raw = home_raw.to_path_buf();
     // Canonicalize home so symlink-heavy temp paths (e.g. macOS /tmp → /private/tmp)
     // compare correctly against the canonicalized candidate paths below.
     let home = home_raw.canonicalize().unwrap_or(home_raw);
@@ -69,12 +81,15 @@ pub fn read_mcp_config() -> Result<McpConfigResult, String> {
 /// Returns the display path on success.
 #[tauri::command]
 pub fn write_mcp_config(servers_json: String) -> Result<String, String> {
+    write_mcp_config_in(&home_dir()?, servers_json)
+}
+
+fn write_mcp_config_in(home: &Path, servers_json: String) -> Result<String, String> {
     // Validate that the caller passed valid JSON before touching the filesystem.
     let servers_value: serde_json::Value = serde_json::from_str(&servers_json)
         .map_err(|e| format!("Invalid JSON for servers_json: {}", e))?;
 
-    let home = dirs::home_dir()
-        .ok_or_else(|| "Could not resolve home directory".to_string())?;
+    let home = home.to_path_buf();
 
     let claude_dir = home.join(".claude");
     if !claude_dir.exists() {
@@ -124,30 +139,15 @@ pub fn write_mcp_config(servers_json: String) -> Result<String, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env;
     use tempfile::TempDir;
-
-    fn with_home(dir: &TempDir, f: impl FnOnce()) {
-        // Hold the crate-level lock so parallel tests don't race on HOME.
-        let _guard = crate::HOME_LOCK.lock().unwrap();
-        let old = env::var("HOME").ok();
-        env::set_var("HOME", dir.path());
-        f();
-        match old {
-            Some(v) => env::set_var("HOME", v),
-            None => env::remove_var("HOME"),
-        }
-    }
 
     #[test]
     fn read_mcp_config_returns_not_found_when_absent() {
         let dir = TempDir::new().unwrap();
-        with_home(&dir, || {
-            let result = read_mcp_config().unwrap();
-            assert!(!result.found);
-            assert!(result.servers_json.is_none());
-            assert!(result.source.is_none());
-        });
+        let result = read_mcp_config_in(dir.path()).unwrap();
+        assert!(!result.found);
+        assert!(result.servers_json.is_none());
+        assert!(result.source.is_none());
     }
 
     #[test]
@@ -160,34 +160,30 @@ mod tests {
             r#"{"mcpServers":{"test":{"command":"npx"}}}"#,
         )
         .unwrap();
-        with_home(&dir, || {
-            let result = read_mcp_config().unwrap();
-            assert!(result.found);
-            assert_eq!(result.source.unwrap(), "~/.claude/mcp.json");
-            let servers: serde_json::Value =
-                serde_json::from_str(&result.servers_json.unwrap()).unwrap();
-            assert!(servers.get("test").is_some());
-            assert_eq!(
-                servers["test"]["command"],
-                serde_json::Value::String("npx".to_string())
-            );
-        });
+        let result = read_mcp_config_in(dir.path()).unwrap();
+        assert!(result.found);
+        assert_eq!(result.source.unwrap(), "~/.claude/mcp.json");
+        let servers: serde_json::Value =
+            serde_json::from_str(&result.servers_json.unwrap()).unwrap();
+        assert!(servers.get("test").is_some());
+        assert_eq!(
+            servers["test"]["command"],
+            serde_json::Value::String("npx".to_string())
+        );
     }
 
     #[test]
     fn write_mcp_config_creates_file() {
         let dir = TempDir::new().unwrap();
-        with_home(&dir, || {
-            let servers = r#"{"my-server":{"command":"node","args":["server.js"]}}"#;
-            let path = write_mcp_config(servers.to_string()).unwrap();
-            assert_eq!(path, "~/.claude/mcp.json");
+        let servers = r#"{"my-server":{"command":"node","args":["server.js"]}}"#;
+        let path = write_mcp_config_in(dir.path(), servers.to_string()).unwrap();
+        assert_eq!(path, "~/.claude/mcp.json");
 
-            let written =
-                std::fs::read_to_string(dir.path().join(".claude/mcp.json")).unwrap();
-            let parsed: serde_json::Value = serde_json::from_str(&written).unwrap();
-            assert!(parsed.get("mcpServers").is_some());
-            assert!(parsed["mcpServers"].get("my-server").is_some());
-        });
+        let written =
+            std::fs::read_to_string(dir.path().join(".claude/mcp.json")).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&written).unwrap();
+        assert!(parsed.get("mcpServers").is_some());
+        assert!(parsed["mcpServers"].get("my-server").is_some());
     }
 
     #[test]
@@ -200,32 +196,28 @@ mod tests {
             r#"{"extra":"value","mcpServers":{}}"#,
         )
         .unwrap();
-        with_home(&dir, || {
-            let new_servers = r#"{"added":{"command":"npx"}}"#;
-            write_mcp_config(new_servers.to_string()).unwrap();
+        let new_servers = r#"{"added":{"command":"npx"}}"#;
+        write_mcp_config_in(dir.path(), new_servers.to_string()).unwrap();
 
-            let written =
-                std::fs::read_to_string(dir.path().join(".claude/mcp.json")).unwrap();
-            let parsed: serde_json::Value = serde_json::from_str(&written).unwrap();
-            // Unknown key must survive the round-trip.
-            assert_eq!(
-                parsed.get("extra"),
-                Some(&serde_json::Value::String("value".to_string()))
-            );
-            // New servers value must be written.
-            assert!(parsed["mcpServers"].get("added").is_some());
-        });
+        let written =
+            std::fs::read_to_string(dir.path().join(".claude/mcp.json")).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&written).unwrap();
+        // Unknown key must survive the round-trip.
+        assert_eq!(
+            parsed.get("extra"),
+            Some(&serde_json::Value::String("value".to_string()))
+        );
+        // New servers value must be written.
+        assert!(parsed["mcpServers"].get("added").is_some());
     }
 
     #[test]
     fn write_mcp_config_rejects_invalid_json() {
         let dir = TempDir::new().unwrap();
-        with_home(&dir, || {
-            let result = write_mcp_config("not valid json {{".to_string());
-            assert!(result.is_err());
-            let msg = result.unwrap_err();
-            assert!(msg.contains("Invalid JSON"));
-        });
+        let result = write_mcp_config_in(dir.path(), "not valid json {{".to_string());
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(msg.contains("Invalid JSON"));
     }
 
     #[test]
@@ -235,14 +227,12 @@ mod tests {
         std::fs::create_dir(&claude).unwrap();
         // Only write .mcp.json, not mcp.json
         std::fs::write(claude.join(".mcp.json"), r#"{"mcpServers":{"legacy":{"command":"npx"}}}"#).unwrap();
-        with_home(&dir, || {
-            let result = read_mcp_config().unwrap();
-            assert!(result.found);
-            assert_eq!(result.source.unwrap(), "~/.claude/.mcp.json");
-            let servers: serde_json::Value =
-                serde_json::from_str(&result.servers_json.unwrap()).unwrap();
-            assert!(servers.get("legacy").is_some());
-        });
+        let result = read_mcp_config_in(dir.path()).unwrap();
+        assert!(result.found);
+        assert_eq!(result.source.unwrap(), "~/.claude/.mcp.json");
+        let servers: serde_json::Value =
+            serde_json::from_str(&result.servers_json.unwrap()).unwrap();
+        assert!(servers.get("legacy").is_some());
     }
 
     #[test]
@@ -251,12 +241,10 @@ mod tests {
         let claude = dir.path().join(".claude");
         std::fs::create_dir(&claude).unwrap();
         std::fs::write(claude.join("mcp.json"), b"not valid json at all!!!").unwrap();
-        with_home(&dir, || {
-            let result = write_mcp_config(r#"{"new":{"command":"npx"}}"#.to_string());
-            assert!(result.is_ok());
-            let content = std::fs::read_to_string(claude.join("mcp.json")).unwrap();
-            let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
-            assert!(parsed.get("mcpServers").is_some());
-        });
+        let result = write_mcp_config_in(dir.path(), r#"{"new":{"command":"npx"}}"#.to_string());
+        assert!(result.is_ok());
+        let content = std::fs::read_to_string(claude.join("mcp.json")).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert!(parsed.get("mcpServers").is_some());
     }
 }

--- a/apps/desktop/src-tauri/src/commands/plugins.rs
+++ b/apps/desktop/src-tauri/src/commands/plugins.rs
@@ -80,8 +80,13 @@ struct RawMarketplaceManifest {
     plugins: Vec<RawMarketplacePlugin>,
 }
 
-fn claude_dir() -> Option<std::path::PathBuf> {
-    dirs::home_dir().map(|h| h.join(".claude"))
+/// Resolve `~/.claude`. The `*_in` variants below take this directory as a
+/// parameter so tests can pass a tempdir instead of mutating the
+/// process-global `HOME`.
+fn claude_dir() -> Result<std::path::PathBuf, String> {
+    dirs::home_dir()
+        .map(|h| h.join(".claude"))
+        .ok_or_else(|| "Could not resolve home directory".to_string())
 }
 
 fn count_subdirectory_entries(install_path: &str, subdir: &str) -> u32 {
@@ -117,8 +122,11 @@ fn read_plugin_manifest_fields(install_path: &str) -> PluginManifestFields {
 
 #[tauri::command]
 pub fn list_installed_plugins() -> Result<Vec<InstalledPlugin>, String> {
-    let path = claude_dir()
-        .ok_or_else(|| "Could not resolve home directory".to_string())?
+    list_installed_plugins_in(&claude_dir()?)
+}
+
+fn list_installed_plugins_in(claude_dir: &std::path::Path) -> Result<Vec<InstalledPlugin>, String> {
+    let path = claude_dir
         .join("plugins")
         .join("installed_plugins.json");
 
@@ -165,8 +173,11 @@ pub fn list_installed_plugins() -> Result<Vec<InstalledPlugin>, String> {
 
 #[tauri::command]
 pub fn list_marketplaces() -> Result<Vec<KnownMarketplace>, String> {
-    let path = claude_dir()
-        .ok_or_else(|| "Could not resolve home directory".to_string())?
+    list_marketplaces_in(&claude_dir()?)
+}
+
+fn list_marketplaces_in(claude_dir: &std::path::Path) -> Result<Vec<KnownMarketplace>, String> {
+    let path = claude_dir
         .join("plugins")
         .join("marketplaces.json");
 
@@ -183,10 +194,13 @@ pub fn list_marketplaces() -> Result<Vec<KnownMarketplace>, String> {
 
 #[tauri::command]
 pub fn check_plugin_updates() -> Result<Vec<PluginUpdateInfo>, String> {
-    let installed = list_installed_plugins()?;
+    check_plugin_updates_in(&claude_dir()?)
+}
 
-    let marketplaces_dir = claude_dir()
-        .ok_or_else(|| "Could not resolve home directory".to_string())?
+fn check_plugin_updates_in(claude_dir: &std::path::Path) -> Result<Vec<PluginUpdateInfo>, String> {
+    let installed = list_installed_plugins_in(claude_dir)?;
+
+    let marketplaces_dir = claude_dir
         .join("plugins")
         .join("marketplaces");
 
@@ -242,14 +256,16 @@ pub fn check_plugin_updates() -> Result<Vec<PluginUpdateInfo>, String> {
 
 #[tauri::command]
 pub fn uninstall_plugin(name: String) -> Result<(), String> {
+    uninstall_plugin_in(&claude_dir()?, name)
+}
+
+fn uninstall_plugin_in(claude_dir: &std::path::Path, name: String) -> Result<(), String> {
     // Validate name doesn't contain path traversal characters
     if name.contains('/') || name.contains('\\') || name.contains("..") {
         return Err("Invalid plugin name".to_string());
     }
 
-    let plugins_dir = claude_dir()
-        .ok_or_else(|| "Could not resolve home directory".to_string())?
-        .join("plugins");
+    let plugins_dir = claude_dir.join("plugins");
 
     // Remove plugin directory — canonicalize before removal to block symlink traversal
     let plugin_dir = plugins_dir.join(&name);
@@ -302,34 +318,20 @@ pub fn uninstall_plugin(name: String) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env;
     use tempfile::TempDir;
-
-    fn with_home(dir: &TempDir, f: impl FnOnce()) {
-        // Hold the crate-level lock so parallel tests don't race on HOME.
-        let _guard = crate::HOME_LOCK.lock().unwrap();
-        let old = env::var("HOME").ok();
-        env::set_var("HOME", dir.path());
-        f();
-        match old {
-            Some(v) => env::set_var("HOME", v),
-            None => env::remove_var("HOME"),
-        }
-    }
 
     #[test]
     fn list_installed_plugins_returns_empty_when_file_absent() {
         let dir = TempDir::new().unwrap();
-        with_home(&dir, || {
-            let result = list_installed_plugins().unwrap();
-            assert_eq!(result.len(), 0);
-        });
+        let result = list_installed_plugins_in(&dir.path().join(".claude")).unwrap();
+        assert_eq!(result.len(), 0);
     }
 
     #[test]
     fn list_installed_plugins_returns_correct_count_when_file_exists() {
         let dir = TempDir::new().unwrap();
-        let plugins_dir = dir.path().join(".claude").join("plugins");
+        let claude = dir.path().join(".claude");
+        let plugins_dir = claude.join("plugins");
         std::fs::create_dir_all(&plugins_dir).unwrap();
         let json = r#"{
             "plugins": {
@@ -345,16 +347,14 @@ mod tests {
             }
         }"#;
         std::fs::write(plugins_dir.join("installed_plugins.json"), json).unwrap();
-        with_home(&dir, || {
-            let result = list_installed_plugins().unwrap();
-            assert_eq!(result.len(), 3);
-            // Results are sorted by name
-            assert_eq!(result[0].name, "explain");
-            assert_eq!(result[0].version, "0.1.0");
-            assert_eq!(result[0].marketplace.as_deref(), Some("harness-kit"));
-            assert_eq!(result[1].name, "orient");
-            assert_eq!(result[2].name, "research");
-            assert_eq!(result[2].version, "0.3.0");
-        });
+        let result = list_installed_plugins_in(&claude).unwrap();
+        assert_eq!(result.len(), 3);
+        // Results are sorted by name
+        assert_eq!(result[0].name, "explain");
+        assert_eq!(result[0].version, "0.1.0");
+        assert_eq!(result[0].marketplace.as_deref(), Some("harness-kit"));
+        assert_eq!(result[1].name, "orient");
+        assert_eq!(result[2].name, "research");
+        assert_eq!(result[2].version, "0.3.0");
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,12 +1,6 @@
 mod commands;
 mod db;
 
-/// Process-wide lock for tests that mutate the HOME env variable.
-/// All `with_home()` helpers across test modules must hold this lock
-/// to prevent races when Rust runs tests in parallel threads.
-#[cfg(test)]
-pub static HOME_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
 use tauri::{LogicalSize, Manager};
 
 /// Detect the current git branch by running `git branch --show-current`


### PR DESCRIPTION
## Problem

Four test modules in `apps/desktop/src-tauri` mutated the process-global `HOME`:

- `commands/agents.rs`
- `commands/harness_file.rs`
- `commands/mcp.rs`
- `commands/plugins.rs`

Each did `env::set_var("HOME", tmpdir)` and restored it afterwards. `cargo` runs tests in parallel within a single process, so those mutations were visible to every other test in the crate. Any test reading `dirs::home_dir()` or expanding `~` raced them — a test could pass under a filter and fail in the full suite because `HOME` had been reassigned mid-run.

A crate-level `HOME_LOCK` mutex existed but was insufficient: it serialized the mutators against each other and never against *readers* like `fs_scope.rs`, which is exactly where the race surfaced.

## Fix

Inject the home directory rather than reading it inside the function under test. Each `#[tauri::command]` is now a thin wrapper that resolves home once and delegates to a private `*_in` / `*_at` function taking the path as a parameter. Tests call the inner function with a tempdir. **Command behavior is unchanged.**

| File | Extracted |
|---|---|
| `agents.rs` | `health_file_path_in`, `record_harness_launch_result_at`, `get_harness_health_at` |
| `harness_file.rs` | `read_harness_file_in`, `write_harness_file_in`, `scan_claude_config_in` |
| `mcp.rs` | `read_mcp_config_in`, `write_mcp_config_in` |
| `plugins.rs` | `claude_dir()` now returns `Result`; all four commands delegate to `*_in(claude_dir)` |
| `lib.rs` | `HOME_LOCK` deleted — no longer needed |

`check_plugin_updates_in` threads its `claude_dir` into `list_installed_plugins_in` rather than re-resolving home a second time.

`grep -rn 'set_var("HOME"\|HOME_LOCK\|with_home' src/` returns nothing.

## Bonus: a guard test with teeth

`fs_scope.rs`'s `home_dir_is_rejected_as_an_ancestor_of_itself` re-implemented `grant_project_scope`'s ancestor check rather than calling it, so it could not catch a regression in the real code. The guard is now a pure `is_home_or_ancestor(candidate, home)`, called by the command and exercised directly by four tests — including a sibling-prefix case (`/Users/exampleother` must not count as an ancestor of `/Users/example`).

Mutation-verified: inverting the comparison to `candidate.starts_with(home)` fails 2 tests. The previous test stayed green under the same mutation.

## Verification

- `cargo test --lib` x10 → 43 passed every run
- All 43 tests run individually with `--exact` → 0 failures, no behavior difference between isolated and full runs
- `cargo test --lib -- --test-threads=1` → 43 passed
- `cargo check` (non-test build) clean
- `cargo clippy --lib --all-targets` → 0 warnings, 0 errors