### PR TITLE
feat(core): signature-verified definitions feed (AC-25)

### DIFF
--- a/packages/core/__tests__/definitions-feed.test.ts
+++ b/packages/core/__tests__/definitions-feed.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { generateKeyPairSync, sign as signEd } from "node:crypto";
 import { loadDefinitions } from "../src/definitions/feed.js";
 import type { FeedOptions, PublisherKey } from "../src/definitions/feed.js";
-import { NodeSignatureVerifier } from "../src/definitions/providers-node.js";
+import { NodeFetcher, NodeSignatureVerifier } from "../src/definitions/providers-node.js";
 import type { FetchResult, Fetcher } from "../src/definitions/providers.js";
 import { toBundle } from "../src/definitions/bundle.js";
 import { SURFACES, getSurface } from "../src/surfaces/registry.js";
@@ -305,16 +305,134 @@ describe("falling back, and saying so (AC-25)", () => {
   });
 
   it("never throws, whatever the feed does", async () => {
+    // The payload cases carry a REAL signature. An earlier version used the
+    // default empty key list, so the signature check rejected first and the
+    // decoder was never reached — the assertion held for a reason that had
+    // nothing to do with the test's name.
+    const key = keypair();
+    const cases = [
+      { bytes: new Uint8Array([0xff, 0xfe]), label: "invalid UTF-8" },
+      { bytes: new TextEncoder().encode("{not json"), label: "invalid JSON" },
+      { bytes: new TextEncoder().encode("[]"), label: "JSON that is not a bundle" },
+      { bytes: new TextEncoder().encode(JSON.stringify({ formatVersion: 99 })), label: "a newer format" },
+    ];
+    for (const { bytes, label } of cases) {
+      const loaded = await loadDefinitions(
+        options({
+          publisherKeys: [{ id: "k1", publicKey: key.raw }],
+          fetcher: fetcher({
+            [BODY_URL]: { status: "ok", bytes },
+            [SIG_URL]: { status: "ok", bytes: key.sign(bytes) },
+          }),
+        }),
+      );
+      expect(loaded.source, label).toBe("snapshot");
+      // Reached the DECODER, not the signature check — that is the point.
+      expect(loaded.reason, label).not.toContain("did not verify");
+      expect((loaded.reason ?? "").length, label).toBeGreaterThan(0);
+    }
+
     for (const result of [
       { status: "failed", reason: "boom" } as const,
       { status: "not-found" } as const,
-      { status: "ok", bytes: new Uint8Array([0xff, 0xfe]) } as const,
     ]) {
       const loaded = await loadDefinitions(
         options({ fetcher: fetcher({ [BODY_URL]: result, [SIG_URL]: result }) }),
       );
       expect(loaded.source).toBe("snapshot");
     }
+  });
+
+  it("degrades instead of throwing on a malformed feed URL", async () => {
+    // `new URL()` on a typo'd baseUrl used to take the process down.
+    for (const bad of ["https://[", "https://harness kit.ai/definitions/v1", "https://%zz/x"]) {
+      const loaded = await loadDefinitions(
+        options({ baseUrl: bad, fetcher: new NodeFetcher() }),
+      );
+      expect(loaded.source, bad).toBe("snapshot");
+    }
+  });
+});
+
+describe("notAfter is an instant, not a string", () => {
+  // Comparing ISO-8601 as strings looked fine and was not. Each case below
+  // is a key that IS expired by Date.parse but sorted as unexpired.
+  const bytes = bundleBytes(10);
+
+  async function accepted(notAfter: string, now: string): Promise<boolean> {
+    const key = keypair();
+    const loaded = await loadDefinitions(
+      options({
+        publisherKeys: [{ id: "old", publicKey: key.raw, notAfter }],
+        now,
+        fetcher: fetcher({
+          [BODY_URL]: { status: "ok", bytes },
+          [SIG_URL]: { status: "ok", bytes: key.sign(bytes) },
+        }),
+      }),
+    );
+    return loaded.source === "remote";
+  }
+
+  it("rejects a key whose expiry carries a UTC offset", async () => {
+    expect(await accepted("2026-09-08T00:00:00+09:00", "2026-09-07T20:00:00.000Z")).toBe(false);
+  });
+
+  it("rejects a second-precision expiry against a millisecond clock", async () => {
+    expect(await accepted("2026-09-08T00:00:00Z", "2026-09-08T00:00:00.500Z")).toBe(false);
+  });
+
+  it("rejects an unpadded expiry, which sorted after everything", async () => {
+    // The worst of them: a key revoked 2026-09-08, written with one missing
+    // zero, stayed honoured months past revocation.
+    expect(await accepted("2026-9-8", "2026-12-20T00:00:00.000Z")).toBe(false);
+  });
+
+  it("treats an UNPARSEABLE expiry as expired, not as no-expiry", async () => {
+    // Failing open here would mean a typo in a revocation silently grants the
+    // key eternal life.
+    expect(await accepted("revoked", "2026-09-08T00:00:00.000Z")).toBe(false);
+  });
+
+  it("still accepts a key that genuinely has not expired", async () => {
+    expect(await accepted("2027-01-01T00:00:00.000Z", "2026-09-08T00:00:00.000Z")).toBe(true);
+  });
+});
+
+describe("anti-rollback cannot be disabled by a bad floor", () => {
+  it("ignores a non-integer floor rather than treating it as no floor", async () => {
+    // The persistence that produces this value lands next; a parseInt on a
+    // truncated ledger file yields NaN, which must not switch the defence off.
+    const key = keypair();
+    const bytes = bundleBytes(2);
+    for (const floor of [Number.NaN, 1.5, "30" as unknown as number]) {
+      const loaded = await loadDefinitions(
+        options({
+          publisherKeys: [{ id: "k1", publicKey: key.raw }],
+          highestSeenBundleNumber: floor,
+          fetcher: fetcher({
+            [BODY_URL]: { status: "ok", bytes },
+            [SIG_URL]: { status: "ok", bytes: key.sign(bytes) },
+          }),
+        }),
+      );
+      // A garbage floor must not silently ACCEPT what a real floor rejects.
+      // With no usable floor the bundle is taken on its signature alone,
+      // which is the documented behaviour when no floor exists at all.
+      expect(loaded.source, String(floor)).toBe("remote");
+    }
+    // And a real floor still rejects the same bundle.
+    const guarded = await loadDefinitions(
+      options({
+        publisherKeys: [{ id: "k1", publicKey: key.raw }],
+        highestSeenBundleNumber: 30,
+        fetcher: fetcher({
+          [BODY_URL]: { status: "ok", bytes },
+          [SIG_URL]: { status: "ok", bytes: key.sign(bytes) },
+        }),
+      }),
+    );
+    expect(guarded.source).toBe("snapshot");
   });
 });
 
@@ -358,5 +476,139 @@ describe("key rotation", () => {
       }),
     );
     expect(loaded.source).toBe("snapshot");
+  });
+});
+
+describe("cross-signed key rotation (design.md D7)", () => {
+  // The reason definitions are remote at all is that they change without an
+  // app release. A compiled-in key list with expiry dates does not rotate
+  // anything: introducing a key still needs a new binary. A transition
+  // statement signed by BOTH the outgoing and incoming keys does.
+  const b64 = (bytes: Uint8Array) => Buffer.from(bytes).toString("base64");
+
+  function statement(from: Uint8Array, to: Uint8Array, over: Record<string, unknown> = {}) {
+    return new TextEncoder().encode(
+      JSON.stringify({
+        fromKey: b64(from),
+        toKey: b64(to),
+        toKeyId: "k2",
+        effectiveFrom: "2026-01-01T00:00:00.000Z",
+        ...over,
+      }),
+    );
+  }
+
+  it("trusts a bundle signed by the INCOMING key once the statement verifies", async () => {
+    const outgoing = keypair();
+    const incoming = keypair();
+    const doc = statement(outgoing.raw, incoming.raw);
+    const bytes = bundleBytes(11);
+    const loaded = await loadDefinitions(
+      options({
+        publisherKeys: [{ id: "k1", publicKey: outgoing.raw }],
+        transition: {
+          bytes: doc,
+          signature: outgoing.sign(doc),
+          counterSignature: incoming.sign(doc),
+        },
+        fetcher: fetcher({
+          [BODY_URL]: { status: "ok", bytes },
+          [SIG_URL]: { status: "ok", bytes: incoming.sign(bytes) },
+        }),
+      }),
+    );
+    expect(loaded.source).toBe("remote");
+  });
+
+  it("refuses a statement the incoming key did not counter-sign", async () => {
+    // Cross-signing is what stops a STOLEN outgoing key installing a public
+    // key whose private half the thief does not hold.
+    const outgoing = keypair();
+    const incoming = keypair();
+    const doc = statement(outgoing.raw, incoming.raw);
+    const bytes = bundleBytes(11);
+    const loaded = await loadDefinitions(
+      options({
+        publisherKeys: [{ id: "k1", publicKey: outgoing.raw }],
+        transition: { bytes: doc, signature: outgoing.sign(doc) },
+        fetcher: fetcher({
+          [BODY_URL]: { status: "ok", bytes },
+          [SIG_URL]: { status: "ok", bytes: incoming.sign(bytes) },
+        }),
+      }),
+    );
+    expect(loaded.source).toBe("snapshot");
+  });
+
+  it("refuses a statement whose outgoing key this build does not already trust", async () => {
+    // Otherwise a statement bootstraps trust from nothing.
+    const stranger = keypair();
+    const incoming = keypair();
+    const known = keypair();
+    const doc = statement(stranger.raw, incoming.raw);
+    const bytes = bundleBytes(11);
+    const loaded = await loadDefinitions(
+      options({
+        publisherKeys: [{ id: "k1", publicKey: known.raw }],
+        transition: {
+          bytes: doc,
+          signature: stranger.sign(doc),
+          counterSignature: incoming.sign(doc),
+        },
+        fetcher: fetcher({
+          [BODY_URL]: { status: "ok", bytes },
+          [SIG_URL]: { status: "ok", bytes: incoming.sign(bytes) },
+        }),
+      }),
+    );
+    expect(loaded.source).toBe("snapshot");
+  });
+
+  it("ignores a statement that is not yet effective", async () => {
+    const outgoing = keypair();
+    const incoming = keypair();
+    const doc = statement(outgoing.raw, incoming.raw, {
+      effectiveFrom: "2099-01-01T00:00:00.000Z",
+    });
+    const bytes = bundleBytes(11);
+    const loaded = await loadDefinitions(
+      options({
+        publisherKeys: [{ id: "k1", publicKey: outgoing.raw }],
+        transition: {
+          bytes: doc,
+          signature: outgoing.sign(doc),
+          counterSignature: incoming.sign(doc),
+        },
+        fetcher: fetcher({
+          [BODY_URL]: { status: "ok", bytes },
+          [SIG_URL]: { status: "ok", bytes: incoming.sign(bytes) },
+        }),
+      }),
+    );
+    expect(loaded.source).toBe("snapshot");
+  });
+
+  it("ignores a malformed statement without disturbing the compiled-in keys", async () => {
+    const outgoing = keypair();
+    const bytes = bundleBytes(11);
+    for (const doc of [
+      new Uint8Array([0xff, 0xfe]),
+      new TextEncoder().encode("{not json"),
+      new TextEncoder().encode(JSON.stringify({ fromKey: 1 })),
+      new TextEncoder().encode(JSON.stringify({ fromKey: "!!", toKey: "!!", toKeyId: "x", effectiveFrom: "2026-01-01T00:00:00.000Z" })),
+    ]) {
+      const loaded = await loadDefinitions(
+        options({
+          publisherKeys: [{ id: "k1", publicKey: outgoing.raw }],
+          transition: { bytes: doc, signature: outgoing.sign(doc), counterSignature: outgoing.sign(doc) },
+          fetcher: fetcher({
+            [BODY_URL]: { status: "ok", bytes },
+            [SIG_URL]: { status: "ok", bytes: outgoing.sign(bytes) },
+          }),
+        }),
+      );
+      // The compiled-in key still works; the statement simply did nothing.
+      expect(loaded.source).toBe("remote");
+    }
   });
 });

--- a/packages/core/__tests__/definitions-feed.test.ts
+++ b/packages/core/__tests__/definitions-feed.test.ts
@@ -1,0 +1,362 @@
+import { describe, expect, it } from "vitest";
+import { generateKeyPairSync, sign as signEd } from "node:crypto";
+import { loadDefinitions } from "../src/definitions/feed.js";
+import type { FeedOptions, PublisherKey } from "../src/definitions/feed.js";
+import { NodeSignatureVerifier } from "../src/definitions/providers-node.js";
+import type { FetchResult, Fetcher } from "../src/definitions/providers.js";
+import { toBundle } from "../src/definitions/bundle.js";
+import { SURFACES, getSurface } from "../src/surfaces/registry.js";
+
+/**
+ * The definitions feed (AC-25, ADR 0004). This data names config-store paths
+ * and installer binaries, so these tests use REAL Ed25519 keys and a real
+ * verifier — a stub verifier would prove nothing about the one property that
+ * matters.
+ */
+
+const MATRIX = { "claude-code": { "mcp-server": { read: "native" } } };
+
+function bundleBytes(bundleNumber: number, surfaces = SURFACES): Uint8Array {
+  return new TextEncoder().encode(
+    JSON.stringify(toBundle({ bundleNumber, surfaces, capabilityMatrix: MATRIX })),
+  );
+}
+
+/** A real keypair; `raw` is the 32-byte public key the feed compares against. */
+function keypair() {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const der = publicKey.export({ format: "der", type: "spki" }) as Buffer;
+  return {
+    privateKey,
+    raw: new Uint8Array(der.subarray(der.length - 32)),
+    sign: (bytes: Uint8Array) => new Uint8Array(signEd(null, bytes, privateKey)),
+  };
+}
+
+/** Serves a fixed map of URL → result. */
+function fetcher(routes: Record<string, FetchResult>): Fetcher {
+  return {
+    async get(url) {
+      return routes[url] ?? { status: "not-found" };
+    },
+  };
+}
+
+const BASE = "https://harnesskit.ai/definitions/v1";
+const BODY_URL = `${BASE}/definitions.json`;
+const SIG_URL = `${BASE}/definitions.json.sig`;
+
+function options(over: Partial<FeedOptions> = {}): FeedOptions {
+  return {
+    fetcher: fetcher({}),
+    verifier: new NodeSignatureVerifier(),
+    baseUrl: BASE,
+    publisherKeys: [],
+    snapshot: toBundle({ bundleNumber: 1, surfaces: SURFACES, capabilityMatrix: MATRIX }),
+    now: "2026-09-08T00:00:00.000Z",
+    ...over,
+  };
+}
+
+describe("a correctly signed bundle is accepted", () => {
+  it("uses the remote definitions and reports no fallback", async () => {
+    const key = keypair();
+    const bytes = bundleBytes(7);
+    const loaded = await loadDefinitions(
+      options({
+        publisherKeys: [{ id: "k1", publicKey: key.raw }],
+        fetcher: fetcher({
+          [BODY_URL]: { status: "ok", bytes },
+          [SIG_URL]: { status: "ok", bytes: key.sign(bytes) },
+        }),
+      }),
+    );
+    expect(loaded.source).toBe("remote");
+    expect(loaded.reason).toBeUndefined();
+    expect(loaded.bundle.bundleNumber).toBe(7);
+  });
+
+  it("carries a CHANGED config path through, which is the point of the feed (AC-26)", async () => {
+    // A path moving without an app release is the reason this exists.
+    const moved = SURFACES.map((surface) =>
+      surface.id !== "claude-code"
+        ? surface
+        : {
+            ...surface,
+            stores: surface.stores.map((store) =>
+              store.kind === "mcp-server" && store.scope === "user"
+                ? { ...store, path: ".claude/moved-mcp.json" }
+                : store,
+            ),
+          },
+    );
+    const key = keypair();
+    const bytes = bundleBytes(8, moved);
+    const loaded = await loadDefinitions(
+      options({
+        publisherKeys: [{ id: "k1", publicKey: key.raw }],
+        fetcher: fetcher({
+          [BODY_URL]: { status: "ok", bytes },
+          [SIG_URL]: { status: "ok", bytes: key.sign(bytes) },
+        }),
+      }),
+    );
+    expect(loaded.source).toBe("remote");
+    const store = loaded.bundle.surfaces
+      .find((s) => s.id === "claude-code")
+      ?.stores.find((s) => s.kind === "mcp-server" && s.scope === "user");
+    expect(store?.path).toBe(".claude/moved-mcp.json");
+    // The compiled-in registry is untouched — the feed does not mutate it.
+    expect(
+      getSurface("claude-code").stores.find((s) => s.kind === "mcp-server" && s.scope === "user")
+        ?.path,
+    ).toBe(".claude.json");
+  });
+});
+
+describe("an unverifiable bundle never reaches the parser", () => {
+  it("rejects a signature from a key this build does not know", async () => {
+    const publisher = keypair();
+    const attacker = keypair();
+    const bytes = bundleBytes(9);
+    const loaded = await loadDefinitions(
+      options({
+        publisherKeys: [{ id: "k1", publicKey: publisher.raw }],
+        fetcher: fetcher({
+          [BODY_URL]: { status: "ok", bytes },
+          [SIG_URL]: { status: "ok", bytes: attacker.sign(bytes) },
+        }),
+      }),
+    );
+    expect(loaded.source).toBe("snapshot");
+    expect(loaded.reason).toContain("did not verify");
+  });
+
+  it("rejects a body altered after signing, by a single byte", async () => {
+    const key = keypair();
+    const bytes = bundleBytes(9);
+    const signature = key.sign(bytes);
+    const tampered = Uint8Array.from(bytes);
+    tampered[tampered.length - 2] ^= 0x01;
+    const loaded = await loadDefinitions(
+      options({
+        publisherKeys: [{ id: "k1", publicKey: key.raw }],
+        fetcher: fetcher({
+          [BODY_URL]: { status: "ok", bytes: tampered },
+          [SIG_URL]: { status: "ok", bytes: signature },
+        }),
+      }),
+    );
+    expect(loaded.source).toBe("snapshot");
+  });
+
+  it("does not parse the payload when the signature fails", async () => {
+    // Verification precedes decoding on purpose: parsing first would run the
+    // JSON parser and every bundle validator over attacker-controlled bytes.
+    // Unsigned garbage that would CRASH the decoder must be refused for the
+    // signature, not survive to reach it.
+    const key = keypair();
+    const attacker = keypair();
+    const junk = new TextEncoder().encode("{".repeat(50_000));
+    const loaded = await loadDefinitions(
+      options({
+        publisherKeys: [{ id: "k1", publicKey: key.raw }],
+        fetcher: fetcher({
+          [BODY_URL]: { status: "ok", bytes: junk },
+          [SIG_URL]: { status: "ok", bytes: attacker.sign(junk) },
+        }),
+      }),
+    );
+    expect(loaded.source).toBe("snapshot");
+    expect(loaded.reason).toContain("did not verify");
+    expect(loaded.reason).not.toContain("JSON");
+  });
+
+  it("treats a malformed key as a failed verification, not an exception", async () => {
+    const key = keypair();
+    const bytes = bundleBytes(9);
+    const loaded = await loadDefinitions(
+      options({
+        publisherKeys: [{ id: "bad", publicKey: new Uint8Array([1, 2, 3]) }],
+        fetcher: fetcher({
+          [BODY_URL]: { status: "ok", bytes },
+          [SIG_URL]: { status: "ok", bytes: key.sign(bytes) },
+        }),
+      }),
+    );
+    expect(loaded.source).toBe("snapshot");
+  });
+});
+
+describe("anti-rollback", () => {
+  it("refuses a genuinely signed OLDER bundle", async () => {
+    // The attack a signature alone does not stop: replay a real, correctly
+    // signed bundle from before a path or permission was tightened.
+    const key = keypair();
+    const bytes = bundleBytes(3);
+    const loaded = await loadDefinitions(
+      options({
+        publisherKeys: [{ id: "k1", publicKey: key.raw }],
+        highestSeenBundleNumber: 12,
+        fetcher: fetcher({
+          [BODY_URL]: { status: "ok", bytes },
+          [SIG_URL]: { status: "ok", bytes: key.sign(bytes) },
+        }),
+      }),
+    );
+    expect(loaded.source).toBe("snapshot");
+    expect(loaded.reason).toContain("refusing a rollback");
+  });
+
+  it("accepts the same number again, which is a re-fetch and not a rollback", async () => {
+    const key = keypair();
+    const bytes = bundleBytes(12);
+    const loaded = await loadDefinitions(
+      options({
+        publisherKeys: [{ id: "k1", publicKey: key.raw }],
+        highestSeenBundleNumber: 12,
+        fetcher: fetcher({
+          [BODY_URL]: { status: "ok", bytes },
+          [SIG_URL]: { status: "ok", bytes: key.sign(bytes) },
+        }),
+      }),
+    );
+    expect(loaded.source).toBe("remote");
+  });
+
+  it("takes the floor from the machine's history, not from the cache", async () => {
+    // A cache an attacker can DELETE must not also reset the rollback floor.
+    const key = keypair();
+    const old = bundleBytes(2);
+    const loaded = await loadDefinitions(
+      options({
+        publisherKeys: [{ id: "k1", publicKey: key.raw }],
+        highestSeenBundleNumber: 30,
+        cached: undefined,
+        fetcher: fetcher({
+          [BODY_URL]: { status: "ok", bytes: old },
+          [SIG_URL]: { status: "ok", bytes: key.sign(old) },
+        }),
+      }),
+    );
+    expect(loaded.source).toBe("snapshot");
+    expect(loaded.reason).toContain("refusing a rollback");
+  });
+});
+
+describe("falling back, and saying so (AC-25)", () => {
+  it("uses the cache when the feed is unreachable", async () => {
+    const key = keypair();
+    const bytes = bundleBytes(5);
+    const loaded = await loadDefinitions(
+      options({
+        publisherKeys: [{ id: "k1", publicKey: key.raw }],
+        cached: { bytes, signature: key.sign(bytes) },
+        fetcher: fetcher({
+          [BODY_URL]: { status: "failed", reason: "getaddrinfo ENOTFOUND" },
+          [SIG_URL]: { status: "failed", reason: "getaddrinfo ENOTFOUND" },
+        }),
+      }),
+    );
+    expect(loaded.source).toBe("cache");
+    expect(loaded.reason).toContain("could not be reached");
+    expect(loaded.bundle.bundleNumber).toBe(5);
+  });
+
+  it("RE-VERIFIES the cache rather than trusting it", async () => {
+    // The cache is a file any process running as this user can rewrite.
+    const key = keypair();
+    const attacker = keypair();
+    const bytes = bundleBytes(5);
+    const loaded = await loadDefinitions(
+      options({
+        publisherKeys: [{ id: "k1", publicKey: key.raw }],
+        cached: { bytes, signature: attacker.sign(bytes) },
+        fetcher: fetcher({ [BODY_URL]: { status: "not-found" }, [SIG_URL]: { status: "not-found" } }),
+      }),
+    );
+    expect(loaded.source).toBe("snapshot");
+    expect(loaded.reason).toContain("cached definitions are unusable");
+  });
+
+  it("always states the reason when it is not using remote definitions", async () => {
+    const loaded = await loadDefinitions(options());
+    expect(loaded.source).toBe("snapshot");
+    expect(loaded.reason).toBeTypeOf("string");
+    expect((loaded.reason as string).length).toBeGreaterThan(0);
+  });
+
+  it("refuses a non-https feed without fetching anything", async () => {
+    let called = false;
+    const loaded = await loadDefinitions(
+      options({
+        baseUrl: "http://harnesskit.ai/definitions/v1",
+        fetcher: {
+          async get() {
+            called = true;
+            return { status: "not-found" };
+          },
+        },
+      }),
+    );
+    expect(loaded.source).toBe("snapshot");
+    expect(loaded.reason).toContain("not https");
+    expect(called).toBe(false);
+  });
+
+  it("never throws, whatever the feed does", async () => {
+    for (const result of [
+      { status: "failed", reason: "boom" } as const,
+      { status: "not-found" } as const,
+      { status: "ok", bytes: new Uint8Array([0xff, 0xfe]) } as const,
+    ]) {
+      const loaded = await loadDefinitions(
+        options({ fetcher: fetcher({ [BODY_URL]: result, [SIG_URL]: result }) }),
+      );
+      expect(loaded.source).toBe("snapshot");
+    }
+  });
+});
+
+describe("key rotation", () => {
+  const bytesFor = (n: number) => bundleBytes(n);
+
+  it("still accepts a bundle signed by an outgoing key before it expires", async () => {
+    const outgoing = keypair();
+    const incoming = keypair();
+    const bytes = bytesFor(10);
+    const keys: PublisherKey[] = [
+      { id: "old", publicKey: outgoing.raw, notAfter: "2026-12-01T00:00:00.000Z" },
+      { id: "new", publicKey: incoming.raw },
+    ];
+    const loaded = await loadDefinitions(
+      options({
+        publisherKeys: keys,
+        now: "2026-09-08T00:00:00.000Z",
+        fetcher: fetcher({
+          [BODY_URL]: { status: "ok", bytes },
+          [SIG_URL]: { status: "ok", bytes: outgoing.sign(bytes) },
+        }),
+      }),
+    );
+    expect(loaded.source).toBe("remote");
+  });
+
+  it("stops accepting that key once it has expired", async () => {
+    const outgoing = keypair();
+    const bytes = bytesFor(10);
+    const loaded = await loadDefinitions(
+      options({
+        publisherKeys: [
+          { id: "old", publicKey: outgoing.raw, notAfter: "2026-01-01T00:00:00.000Z" },
+        ],
+        now: "2026-09-08T00:00:00.000Z",
+        fetcher: fetcher({
+          [BODY_URL]: { status: "ok", bytes },
+          [SIG_URL]: { status: "ok", bytes: outgoing.sign(bytes) },
+        }),
+      }),
+    );
+    expect(loaded.source).toBe("snapshot");
+  });
+});

--- a/packages/core/__tests__/definitions-feed.test.ts
+++ b/packages/core/__tests__/definitions-feed.test.ts
@@ -311,12 +311,16 @@ describe("falling back, and saying so (AC-25)", () => {
     // nothing to do with the test's name.
     const key = keypair();
     const cases = [
-      { bytes: new Uint8Array([0xff, 0xfe]), label: "invalid UTF-8" },
-      { bytes: new TextEncoder().encode("{not json"), label: "invalid JSON" },
-      { bytes: new TextEncoder().encode("[]"), label: "JSON that is not a bundle" },
-      { bytes: new TextEncoder().encode(JSON.stringify({ formatVersion: 99 })), label: "a newer format" },
+      // Each case pins the reason to ITS OWN branch. Asserting only "not
+      // 'did not verify'" let the UTF-8 case pass with `fatal: true` removed:
+      // 0xff 0xfe became two replacement characters and fell through to the
+      // JSON branch, which the assertions could not tell apart.
+      { bytes: new Uint8Array([0xff, 0xfe]), label: "invalid UTF-8", expect: "not valid UTF-8" },
+      { bytes: new TextEncoder().encode("{not json"), label: "invalid JSON", expect: "not valid JSON" },
+      { bytes: new TextEncoder().encode("[]"), label: "JSON that is not a bundle", expect: "not usable by this build" },
+      { bytes: new TextEncoder().encode(JSON.stringify({ formatVersion: 99 })), label: "a newer format", expect: "not usable by this build" },
     ];
-    for (const { bytes, label } of cases) {
+    for (const { bytes, label, expect: fragment } of cases) {
       const loaded = await loadDefinitions(
         options({
           publisherKeys: [{ id: "k1", publicKey: key.raw }],
@@ -329,7 +333,7 @@ describe("falling back, and saying so (AC-25)", () => {
       expect(loaded.source, label).toBe("snapshot");
       // Reached the DECODER, not the signature check — that is the point.
       expect(loaded.reason, label).not.toContain("did not verify");
-      expect((loaded.reason ?? "").length, label).toBeGreaterThan(0);
+      expect(loaded.reason, label).toContain(fragment);
     }
 
     for (const result of [
@@ -340,6 +344,108 @@ describe("falling back, and saying so (AC-25)", () => {
         options({ fetcher: fetcher({ [BODY_URL]: result, [SIG_URL]: result }) }),
       );
       expect(loaded.source).toBe("snapshot");
+    }
+  });
+
+  it("degrades when an injected provider REJECTS instead of returning", async () => {
+    // Every case above supplies a well-behaved provider that returns a
+    // FetchResult. But these are interfaces the CALLER implements, and the
+    // next one planned is a Tauri `invoke` — which rejects whenever the Rust
+    // side returns Err. Nothing here caught that, so the one function whose
+    // whole purpose is degrading instead of crashing took the app down.
+    const key = keypair();
+    const bytes = bundleBytes(9);
+
+    const thrownFetcher = await loadDefinitions(
+      options({
+        fetcher: {
+          get: () => Promise.reject(new Error("invoke('fetch_definitions') failed")),
+        },
+      }),
+    );
+    expect(thrownFetcher.source).toBe("snapshot");
+    expect(thrownFetcher.reason).toContain("the fetcher threw");
+
+    const thrownVerifier = await loadDefinitions(
+      options({
+        publisherKeys: [{ id: "k1", publicKey: key.raw }],
+        verifier: {
+          verifyEd25519: () => Promise.reject(new Error("command not found")),
+        },
+        fetcher: fetcher({
+          [BODY_URL]: { status: "ok", bytes },
+          [SIG_URL]: { status: "ok", bytes: key.sign(bytes) },
+        }),
+      }),
+    );
+    expect(thrownVerifier.source).toBe("snapshot");
+    // A verifier that throws is a verifier that failed — no trust granted.
+    expect(thrownVerifier.reason).toContain("did not verify");
+
+    // A synchronous throw, not just a rejected promise.
+    const syncThrow = await loadDefinitions(
+      options({
+        fetcher: {
+          get: () => {
+            throw new Error("synchronous boom");
+          },
+        },
+      }),
+    );
+    expect(syncThrow.source).toBe("snapshot");
+  });
+
+  it("refuses a limit that would not bound the response, rather than substituting one", async () => {
+    // `NaN` compares false against every size, so `maxBytes: NaN` read an
+    // unbounded body; a timeoutMs past 2^31 collapses setTimeout to ~1ms.
+    // Both are the shape that made the rollback floor a no-op: a bad number
+    // silently disarming the control it configures.
+    for (const [field, value] of [
+      ["maxBytes", Number.NaN],
+      ["maxBytes", 0],
+      ["maxBytes", -1],
+      ["timeoutMs", Number.NaN],
+      ["timeoutMs", Number.POSITIVE_INFINITY],
+      ["timeoutMs", 2_147_483_648],
+    ] as const) {
+      let called = false;
+      const loaded = await loadDefinitions(
+        options({
+          [field]: value,
+          fetcher: {
+            get: () => {
+              called = true;
+              return Promise.resolve({ status: "not-found" as const });
+            },
+          },
+        }),
+      );
+      const label = `${field}=${String(value)}`;
+      expect(loaded.source, label).toBe("snapshot");
+      expect(loaded.reason, label).toContain(`unusable ${field}`);
+      expect(called, label).toBe(false);
+    }
+  });
+
+  it("refuses a clock it cannot read, rather than blaming the signature", async () => {
+    // A timezone-less `now` used to leave perpetual keys trusted while
+    // revoking every key that had a notAfter — a split failure, and the user
+    // was told the signature did not verify.
+    const key = keypair();
+    const bytes = bundleBytes(9);
+    for (const now of ["not a date", "2026-09-08T00:00:00", ""]) {
+      const loaded = await loadDefinitions(
+        options({
+          now,
+          publisherKeys: [{ id: "k1", publicKey: key.raw }],
+          fetcher: fetcher({
+            [BODY_URL]: { status: "ok", bytes },
+            [SIG_URL]: { status: "ok", bytes: key.sign(bytes) },
+          }),
+        }),
+      );
+      expect(loaded.source, now).toBe("snapshot");
+      expect(loaded.reason, now).toContain("UTC offset");
     }
   });
 
@@ -397,42 +503,106 @@ describe("notAfter is an instant, not a string", () => {
   it("still accepts a key that genuinely has not expired", async () => {
     expect(await accepted("2027-01-01T00:00:00.000Z", "2026-09-08T00:00:00.000Z")).toBe(true);
   });
+
+  it("refuses an expiry with no UTC offset, which the host timezone would resolve", async () => {
+    // `2026-09-08T00:00:00` is valid ISO-8601 and Date.parse reads it in the
+    // HOST's zone: the same key expired in Tokyo and stayed honoured in
+    // Honolulu 26 hours later, so a bundle verified on one machine and not
+    // its neighbour. Ambiguous is refused rather than guessed.
+    expect(await accepted("2026-09-08T00:00:00", "2026-09-08T02:00:00.000Z")).toBe(false);
+    expect(await accepted("2027-01-01T00:00:00", "2026-09-08T02:00:00.000Z")).toBe(false);
+  });
+
+  it("makes the notAfter boundary EXCLUSIVE, at the instant itself", async () => {
+    // RFC 5280 treats notAfter as inclusive; this does not. Pinned by test so
+    // the next reader finds the answer instead of re-deriving it.
+    const instant = "2026-09-08T00:00:00.000Z";
+    expect(await accepted(instant, instant)).toBe(false);
+    expect(await accepted(instant, "2026-09-07T23:59:59.999Z")).toBe(true);
+  });
+});
+
+describe("the verifier's key handling", () => {
+  // The DER lengths in the SPKI prefix are fixed for 32 bytes and OpenSSL
+  // ignores trailing data after the SEQUENCE, so an over-length key was
+  // silently truncated to its first 32 and ACCEPTED — infinitely many
+  // distinct key values acting as one key. Short keys failed on their own.
+  const verifier = new NodeSignatureVerifier();
+
+  it("refuses a public key that is not exactly 32 bytes", async () => {
+    const key = keypair();
+    const message = new TextEncoder().encode("definitions");
+    const signature = key.sign(message);
+
+    expect(await verifier.verifyEd25519(message, signature, key.raw)).toBe(true);
+
+    for (const extra of [1, 32, 4096]) {
+      const padded = new Uint8Array(key.raw.length + extra);
+      padded.set(key.raw);
+      expect(await verifier.verifyEd25519(message, signature, padded), `+${extra}`).toBe(false);
+    }
+    for (const short of [0, 31]) {
+      expect(await verifier.verifyEd25519(message, signature, key.raw.subarray(0, short))).toBe(
+        false,
+      );
+    }
+  });
+
+  it("returns false rather than throwing on a malformed signature", async () => {
+    const key = keypair();
+    const message = new TextEncoder().encode("definitions");
+    for (const length of [0, 1, 63, 65, 128]) {
+      expect(await verifier.verifyEd25519(message, new Uint8Array(length), key.raw)).toBe(false);
+    }
+  });
 });
 
 describe("anti-rollback cannot be disabled by a bad floor", () => {
-  it("ignores a non-integer floor rather than treating it as no floor", async () => {
-    // The persistence that produces this value lands next; a parseInt on a
-    // truncated ledger file yields NaN, which must not switch the defence off.
-    const key = keypair();
+  // An earlier version of this block asserted `toBe("remote")` for every
+  // garbage floor — it accepted the rollback under a title saying the defence
+  // could not be switched off, and under a comment saying the same. The
+  // assertion and the name were opposites, and the name was right.
+  const rollback = (floor: unknown, key: ReturnType<typeof keypair>) => {
     const bytes = bundleBytes(2);
-    for (const floor of [Number.NaN, 1.5, "30" as unknown as number]) {
-      const loaded = await loadDefinitions(
-        options({
-          publisherKeys: [{ id: "k1", publicKey: key.raw }],
-          highestSeenBundleNumber: floor,
-          fetcher: fetcher({
-            [BODY_URL]: { status: "ok", bytes },
-            [SIG_URL]: { status: "ok", bytes: key.sign(bytes) },
-          }),
-        }),
-      );
-      // A garbage floor must not silently ACCEPT what a real floor rejects.
-      // With no usable floor the bundle is taken on its signature alone,
-      // which is the documented behaviour when no floor exists at all.
-      expect(loaded.source, String(floor)).toBe("remote");
-    }
-    // And a real floor still rejects the same bundle.
-    const guarded = await loadDefinitions(
+    return loadDefinitions(
       options({
         publisherKeys: [{ id: "k1", publicKey: key.raw }],
-        highestSeenBundleNumber: 30,
+        highestSeenBundleNumber: floor as number,
         fetcher: fetcher({
           [BODY_URL]: { status: "ok", bytes },
           [SIG_URL]: { status: "ok", bytes: key.sign(bytes) },
         }),
       }),
     );
-    expect(guarded.source).toBe("snapshot");
+  };
+
+  it("REFUSES a rollback when the floor is present but unreadable", async () => {
+    // A truncated ledger yields NaN; a JSON round-trip yields "30". Neither
+    // is a floor of zero, and neither may mean "no protection" — a corrupt
+    // machine history is a reason to distrust a replayed bundle, not to wave
+    // it through. `n < NaN` is already false, which is why the previous
+    // `Number.isInteger` guard did nothing for the case it was written for.
+    const key = keypair();
+    for (const floor of [Number.NaN, 1.5, "30", -1, null]) {
+      const loaded = await rollback(floor, key);
+      expect(loaded.source, String(floor)).toBe("snapshot");
+      expect(loaded.reason, String(floor)).toContain("unreadable");
+    }
+  });
+
+  it("still refuses a rollback against a real floor, and says the number", async () => {
+    const key = keypair();
+    const loaded = await rollback(30, key);
+    expect(loaded.source).toBe("snapshot");
+    expect(loaded.reason).toContain("older than 30");
+  });
+
+  it("accepts the bundle when no floor is recorded at all", async () => {
+    // Absent is not the same as corrupt: a machine with no history yet has
+    // nothing to roll back from.
+    const key = keypair();
+    const loaded = await rollback(undefined, key);
+    expect(loaded.source).toBe("remote");
   });
 });
 
@@ -476,139 +646,5 @@ describe("key rotation", () => {
       }),
     );
     expect(loaded.source).toBe("snapshot");
-  });
-});
-
-describe("cross-signed key rotation (design.md D7)", () => {
-  // The reason definitions are remote at all is that they change without an
-  // app release. A compiled-in key list with expiry dates does not rotate
-  // anything: introducing a key still needs a new binary. A transition
-  // statement signed by BOTH the outgoing and incoming keys does.
-  const b64 = (bytes: Uint8Array) => Buffer.from(bytes).toString("base64");
-
-  function statement(from: Uint8Array, to: Uint8Array, over: Record<string, unknown> = {}) {
-    return new TextEncoder().encode(
-      JSON.stringify({
-        fromKey: b64(from),
-        toKey: b64(to),
-        toKeyId: "k2",
-        effectiveFrom: "2026-01-01T00:00:00.000Z",
-        ...over,
-      }),
-    );
-  }
-
-  it("trusts a bundle signed by the INCOMING key once the statement verifies", async () => {
-    const outgoing = keypair();
-    const incoming = keypair();
-    const doc = statement(outgoing.raw, incoming.raw);
-    const bytes = bundleBytes(11);
-    const loaded = await loadDefinitions(
-      options({
-        publisherKeys: [{ id: "k1", publicKey: outgoing.raw }],
-        transition: {
-          bytes: doc,
-          signature: outgoing.sign(doc),
-          counterSignature: incoming.sign(doc),
-        },
-        fetcher: fetcher({
-          [BODY_URL]: { status: "ok", bytes },
-          [SIG_URL]: { status: "ok", bytes: incoming.sign(bytes) },
-        }),
-      }),
-    );
-    expect(loaded.source).toBe("remote");
-  });
-
-  it("refuses a statement the incoming key did not counter-sign", async () => {
-    // Cross-signing is what stops a STOLEN outgoing key installing a public
-    // key whose private half the thief does not hold.
-    const outgoing = keypair();
-    const incoming = keypair();
-    const doc = statement(outgoing.raw, incoming.raw);
-    const bytes = bundleBytes(11);
-    const loaded = await loadDefinitions(
-      options({
-        publisherKeys: [{ id: "k1", publicKey: outgoing.raw }],
-        transition: { bytes: doc, signature: outgoing.sign(doc) },
-        fetcher: fetcher({
-          [BODY_URL]: { status: "ok", bytes },
-          [SIG_URL]: { status: "ok", bytes: incoming.sign(bytes) },
-        }),
-      }),
-    );
-    expect(loaded.source).toBe("snapshot");
-  });
-
-  it("refuses a statement whose outgoing key this build does not already trust", async () => {
-    // Otherwise a statement bootstraps trust from nothing.
-    const stranger = keypair();
-    const incoming = keypair();
-    const known = keypair();
-    const doc = statement(stranger.raw, incoming.raw);
-    const bytes = bundleBytes(11);
-    const loaded = await loadDefinitions(
-      options({
-        publisherKeys: [{ id: "k1", publicKey: known.raw }],
-        transition: {
-          bytes: doc,
-          signature: stranger.sign(doc),
-          counterSignature: incoming.sign(doc),
-        },
-        fetcher: fetcher({
-          [BODY_URL]: { status: "ok", bytes },
-          [SIG_URL]: { status: "ok", bytes: incoming.sign(bytes) },
-        }),
-      }),
-    );
-    expect(loaded.source).toBe("snapshot");
-  });
-
-  it("ignores a statement that is not yet effective", async () => {
-    const outgoing = keypair();
-    const incoming = keypair();
-    const doc = statement(outgoing.raw, incoming.raw, {
-      effectiveFrom: "2099-01-01T00:00:00.000Z",
-    });
-    const bytes = bundleBytes(11);
-    const loaded = await loadDefinitions(
-      options({
-        publisherKeys: [{ id: "k1", publicKey: outgoing.raw }],
-        transition: {
-          bytes: doc,
-          signature: outgoing.sign(doc),
-          counterSignature: incoming.sign(doc),
-        },
-        fetcher: fetcher({
-          [BODY_URL]: { status: "ok", bytes },
-          [SIG_URL]: { status: "ok", bytes: incoming.sign(bytes) },
-        }),
-      }),
-    );
-    expect(loaded.source).toBe("snapshot");
-  });
-
-  it("ignores a malformed statement without disturbing the compiled-in keys", async () => {
-    const outgoing = keypair();
-    const bytes = bundleBytes(11);
-    for (const doc of [
-      new Uint8Array([0xff, 0xfe]),
-      new TextEncoder().encode("{not json"),
-      new TextEncoder().encode(JSON.stringify({ fromKey: 1 })),
-      new TextEncoder().encode(JSON.stringify({ fromKey: "!!", toKey: "!!", toKeyId: "x", effectiveFrom: "2026-01-01T00:00:00.000Z" })),
-    ]) {
-      const loaded = await loadDefinitions(
-        options({
-          publisherKeys: [{ id: "k1", publicKey: outgoing.raw }],
-          transition: { bytes: doc, signature: outgoing.sign(doc), counterSignature: outgoing.sign(doc) },
-          fetcher: fetcher({
-            [BODY_URL]: { status: "ok", bytes },
-            [SIG_URL]: { status: "ok", bytes: outgoing.sign(bytes) },
-          }),
-        }),
-      );
-      // The compiled-in key still works; the statement simply did nothing.
-      expect(loaded.source).toBe("remote");
-    }
   });
 });

--- a/packages/core/__tests__/definitions-fetcher.test.ts
+++ b/packages/core/__tests__/definitions-fetcher.test.ts
@@ -101,7 +101,11 @@ describe("redirects", () => {
       new Response(null, { status: 302, headers: { location: "http://harnesskit.ai/x" } }),
     );
     const result = await fetcher.get("https://harnesskit.ai/definitions.json", limits);
-    expect(result.status).toBe("failed");
+    // Asserting only `status === "failed"` passed with the origin pin
+    // deleted: the recursive call's own non-https guard produced the same
+    // verdict, so the test never exercised the comparison it is named for.
+    // The reason is what tells the two guards apart.
+    expect(result.status === "failed" ? result.reason : "").toContain("off its own origin");
   });
 
   it("refuses a redirect with no target", async () => {
@@ -125,6 +129,33 @@ describe("redirects", () => {
     // The REASON is what distinguishes the deadline from the redirect bound:
     // with a per-hop timeout the chain would instead run out of hops, and an
     // elapsed-time assertion alone cannot tell those apart.
+    expect(result.status === "failed" ? result.reason : "").toContain("did not answer within");
+  });
+
+  it("ARMS the abort signal, so one hung request is cut off too", async () => {
+    // The test above passes entirely on the `remaining <= 0` check BETWEEN
+    // hops, so replacing `controller.abort()` with a no-op kept the whole
+    // suite green. A single request that never answers has no next hop to
+    // check: only the signal stops it. This stub honours the signal the way
+    // undici does, which is what makes the assertion meaningful.
+    let aborted = false;
+    vi.stubGlobal("fetch", (_url: string, init?: { signal?: AbortSignal }) => {
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          aborted = true;
+          const error = new Error("This operation was aborted");
+          error.name = "AbortError";
+          reject(error);
+        });
+      });
+    });
+    const started = Date.now();
+    const result = await fetcher.get("https://harnesskit.ai/definitions.json", {
+      maxBytes: 4096,
+      timeoutMs: 100,
+    });
+    expect(aborted).toBe(true);
+    expect(Date.now() - started).toBeLessThan(3_000);
     expect(result.status === "failed" ? result.reason : "").toContain("did not answer within");
   });
 });
@@ -168,11 +199,62 @@ describe("body caps", () => {
   });
 
   it("ignores a nonsense content-length and falls back to the read cap", async () => {
+    // `Number("not-a-number")` is NaN and `NaN > maxBytes` is already false,
+    // so this case passes with the `Number.isFinite` guard deleted. The guard
+    // exists for a literal `Infinity`, which is the case below.
     vi.stubGlobal("fetch", async () =>
       new Response("tiny", { status: 200, headers: { "content-length": "not-a-number" } }),
     );
     const result = await fetcher.get("https://harnesskit.ai/definitions.json", limits);
     expect(result.status).toBe("ok");
+  });
+
+  it("treats an Infinity content-length as unknown, deferring to the read cap", async () => {
+    // This is the case the isFinite guard actually changes: without it,
+    // `Infinity > maxBytes` rejects a body that in fact fits.
+    vi.stubGlobal("fetch", async () =>
+      new Response("tiny", { status: 200, headers: { "content-length": "Infinity" } }),
+    );
+    const result = await fetcher.get("https://harnesskit.ai/definitions.json", limits);
+    expect(result.status).toBe("ok");
+  });
+
+  it("still enforces the cap when the body arrives one byte at a time", async () => {
+    // A drip-fed body is the shape that made chunk RETENTION expensive: the
+    // cap counted bytes while every chunk stayed in an array, so 4 MiB of
+    // payload reached 2.2 GiB resident. The bytes-read cap must fire on this
+    // shape exactly as it does on large chunks.
+    //
+    // The memory fix itself is deliberately NOT asserted here. Measured under
+    // `node --expose-gc`, a 2 MiB drip cost 70-84 MiB retaining chunks and
+    // 1.9-20.4 MiB with one growing buffer — a real 4-40x win, but the lower
+    // figure swings by an order of magnitude with heap ordering and vitest
+    // does not run with `--expose-gc`. A threshold across that range would
+    // either flake or pass vacuously, which is worse than not asserting it.
+    const counter = { read: 0 };
+    const chunks = Array.from({ length: 200_000 }, () => new Uint8Array(1));
+    vi.stubGlobal("fetch", async () => streaming(chunks, counter));
+    const result = await fetcher.get("https://harnesskit.ai/definitions.json", {
+      maxBytes: 64 * 1024,
+      timeoutMs: 30_000,
+    });
+    expect(result.status).toBe("failed");
+    expect(result.status === "failed" ? result.reason : "").toContain("larger than");
+    // Stopped at the cap rather than draining all 200k chunks.
+    expect(counter.read).toBeLessThan(70 * 1024);
+  });
+
+  it("reassembles a drip-fed body byte-for-byte", async () => {
+    // Growing one buffer instead of concatenating chunks is only correct if
+    // the bytes still come back in order and intact.
+    const counter = { read: 0 };
+    const expected = new Uint8Array(200_000).map((_, index) => index % 251);
+    const chunks: Uint8Array[] = [];
+    for (let at = 0; at < expected.length; at += 7) chunks.push(expected.subarray(at, at + 7));
+    vi.stubGlobal("fetch", async () => streaming(chunks, counter));
+    const result = await fetcher.get("https://harnesskit.ai/definitions.json", limits);
+    expect(result.status).toBe("ok");
+    expect(result.status === "ok" ? Array.from(result.bytes) : []).toEqual(Array.from(expected));
   });
 
   it("returns a body that fits", async () => {

--- a/packages/core/__tests__/definitions-fetcher.test.ts
+++ b/packages/core/__tests__/definitions-fetcher.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NodeFetcher } from "../src/definitions/providers-node.js";
+
+/**
+ * `NodeFetcher`'s transport guarantees.
+ *
+ * These had NO test: every control could be deleted and the whole suite
+ * stayed green while the PR asserted each as a fact.
+ *
+ * `fetch` is stubbed rather than served, deliberately. What is under test is
+ * this class's own control flow — redirect bounding, cap enforcement while
+ * READING, deadline propagation — and a stub drives every branch faithfully.
+ * (Contrast the signature tests, which use real keys, because there the
+ * cryptography is the thing being checked rather than the plumbing.) A real
+ * server would need https, and adding a loopback-http exemption to production
+ * code to make a test easier is how a guarantee quietly stops holding.
+ */
+
+const fetcher = new NodeFetcher();
+const limits = { maxBytes: 2 * 1024 * 1024, timeoutMs: 5_000 };
+
+afterEach(() => vi.unstubAllGlobals());
+
+/** A Response whose body streams `chunks`, counting what is actually read. */
+function streaming(chunks: Uint8Array[], counter: { read: number }): Response {
+  let index = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (index >= chunks.length) return controller.close();
+      const chunk = chunks[index++];
+      counter.read += chunk.byteLength;
+      controller.enqueue(chunk);
+    },
+  });
+  return new Response(body, { status: 200 });
+}
+
+describe("transport refusals", () => {
+  it("refuses a non-https URL without connecting", async () => {
+    const spy = vi.fn();
+    vi.stubGlobal("fetch", spy);
+    const result = await fetcher.get("http://harnesskit.ai/definitions.json", limits);
+    expect(result.status).toBe("failed");
+    expect(result.status === "failed" ? result.reason : "").toContain("non-https");
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("degrades on a malformed URL instead of throwing", async () => {
+    // `new URL()` sat above the try, so a typo'd feed URL took the process
+    // down rather than falling back to the snapshot.
+    vi.stubGlobal("fetch", vi.fn());
+    for (const bad of ["https://[", "https://a b.com/x", "https://%zz/x"]) {
+      const result = await fetcher.get(bad, limits);
+      expect(result.status, bad).toBe("failed");
+    }
+  });
+});
+
+describe("redirects", () => {
+  it("stops a same-origin LOOP rather than following it forever", async () => {
+    // The origin pin means a self-referential 302 is the one redirect this
+    // follows — the shape of an infinite loop, reachable from a single CDN
+    // misconfiguration with no attacker involved. Unbounded recursion spun
+    // 100k hops in 156ms, leaking a timer and a controller per hop.
+    let hops = 0;
+    vi.stubGlobal("fetch", async (url: string) => {
+      hops += 1;
+      return new Response(null, { status: 302, headers: { location: url } });
+    });
+    const result = await fetcher.get("https://harnesskit.ai/definitions.json", limits);
+    expect(result.status).toBe("failed");
+    expect(result.status === "failed" ? result.reason : "").toContain("too many times");
+    expect(hops).toBeLessThan(20);
+  });
+
+  it("follows a bounded number of same-origin hops", async () => {
+    let hops = 0;
+    vi.stubGlobal("fetch", async () => {
+      hops += 1;
+      return hops < 3
+        ? new Response(null, {
+            status: 302,
+            headers: { location: `https://harnesskit.ai/hop${hops}` },
+          })
+        : new Response("done", { status: 200 });
+    });
+    const result = await fetcher.get("https://harnesskit.ai/definitions.json", limits);
+    expect(result.status).toBe("ok");
+  });
+
+  it("refuses a redirect that leaves the origin", async () => {
+    vi.stubGlobal("fetch", async () =>
+      new Response(null, { status: 302, headers: { location: "https://evil.example/x" } }),
+    );
+    const result = await fetcher.get("https://harnesskit.ai/definitions.json", limits);
+    expect(result.status === "failed" ? result.reason : "").toContain("off its own origin");
+  });
+
+  it("refuses an https to http downgrade on the same host", async () => {
+    vi.stubGlobal("fetch", async () =>
+      new Response(null, { status: 302, headers: { location: "http://harnesskit.ai/x" } }),
+    );
+    const result = await fetcher.get("https://harnesskit.ai/definitions.json", limits);
+    expect(result.status).toBe("failed");
+  });
+
+  it("refuses a redirect with no target", async () => {
+    vi.stubGlobal("fetch", async () => new Response(null, { status: 302 }));
+    const result = await fetcher.get("https://harnesskit.ai/definitions.json", limits);
+    expect(result.status === "failed" ? result.reason : "").toContain("without a target");
+  });
+
+  it("bounds the whole chain by ONE deadline, not one per hop", async () => {
+    // A per-hop timeout bounds no chain: each hop resets it, so N hops take N
+    // times as long as the caller asked to wait.
+    vi.stubGlobal("fetch", async (url: string) => {
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      return new Response(null, { status: 302, headers: { location: url } });
+    });
+    const result = await fetcher.get("https://harnesskit.ai/definitions.json", {
+      maxBytes: 4096,
+      timeoutMs: 120,
+    });
+    expect(result.status).toBe("failed");
+    // The REASON is what distinguishes the deadline from the redirect bound:
+    // with a per-hop timeout the chain would instead run out of hops, and an
+    // elapsed-time assertion alone cannot tell those apart.
+    expect(result.status === "failed" ? result.reason : "").toContain("did not answer within");
+  });
+});
+
+describe("body caps", () => {
+  it("stops READING at the cap rather than buffering then complaining", async () => {
+    // `arrayBuffer()` read everything first: 1.5 GiB resident against a 2 MiB
+    // cap, from a response with no content-length so the header check was
+    // skipped entirely.
+    const counter = { read: 0 };
+    const chunk = new Uint8Array(16 * 1024);
+    const chunks = Array.from({ length: 512 }, () => chunk); // 8 MiB available
+    vi.stubGlobal("fetch", async () => streaming(chunks, counter));
+    const result = await fetcher.get("https://harnesskit.ai/definitions.json", {
+      maxBytes: 64 * 1024,
+      timeoutMs: 5_000,
+    });
+    expect(result.status).toBe("failed");
+    expect(result.status === "failed" ? result.reason : "").toContain("larger than");
+    // Read only a little past the cap, not the whole 8 MiB on offer.
+    expect(counter.read).toBeLessThan(256 * 1024);
+  });
+
+  it("honours content-length over the cap, even when the body would fit", async () => {
+    // The discriminator: a tiny body under a huge declared length. Reading it
+    // would SUCCEED, so a failure here can only come from the header check
+    // firing first. (Asserting "zero bytes read" is not observable — the
+    // Response constructor pulls the stream itself.)
+    vi.stubGlobal("fetch", async () =>
+      new Response("tiny", {
+        status: 200,
+        headers: { "content-length": String(10 * 1024 * 1024) },
+      }),
+    );
+    const result = await fetcher.get("https://harnesskit.ai/definitions.json", {
+      maxBytes: 4096,
+      timeoutMs: 5_000,
+    });
+    expect(result.status).toBe("failed");
+    expect(result.status === "failed" ? result.reason : "").toContain("larger than");
+  });
+
+  it("ignores a nonsense content-length and falls back to the read cap", async () => {
+    vi.stubGlobal("fetch", async () =>
+      new Response("tiny", { status: 200, headers: { "content-length": "not-a-number" } }),
+    );
+    const result = await fetcher.get("https://harnesskit.ai/definitions.json", limits);
+    expect(result.status).toBe("ok");
+  });
+
+  it("returns a body that fits", async () => {
+    vi.stubGlobal("fetch", async () => new Response('{"ok":true}', { status: 200 }));
+    const result = await fetcher.get("https://harnesskit.ai/definitions.json", limits);
+    expect(result.status).toBe("ok");
+    expect(
+      new TextDecoder().decode(result.status === "ok" ? result.bytes : new Uint8Array()),
+    ).toBe('{"ok":true}');
+  });
+});
+
+describe("status handling", () => {
+  it("reports 404 as not-found, distinct from a failure", async () => {
+    vi.stubGlobal("fetch", async () => new Response(null, { status: 404 }));
+    expect((await fetcher.get("https://harnesskit.ai/x", limits)).status).toBe("not-found");
+  });
+
+  it("reports another error status as failed, naming it", async () => {
+    vi.stubGlobal("fetch", async () => new Response(null, { status: 503 }));
+    const result = await fetcher.get("https://harnesskit.ai/x", limits);
+    expect(result.status === "failed" ? result.reason : "").toContain("503");
+  });
+
+  it("reports a thrown network error as failed rather than throwing", async () => {
+    vi.stubGlobal("fetch", async () => {
+      throw new TypeError("getaddrinfo ENOTFOUND harnesskit.ai");
+    });
+    const result = await fetcher.get("https://harnesskit.ai/x", limits);
+    expect(result.status).toBe("failed");
+    expect(result.status === "failed" ? result.reason : "").toContain("ENOTFOUND");
+  });
+});

--- a/packages/core/__tests__/dist-imports.test.ts
+++ b/packages/core/__tests__/dist-imports.test.ts
@@ -1,0 +1,77 @@
+import { readFileSync, statSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const coreRoot = fileURLToPath(new URL("..", import.meta.url));
+
+function newestMtime(dir: string): number {
+  let newest = 0;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    const mtime = entry.isDirectory() ? newestMtime(path) : statSync(path).mtimeMs;
+    if (mtime > newest) newest = mtime;
+  }
+  return newest;
+}
+
+/** dist is current when it exists and is newer than every source/config input. */
+function freshDist(name: string): string | null {
+  const artifact = join(coreRoot, "dist", name);
+  try {
+    const inputs = Math.max(
+      newestMtime(join(coreRoot, "src")),
+      statSync(join(coreRoot, "tsup.config.ts")).mtimeMs,
+    );
+    if (statSync(artifact).mtimeMs < inputs) return null;
+    return readFileSync(artifact, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Guards on the BUILT artifact, not on the source.
+ *
+ * Vitest runs the suite from source, so both failures this covers are
+ * invisible to every other test in the package:
+ *
+ * 1. A node builtin reaching `dist/index.js`. That entry is what the
+ *    desktop's webview loads, and a webview cannot resolve node builtins — a
+ *    bare `node:crypto` import in a core module already shipped four broken
+ *    routes in a packaged build. Source review does not catch it because the
+ *    offending import is legal TypeScript in a file that only the CLI is
+ *    supposed to reach; only the bundle shows what actually got pulled in.
+ * 2. tsup 8 stripping the `node:` prefix. That default turned `node:sqlite`
+ *    into a bare `sqlite` and broke every CLI command. `node:crypto` happens
+ *    to survive the rewrite under Node's own resolver, which makes it the
+ *    more dangerous case: it stays green here and fails under a bundler that
+ *    does not alias bare builtins.
+ *
+ * Skips rather than fails when dist is stale, so `vitest` alone in a fresh
+ * checkout is not a false alarm; CI builds before it tests.
+ */
+describe("built artifacts", () => {
+  it("keeps every node builtin out of the webview-reachable entry", () => {
+    const bundle = freshDist("index.js");
+    if (bundle === null) return;
+    const builtins = [...bundle.matchAll(/(?:from|import\()\s*"(node:[^"]+)"/g)].map((m) => m[1]);
+    expect(builtins).toEqual([]);
+  });
+
+  it("keeps the node: prefix on builtins in the node entry", () => {
+    const bundle = freshDist("node.js");
+    if (bundle === null) return;
+    // Bare specifiers for things that only exist as builtins — what the
+    // `removeNodeProtocol` default produces.
+    const bare = [...bundle.matchAll(/(?:from|import\()\s*"([^".][^"]*)"/g)]
+      .map((m) => m[1])
+      .filter((specifier) =>
+        ["crypto", "fs", "fs/promises", "path", "os", "child_process", "sqlite", "util"].includes(
+          specifier,
+        ),
+      );
+    expect(bare).toEqual([]);
+    expect(bundle).toContain('from "node:crypto"');
+  });
+});

--- a/packages/core/src/definitions/bundle.ts
+++ b/packages/core/src/definitions/bundle.ts
@@ -24,12 +24,10 @@ import { isRecord } from "../utils/is-record.js";
  * structural validation (`fromBundle`) of the JSON payload. In M1 the bundle
  * is loaded from disk or memory.
  *
- * Deliberately NOT here (all M4):
- * - remote fetch of the bundle;
- * - Ed25519 signature creation/verification (detached signatures, key
- *   rotation via cross-signed transition statements);
- * - monotonic `bundleNumber` anti-rollback enforcement — the field is carried
- *   from v1 so M4 can enforce it without a format bump.
+ * Deliberately NOT here — remote fetch, detached-signature verification and
+ * `bundleNumber` anti-rollback all live in `feed.ts` (M4). Key ROTATION is
+ * not built anywhere yet: see the trust-anchor note in `feed.ts` for why
+ * cross-signed transition statements were withdrawn rather than shipped.
  *
  * Open M4 design question: runtime-extensible surface ids. Today `fromBundle`
  * rejects any surface id outside the compiled `SURFACE_IDS` union, so a

--- a/packages/core/src/definitions/feed.ts
+++ b/packages/core/src/definitions/feed.ts
@@ -28,6 +28,15 @@ import type { Fetcher, SignatureVerifier } from "./providers.js";
  * The cache is re-verified on load rather than trusted. It sits in a file any
  * process running as the user can rewrite, so "we verified it when we stored
  * it" says nothing about what is there now.
+ *
+ * KNOWN RESIDUAL — no freshness bound. `generatedAt` is validated as
+ * parseable and then not used, so an attacker who can withhold updates pins a
+ * client on the newest bundle it ever saw for as long as they like.
+ * Anti-rollback stops movement backwards; nothing here notices standing
+ * still. design.md §7 does not call for a maximum age, so closing it is a
+ * deliberate future decision rather than an oversight — but it is the
+ * residual risk after anti-rollback, and it is written down here so the next
+ * reader does not have to rediscover it.
  */
 
 /** Where the definitions in force came from. */
@@ -78,6 +87,11 @@ export interface FeedOptions {
    * delete must not also reset the floor.
    */
   highestSeenBundleNumber?: number;
+  /**
+   * A cross-signed key-rotation statement, when one has been fetched or
+   * cached. Optional: without it only the compiled-in keys are trusted.
+   */
+  transition?: SignedArtifact & { counterSignature?: Uint8Array };
   /** Injected clock — core never reads the system clock. */
   now: string;
   /** Refuse a body larger than this. */
@@ -122,17 +136,36 @@ function errorText(error: unknown): string {
 }
 
 /**
- * Verify a detached signature against every key still valid at `now`.
+ * Whether a key is still usable at `now`.
  *
- * Trying each key is what makes rotation work: a bundle signed by the
- * outgoing key still verifies until that key's `notAfter` passes.
+ * Both sides go through `Date.parse`. Comparing ISO-8601 as STRINGS looked
+ * fine and was not: `2026-09-08T00:00:00+09:00` sorts after a `Z` instant it
+ * actually precedes, second precision loses to millisecond precision, and an
+ * unpadded `2026-9-8` sorts after everything — that last one kept a revoked
+ * key honoured for months. An unparseable `notAfter` is treated as EXPIRED
+ * rather than as "no expiry", so a typo in a revocation fails closed.
+ */
+function keyUsableAt(key: PublisherKey, now: string): boolean {
+  if (key.notAfter === undefined) return true;
+  const expires = Date.parse(key.notAfter);
+  const current = Date.parse(now);
+  if (Number.isNaN(expires)) return false;
+  if (Number.isNaN(current)) return false;
+  return current < expires;
+}
+
+/**
+ * Verify a detached signature against every key trusted right now — the keys
+ * compiled into this release, plus any key a verified transition statement
+ * has introduced (see `resolveTrustedKeys`).
  */
 async function verifyWithAnyKey(
   artifact: SignedArtifact,
+  keys: readonly PublisherKey[],
   options: FeedOptions,
 ): Promise<boolean> {
-  for (const key of options.publisherKeys) {
-    if (key.notAfter !== undefined && key.notAfter <= options.now) continue;
+  for (const key of keys) {
+    if (!keyUsableAt(key, options.now)) continue;
     if (await options.verifier.verifyEd25519(artifact.bytes, artifact.signature, key.publicKey)) {
       return true;
     }
@@ -141,21 +174,133 @@ async function verifyWithAnyKey(
 }
 
 /**
+ * A key-rotation transition statement (design.md D7).
+ *
+ * The document names the outgoing and incoming keys and is signed by BOTH:
+ * the outgoing signature proves the current publisher authorised the
+ * handover, and the incoming one proves whoever holds the new key
+ * participated, so a stolen outgoing key cannot install a public key its
+ * holder does not have the private half of.
+ *
+ * This is what makes rotation possible WITHOUT an app release, which is the
+ * whole reason definitions are remote. A compiled-in key list with expiry
+ * dates — which is what this shipped as first — still requires a new binary
+ * to introduce a key, and so does not rotate anything.
+ */
+export interface TransitionStatement {
+  /** Base64 of the raw 32-byte outgoing public key. */
+  fromKey: string;
+  /** Base64 of the raw 32-byte incoming public key. */
+  toKey: string;
+  /** Identifier for the incoming key. */
+  toKeyId: string;
+  /** ISO-8601; the statement is ignored before this instant. */
+  effectiveFrom: string;
+}
+
+function decodeBase64(value: string): Uint8Array | null {
+  if (!/^[A-Za-z0-9+/]*={0,2}$/.test(value) || value.length % 4 !== 0) return null;
+  try {
+    const binary = atob(value);
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index += 1) bytes[index] = binary.charCodeAt(index);
+    return bytes.length === 32 ? bytes : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Byte-compare two keys without leaking a position through early exit. */
+function sameKey(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.length !== right.length) return false;
+  let difference = 0;
+  for (let index = 0; index < left.length; index += 1) difference |= left[index] ^ right[index];
+  return difference === 0;
+}
+
+/**
+ * Resolve the keys to trust for this load: the compiled-in set, plus any key
+ * a valid transition statement introduces.
+ *
+ * A statement is accepted only when its `fromKey` is a key this build already
+ * trusts AND both signatures verify over the statement's exact bytes. An
+ * unverifiable statement is ignored silently — it is an attacker's opening
+ * move, not a condition worth reporting to a user.
+ */
+async function resolveTrustedKeys(options: FeedOptions): Promise<readonly PublisherKey[]> {
+  const statement = options.transition;
+  if (statement === undefined) return options.publisherKeys;
+
+  let parsed: TransitionStatement;
+  try {
+    const text = new TextDecoder("utf-8", { fatal: true }).decode(statement.bytes);
+    const value: unknown = JSON.parse(text);
+    if (value === null || typeof value !== "object") return options.publisherKeys;
+    const candidate = value as Partial<TransitionStatement>;
+    if (
+      typeof candidate.fromKey !== "string" ||
+      typeof candidate.toKey !== "string" ||
+      typeof candidate.toKeyId !== "string" ||
+      typeof candidate.effectiveFrom !== "string"
+    ) {
+      return options.publisherKeys;
+    }
+    parsed = candidate as TransitionStatement;
+  } catch {
+    return options.publisherKeys;
+  }
+
+  const effective = Date.parse(parsed.effectiveFrom);
+  const current = Date.parse(options.now);
+  if (Number.isNaN(effective) || Number.isNaN(current) || current < effective) {
+    return options.publisherKeys;
+  }
+
+  const from = decodeBase64(parsed.fromKey);
+  const to = decodeBase64(parsed.toKey);
+  if (from === null || to === null) return options.publisherKeys;
+
+  // The outgoing key must be one this build already trusts. Without that a
+  // statement could bootstrap trust from nothing.
+  const outgoing = options.publisherKeys.find(
+    (key) => sameKey(key.publicKey, from) && keyUsableAt(key, options.now),
+  );
+  if (outgoing === undefined) return options.publisherKeys;
+
+  // Cross-signed: BOTH halves must sign the same bytes.
+  const byOutgoing = await options.verifier.verifyEd25519(
+    statement.bytes,
+    statement.signature,
+    from,
+  );
+  const byIncoming =
+    statement.counterSignature !== undefined &&
+    (await options.verifier.verifyEd25519(statement.bytes, statement.counterSignature, to));
+  if (!byOutgoing || !byIncoming) return options.publisherKeys;
+
+  return [...options.publisherKeys, { id: parsed.toKeyId, publicKey: to }];
+}
+
+/**
  * Accept a signed artifact, or explain why not. Verification comes before
  * decoding, and the rollback check before the result is usable.
  */
 async function accept(
   artifact: SignedArtifact,
+  trustedKeys: readonly PublisherKey[],
   options: FeedOptions,
 ): Promise<{ bundle: DefinitionsBundle } | { reason: string }> {
-  if (!(await verifyWithAnyKey(artifact, options))) {
+  if (!(await verifyWithAnyKey(artifact, trustedKeys, options))) {
     return { reason: "the signature did not verify against any known publisher key" };
   }
   const decoded = decode(artifact.bytes);
   if ("reason" in decoded) return decoded;
 
+  // Only an integer floor disables nothing by accident. A NaN from a
+  // truncated ledger file would otherwise switch anti-rollback off silently,
+  // and the persistence that produces this value lands in the next commit.
   const floor = options.highestSeenBundleNumber;
-  if (floor !== undefined && decoded.bundle.bundleNumber < floor) {
+  if (floor !== undefined && Number.isInteger(floor) && decoded.bundle.bundleNumber < floor) {
     return {
       reason:
         `bundle ${decoded.bundle.bundleNumber} is older than ${floor}, which this machine has already accepted ` +
@@ -191,6 +336,8 @@ export async function loadDefinitions(options: FeedOptions): Promise<LoadedDefin
     maxBytes: options.maxBytes ?? DEFAULT_MAX_BYTES,
     timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
   };
+  // Resolved once per load, before anything is verified against them.
+  const trustedKeys = await resolveTrustedKeys(options);
   const base = options.baseUrl.replace(/\/+$/, "");
   const [body, signature] = await Promise.all([
     options.fetcher.get(`${base}/definitions.json`, limits),
@@ -199,7 +346,7 @@ export async function loadDefinitions(options: FeedOptions): Promise<LoadedDefin
 
   let remoteReason: string;
   if (body.status === "ok" && signature.status === "ok") {
-    const result = await accept({ bytes: body.bytes, signature: signature.bytes }, options);
+    const result = await accept({ bytes: body.bytes, signature: signature.bytes }, trustedKeys, options);
     if ("bundle" in result) return { bundle: result.bundle, source: "remote" };
     remoteReason = result.reason;
   } else {
@@ -213,7 +360,7 @@ export async function loadDefinitions(options: FeedOptions): Promise<LoadedDefin
   // The cache is re-verified, not trusted: it lives in a file any process
   // running as this user can rewrite.
   if (options.cached !== undefined) {
-    const result = await accept(options.cached, options);
+    const result = await accept(options.cached, trustedKeys, options);
     if ("bundle" in result) {
       return {
         bundle: result.bundle,

--- a/packages/core/src/definitions/feed.ts
+++ b/packages/core/src/definitions/feed.ts
@@ -1,6 +1,6 @@
 import { fromBundle, BundleError } from "./bundle.js";
 import type { DefinitionsBundle } from "./bundle.js";
-import type { Fetcher, SignatureVerifier } from "./providers.js";
+import type { FetchResult, Fetcher, SignatureVerifier } from "./providers.js";
 
 /**
  * The definitions feed (AC-25, AC-26, ADR 0004, design.md §7).
@@ -29,14 +29,32 @@ import type { Fetcher, SignatureVerifier } from "./providers.js";
  * process running as the user can rewrite, so "we verified it when we stored
  * it" says nothing about what is there now.
  *
+ * TRUST ANCHOR — compiled-in keys only. The set of keys that can authorise a
+ * bundle is fixed at build time; `notAfter` retires one, and only a new
+ * binary introduces one. That means key ROTATION still needs a release, and
+ * design.md D7 (cross-signed transition statements) is deliberately NOT
+ * implemented here. A first attempt at it was written and withdrawn: an
+ * attacker could replay the publisher's own statement to resurrect a revoked
+ * key, and revoking the outgoing key destroyed the incoming one with it, so
+ * rotation could not survive the event it exists for. Both follow from
+ * revocation semantics design.md §7 does not yet pin down — expiry and
+ * compromise are not the same thing and cannot share one `notAfter` field.
+ * That is a design decision to take deliberately, not a patch to land in a
+ * review round.
+ *
+ * Cross-signing, when it is built, proves POSSESSION of the incoming key. It
+ * is not theft protection: a thief holding a stolen publisher key generates
+ * their own second keypair and counter-signs with it. An earlier draft of
+ * this file claimed otherwise.
+ *
  * KNOWN RESIDUAL — no freshness bound. `generatedAt` is validated as
  * parseable and then not used, so an attacker who can withhold updates pins a
  * client on the newest bundle it ever saw for as long as they like.
  * Anti-rollback stops movement backwards; nothing here notices standing
- * still. design.md §7 does not call for a maximum age, so closing it is a
- * deliberate future decision rather than an oversight — but it is the
- * residual risk after anti-rollback, and it is written down here so the next
- * reader does not have to rediscover it.
+ * still. This matters more than it looks: freezing a client also freezes the
+ * arrival of a `notAfter`, which is currently the only way to retire a
+ * compromised key. Closing it is a prerequisite for rotation, not an
+ * independent nicety.
  */
 
 /** Where the definitions in force came from. */
@@ -88,19 +106,64 @@ export interface FeedOptions {
    */
   highestSeenBundleNumber?: number;
   /**
-   * A cross-signed key-rotation statement, when one has been fetched or
-   * cached. Optional: without it only the compiled-in keys are trusted.
+   * Injected clock — core never reads the system clock. MUST carry a UTC
+   * offset (`Z` or `±HH:MM`); see `keyUsableAt`.
    */
-  transition?: SignedArtifact & { counterSignature?: Uint8Array };
-  /** Injected clock — core never reads the system clock. */
   now: string;
-  /** Refuse a body larger than this. */
+  /**
+   * Refuse a body larger than this. A non-finite or non-positive value is
+   * refused rather than substituted: the one option whose whole purpose is
+   * bounding a hostile response must not be disarmed by a bad number.
+   */
   maxBytes?: number;
+  /** Deadline for the whole fetch. Same fail-closed rule as `maxBytes`. */
   timeoutMs?: number;
 }
 
 const DEFAULT_MAX_BYTES = 2 * 1024 * 1024;
 const DEFAULT_TIMEOUT_MS = 10_000;
+/**
+ * Largest value `setTimeout` honours. Past this it wraps to ~1 ms, so a
+ * caller asking for "effectively no timeout" gets the tightest possible
+ * deadline instead of the loosest.
+ */
+const MAX_TIMER_MS = 2_147_483_647;
+
+/**
+ * Call an injected provider without letting it throw.
+ *
+ * `Fetcher` and `SignatureVerifier` are interfaces the CALLER implements, so
+ * a non-conforming one is the ordinary case rather than the exotic one — the
+ * planned desktop verifier is a Tauri `invoke`, and `invoke` rejects whenever
+ * the Rust side returns `Err`. Nothing else in this module has a throwing
+ * path, so without these wrappers the single function documented to degrade
+ * instead of crashing is the one that takes the app down.
+ */
+async function fetchOrFail(
+  options: FeedOptions,
+  url: string,
+  limits: { maxBytes: number; timeoutMs: number },
+): Promise<FetchResult> {
+  try {
+    return await options.fetcher.get(url, limits);
+  } catch (error) {
+    return { status: "failed", reason: `the fetcher threw (${errorText(error)})` };
+  }
+}
+
+/** A verifier that throws is a verifier that failed: no signature, no trust. */
+async function verifyOrFalse(
+  options: FeedOptions,
+  message: Uint8Array,
+  signature: Uint8Array,
+  publicKey: Uint8Array,
+): Promise<boolean> {
+  try {
+    return await options.verifier.verifyEd25519(message, signature, publicKey);
+  } catch {
+    return false;
+  }
+}
 
 /** Decode verified bytes into a bundle, or explain why they are unusable. */
 function decode(bytes: Uint8Array): { bundle: DefinitionsBundle } | { reason: string } {
@@ -136,28 +199,43 @@ function errorText(error: unknown): string {
 }
 
 /**
- * Whether a key is still usable at `now`.
+ * Whether an instant string is absolute — ISO-8601 carrying a UTC offset.
  *
- * Both sides go through `Date.parse`. Comparing ISO-8601 as STRINGS looked
- * fine and was not: `2026-09-08T00:00:00+09:00` sorts after a `Z` instant it
- * actually precedes, second precision loses to millisecond precision, and an
- * unpadded `2026-9-8` sorts after everything — that last one kept a revoked
- * key honoured for months. An unparseable `notAfter` is treated as EXPIRED
- * rather than as "no expiry", so a typo in a revocation fails closed.
+ * `Date.parse` resolves an offset-less `2026-09-08T00:00:00` in the HOST's
+ * timezone, so the same `notAfter` expired in Tokyo and was still honoured in
+ * Honolulu 26 hours later, and a bundle verified on one machine and not its
+ * neighbour. Refusing the ambiguous form is the only way to keep this
+ * decision independent of where the user happens to be: core does not read
+ * the system clock, and it must not read the system timezone either.
  */
-function keyUsableAt(key: PublisherKey, now: string): boolean {
-  if (key.notAfter === undefined) return true;
-  const expires = Date.parse(key.notAfter);
-  const current = Date.parse(now);
-  if (Number.isNaN(expires)) return false;
-  if (Number.isNaN(current)) return false;
-  return current < expires;
+function isAbsoluteInstant(value: string): boolean {
+  return /(?:Z|[+-]\d{2}:\d{2})$/.test(value) && !Number.isNaN(Date.parse(value));
 }
 
 /**
- * Verify a detached signature against every key trusted right now — the keys
- * compiled into this release, plus any key a verified transition statement
- * has introduced (see `resolveTrustedKeys`).
+ * Whether a key is still usable at `now`.
+ *
+ * Every ambiguous or unparseable input fails CLOSED — treated as expired
+ * rather than as "no expiry" — so a typo in a revocation, a bad clock, or a
+ * timezone-dependent timestamp cannot keep a revoked key alive. Comparing
+ * ISO-8601 as STRINGS looked fine and was not: an unpadded `2026-9-8` sorts
+ * after everything, which kept a revoked key honoured for months.
+ *
+ * The boundary is EXCLUSIVE: a key is unusable at exactly its `notAfter`.
+ * That is stricter than RFC 5280, where `notAfter` is inclusive, and is
+ * pinned by test rather than left to be rediscovered.
+ */
+function keyUsableAt(key: PublisherKey, now: string): boolean {
+  if (!isAbsoluteInstant(now)) return false;
+  if (key.notAfter === undefined) return true;
+  if (!isAbsoluteInstant(key.notAfter)) return false;
+  return Date.parse(now) < Date.parse(key.notAfter);
+}
+
+/**
+ * Verify a detached signature against every key compiled into this release
+ * that is still usable at `options.now`. That set is the whole trust anchor:
+ * nothing at runtime can add a key to it.
  */
 async function verifyWithAnyKey(
   artifact: SignedArtifact,
@@ -166,119 +244,11 @@ async function verifyWithAnyKey(
 ): Promise<boolean> {
   for (const key of keys) {
     if (!keyUsableAt(key, options.now)) continue;
-    if (await options.verifier.verifyEd25519(artifact.bytes, artifact.signature, key.publicKey)) {
+    if (await verifyOrFalse(options, artifact.bytes, artifact.signature, key.publicKey)) {
       return true;
     }
   }
   return false;
-}
-
-/**
- * A key-rotation transition statement (design.md D7).
- *
- * The document names the outgoing and incoming keys and is signed by BOTH:
- * the outgoing signature proves the current publisher authorised the
- * handover, and the incoming one proves whoever holds the new key
- * participated, so a stolen outgoing key cannot install a public key its
- * holder does not have the private half of.
- *
- * This is what makes rotation possible WITHOUT an app release, which is the
- * whole reason definitions are remote. A compiled-in key list with expiry
- * dates — which is what this shipped as first — still requires a new binary
- * to introduce a key, and so does not rotate anything.
- */
-export interface TransitionStatement {
-  /** Base64 of the raw 32-byte outgoing public key. */
-  fromKey: string;
-  /** Base64 of the raw 32-byte incoming public key. */
-  toKey: string;
-  /** Identifier for the incoming key. */
-  toKeyId: string;
-  /** ISO-8601; the statement is ignored before this instant. */
-  effectiveFrom: string;
-}
-
-function decodeBase64(value: string): Uint8Array | null {
-  if (!/^[A-Za-z0-9+/]*={0,2}$/.test(value) || value.length % 4 !== 0) return null;
-  try {
-    const binary = atob(value);
-    const bytes = new Uint8Array(binary.length);
-    for (let index = 0; index < binary.length; index += 1) bytes[index] = binary.charCodeAt(index);
-    return bytes.length === 32 ? bytes : null;
-  } catch {
-    return null;
-  }
-}
-
-/** Byte-compare two keys without leaking a position through early exit. */
-function sameKey(left: Uint8Array, right: Uint8Array): boolean {
-  if (left.length !== right.length) return false;
-  let difference = 0;
-  for (let index = 0; index < left.length; index += 1) difference |= left[index] ^ right[index];
-  return difference === 0;
-}
-
-/**
- * Resolve the keys to trust for this load: the compiled-in set, plus any key
- * a valid transition statement introduces.
- *
- * A statement is accepted only when its `fromKey` is a key this build already
- * trusts AND both signatures verify over the statement's exact bytes. An
- * unverifiable statement is ignored silently — it is an attacker's opening
- * move, not a condition worth reporting to a user.
- */
-async function resolveTrustedKeys(options: FeedOptions): Promise<readonly PublisherKey[]> {
-  const statement = options.transition;
-  if (statement === undefined) return options.publisherKeys;
-
-  let parsed: TransitionStatement;
-  try {
-    const text = new TextDecoder("utf-8", { fatal: true }).decode(statement.bytes);
-    const value: unknown = JSON.parse(text);
-    if (value === null || typeof value !== "object") return options.publisherKeys;
-    const candidate = value as Partial<TransitionStatement>;
-    if (
-      typeof candidate.fromKey !== "string" ||
-      typeof candidate.toKey !== "string" ||
-      typeof candidate.toKeyId !== "string" ||
-      typeof candidate.effectiveFrom !== "string"
-    ) {
-      return options.publisherKeys;
-    }
-    parsed = candidate as TransitionStatement;
-  } catch {
-    return options.publisherKeys;
-  }
-
-  const effective = Date.parse(parsed.effectiveFrom);
-  const current = Date.parse(options.now);
-  if (Number.isNaN(effective) || Number.isNaN(current) || current < effective) {
-    return options.publisherKeys;
-  }
-
-  const from = decodeBase64(parsed.fromKey);
-  const to = decodeBase64(parsed.toKey);
-  if (from === null || to === null) return options.publisherKeys;
-
-  // The outgoing key must be one this build already trusts. Without that a
-  // statement could bootstrap trust from nothing.
-  const outgoing = options.publisherKeys.find(
-    (key) => sameKey(key.publicKey, from) && keyUsableAt(key, options.now),
-  );
-  if (outgoing === undefined) return options.publisherKeys;
-
-  // Cross-signed: BOTH halves must sign the same bytes.
-  const byOutgoing = await options.verifier.verifyEd25519(
-    statement.bytes,
-    statement.signature,
-    from,
-  );
-  const byIncoming =
-    statement.counterSignature !== undefined &&
-    (await options.verifier.verifyEd25519(statement.bytes, statement.counterSignature, to));
-  if (!byOutgoing || !byIncoming) return options.publisherKeys;
-
-  return [...options.publisherKeys, { id: parsed.toKeyId, publicKey: to }];
 }
 
 /**
@@ -296,16 +266,30 @@ async function accept(
   const decoded = decode(artifact.bytes);
   if ("reason" in decoded) return decoded;
 
-  // Only an integer floor disables nothing by accident. A NaN from a
-  // truncated ledger file would otherwise switch anti-rollback off silently,
-  // and the persistence that produces this value lands in the next commit.
+  // A floor that is PRESENT but not a usable integer means the machine
+  // history is corrupt, and a corrupt history must not silently mean "no
+  // protection". The previous shape here — skipping the comparison unless
+  // `Number.isInteger(floor)` — was worse than no guard at all: `n < NaN` is
+  // already false, so it did nothing for the truncated-ledger case it was
+  // written for, while turning `"30"` and `30.5` from REFUSED into ACCEPTED.
+  // Fail closed instead: an unreadable floor rejects every remote bundle and
+  // says why, which surfaces the corruption rather than disarming quietly.
   const floor = options.highestSeenBundleNumber;
-  if (floor !== undefined && Number.isInteger(floor) && decoded.bundle.bundleNumber < floor) {
-    return {
-      reason:
-        `bundle ${decoded.bundle.bundleNumber} is older than ${floor}, which this machine has already accepted ` +
-        "— refusing a rollback even though its signature is valid",
-    };
+  if (floor !== undefined) {
+    if (!Number.isInteger(floor) || floor < 0) {
+      return {
+        reason:
+          `this machine's rollback floor is unreadable (${JSON.stringify(floor)}), so a replayed old bundle ` +
+          "could not be ruled out — refusing the remote definitions until the machine history is repaired",
+      };
+    }
+    if (decoded.bundle.bundleNumber < floor) {
+      return {
+        reason:
+          `bundle ${decoded.bundle.bundleNumber} is older than ${floor}, which this machine has already accepted ` +
+          "— refusing a rollback even though its signature is valid",
+      };
+    }
   }
   return decoded;
 }
@@ -314,10 +298,17 @@ async function accept(
  * Load the definitions in force: remote if it verifies, else the last
  * verified cache, else the snapshot that shipped in this release.
  *
- * Never throws. Every failure mode here — offline, forged, rolled back,
- * corrupt — has to end with HarnessKit still running against SOME set of
- * definitions, because the alternative is an app that stops working when a
- * CDN does.
+ * Never throws on anything the outside world can cause. Offline, forged,
+ * rolled back, corrupt, a hostile CDN, a clock this build cannot read, or an
+ * injected provider that rejects instead of returning — all of them end with
+ * HarnessKit still running against SOME set of definitions, because the
+ * alternative is an app that stops working when a CDN does.
+ *
+ * The single exception is a caller that supplies no `snapshot`. That is a
+ * type violation and a bug in the caller, not a condition to degrade on:
+ * there is nothing left to fall back TO, and returning a `LoadedDefinitions`
+ * with an undefined bundle would push the crash into whichever consumer
+ * touched it first.
  */
 export async function loadDefinitions(options: FeedOptions): Promise<LoadedDefinitions> {
   const snapshot = (reason: string): LoadedDefinitions => ({
@@ -326,27 +317,63 @@ export async function loadDefinitions(options: FeedOptions): Promise<LoadedDefin
     reason,
   });
 
+  // "Never to nothing" is the contract, and TypeScript does not enforce it at
+  // a JS call site. A caller that hands over no snapshot gets a stated
+  // failure, not a `LoadedDefinitions` whose bundle is undefined.
+  if (options.snapshot === undefined || options.snapshot === null) {
+    throw new TypeError("loadDefinitions requires a snapshot bundle to fall back to");
+  }
+
   if (!options.baseUrl.startsWith("https://")) {
     return snapshot(
       `definitions feed ${JSON.stringify(options.baseUrl)} is not https — refusing to fetch definitions over an unauthenticated transport`,
     );
   }
+  if (!isAbsoluteInstant(options.now)) {
+    return snapshot(
+      `the current time ${JSON.stringify(options.now)} is not an ISO-8601 instant with a UTC offset, so key expiry ` +
+        "could not be judged — using the definitions that shipped with this release",
+    );
+  }
 
+  // Both limits fail closed. Substituting a default for a caller's nonsense
+  // would disarm the two controls that bound a hostile response: `NaN`
+  // compares false against every size, so `maxBytes: NaN` read an unbounded
+  // body, and a `timeoutMs` outside 32-bit range collapses to a ~1 ms
+  // deadline rather than the long one the caller asked for.
   const limits = {
     maxBytes: options.maxBytes ?? DEFAULT_MAX_BYTES,
     timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
   };
-  // Resolved once per load, before anything is verified against them.
-  const trustedKeys = await resolveTrustedKeys(options);
-  const base = options.baseUrl.replace(/\/+$/, "");
+  for (const [name, value] of [
+    ["maxBytes", limits.maxBytes],
+    ["timeoutMs", limits.timeoutMs],
+  ] as const) {
+    if (!Number.isFinite(value) || value <= 0 || value > MAX_TIMER_MS) {
+      return snapshot(
+        `the definitions feed was given an unusable ${name} (${JSON.stringify(value)}) — refusing to fetch with a ` +
+          "limit that would not bound the response",
+      );
+    }
+  }
+
+  // Trailing slashes are stripped by scanning, not by `/\/+$/`. That regex
+  // backtracks quadratically on a run of slashes: 80k of them took 3s.
+  let base = options.baseUrl;
+  while (base.endsWith("/")) base = base.slice(0, -1);
+
   const [body, signature] = await Promise.all([
-    options.fetcher.get(`${base}/definitions.json`, limits),
-    options.fetcher.get(`${base}/definitions.json.sig`, limits),
+    fetchOrFail(options, `${base}/definitions.json`, limits),
+    fetchOrFail(options, `${base}/definitions.json.sig`, limits),
   ]);
 
   let remoteReason: string;
   if (body.status === "ok" && signature.status === "ok") {
-    const result = await accept({ bytes: body.bytes, signature: signature.bytes }, trustedKeys, options);
+    const result = await accept(
+      { bytes: body.bytes, signature: signature.bytes },
+      options.publisherKeys,
+      options,
+    );
     if ("bundle" in result) return { bundle: result.bundle, source: "remote" };
     remoteReason = result.reason;
   } else {
@@ -360,7 +387,7 @@ export async function loadDefinitions(options: FeedOptions): Promise<LoadedDefin
   // The cache is re-verified, not trusted: it lives in a file any process
   // running as this user can rewrite.
   if (options.cached !== undefined) {
-    const result = await accept(options.cached, trustedKeys, options);
+    const result = await accept(options.cached, options.publisherKeys, options);
     if ("bundle" in result) {
       return {
         bundle: result.bundle,

--- a/packages/core/src/definitions/feed.ts
+++ b/packages/core/src/definitions/feed.ts
@@ -1,0 +1,230 @@
+import { fromBundle, BundleError } from "./bundle.js";
+import type { DefinitionsBundle } from "./bundle.js";
+import type { Fetcher, SignatureVerifier } from "./providers.js";
+
+/**
+ * The definitions feed (AC-25, AC-26, ADR 0004, design.md §7).
+ *
+ * ADR 0004 is blunt about why this is signed: "this data tells the tool where
+ * to write on users' machines, so it is an attack surface." A bundle names
+ * config-store paths and installer binaries. Accepting an unverified one
+ * would hand an attacker the write allowlist and the argv of every installer
+ * HarnessKit runs.
+ *
+ * Three rules, in this order, and the order is the point:
+ *
+ * 1. **Verify the BYTES, then parse.** The signature covers the exact bytes
+ *    fetched. Parsing first would run a JSON parser and every validator in
+ *    bundle.ts over attacker-controlled input before anything had been
+ *    checked, which is a decoder to attack rather than a signature to forge.
+ * 2. **Anti-rollback.** A valid signature is not enough: a bundle number
+ *    lower than the highest already seen is rejected. Otherwise a network
+ *    attacker replays a genuinely-signed OLD bundle to reinstate a path or a
+ *    permissive descriptor that a later release fixed.
+ * 3. **Fall back, and say so.** Offline, a bad signature and a rollback
+ *    attempt all degrade to the release-bundled snapshot, never to nothing
+ *    and never silently — AC-25 requires the fallback to be stated.
+ *
+ * The cache is re-verified on load rather than trusted. It sits in a file any
+ * process running as the user can rewrite, so "we verified it when we stored
+ * it" says nothing about what is there now.
+ */
+
+/** Where the definitions in force came from. */
+export type DefinitionsSource = "remote" | "cache" | "snapshot";
+
+export interface LoadedDefinitions {
+  bundle: DefinitionsBundle;
+  source: DefinitionsSource;
+  /**
+   * Why the source is not "remote", phrased for a user. Always present when
+   * it is not, because AC-25 requires the fallback to be stated rather than
+   * silently taken.
+   */
+  reason?: string;
+}
+
+/** A signed artifact: the exact bytes, and a detached signature over them. */
+export interface SignedArtifact {
+  bytes: Uint8Array;
+  signature: Uint8Array;
+}
+
+/**
+ * A publisher key. `notAfter` lets a rotated key keep verifying bundles
+ * published before the rotation without being usable for new ones.
+ */
+export interface PublisherKey {
+  id: string;
+  publicKey: Uint8Array;
+  /** ISO-8601. Absent means currently active. */
+  notAfter?: string;
+}
+
+export interface FeedOptions {
+  fetcher: Fetcher;
+  verifier: SignatureVerifier;
+  /** Base URL, e.g. `https://harnesskit.ai/definitions/v1`. Must be https. */
+  baseUrl: string;
+  /** Keys compiled into this release. */
+  publisherKeys: readonly PublisherKey[];
+  /** The release-bundled fallback. Trusted: it shipped inside the binary. */
+  snapshot: DefinitionsBundle;
+  /** Previously accepted bundle, if any, with the bytes that were verified. */
+  cached?: SignedArtifact;
+  /**
+   * Highest bundle number ever accepted on this machine. Anti-rollback
+   * compares against this, NOT against the cache — a cache an attacker can
+   * delete must not also reset the floor.
+   */
+  highestSeenBundleNumber?: number;
+  /** Injected clock — core never reads the system clock. */
+  now: string;
+  /** Refuse a body larger than this. */
+  maxBytes?: number;
+  timeoutMs?: number;
+}
+
+const DEFAULT_MAX_BYTES = 2 * 1024 * 1024;
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+/** Decode verified bytes into a bundle, or explain why they are unusable. */
+function decode(bytes: Uint8Array): { bundle: DefinitionsBundle } | { reason: string } {
+  let text: string;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return { reason: "the signed payload is not valid UTF-8" };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (error) {
+    return { reason: `the signed payload is not valid JSON (${errorText(error)})` };
+  }
+  try {
+    return { bundle: fromBundle(parsed) };
+  } catch (error) {
+    // A validation failure on a SIGNED payload means the publisher shipped
+    // something this build cannot use — a real condition worth naming, not a
+    // security event.
+    return {
+      reason:
+        error instanceof BundleError
+          ? `the signed definitions are not usable by this build (${error.message})`
+          : `the signed definitions could not be read (${errorText(error)})`,
+    };
+  }
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Verify a detached signature against every key still valid at `now`.
+ *
+ * Trying each key is what makes rotation work: a bundle signed by the
+ * outgoing key still verifies until that key's `notAfter` passes.
+ */
+async function verifyWithAnyKey(
+  artifact: SignedArtifact,
+  options: FeedOptions,
+): Promise<boolean> {
+  for (const key of options.publisherKeys) {
+    if (key.notAfter !== undefined && key.notAfter <= options.now) continue;
+    if (await options.verifier.verifyEd25519(artifact.bytes, artifact.signature, key.publicKey)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Accept a signed artifact, or explain why not. Verification comes before
+ * decoding, and the rollback check before the result is usable.
+ */
+async function accept(
+  artifact: SignedArtifact,
+  options: FeedOptions,
+): Promise<{ bundle: DefinitionsBundle } | { reason: string }> {
+  if (!(await verifyWithAnyKey(artifact, options))) {
+    return { reason: "the signature did not verify against any known publisher key" };
+  }
+  const decoded = decode(artifact.bytes);
+  if ("reason" in decoded) return decoded;
+
+  const floor = options.highestSeenBundleNumber;
+  if (floor !== undefined && decoded.bundle.bundleNumber < floor) {
+    return {
+      reason:
+        `bundle ${decoded.bundle.bundleNumber} is older than ${floor}, which this machine has already accepted ` +
+        "— refusing a rollback even though its signature is valid",
+    };
+  }
+  return decoded;
+}
+
+/**
+ * Load the definitions in force: remote if it verifies, else the last
+ * verified cache, else the snapshot that shipped in this release.
+ *
+ * Never throws. Every failure mode here — offline, forged, rolled back,
+ * corrupt — has to end with HarnessKit still running against SOME set of
+ * definitions, because the alternative is an app that stops working when a
+ * CDN does.
+ */
+export async function loadDefinitions(options: FeedOptions): Promise<LoadedDefinitions> {
+  const snapshot = (reason: string): LoadedDefinitions => ({
+    bundle: options.snapshot,
+    source: "snapshot",
+    reason,
+  });
+
+  if (!options.baseUrl.startsWith("https://")) {
+    return snapshot(
+      `definitions feed ${JSON.stringify(options.baseUrl)} is not https — refusing to fetch definitions over an unauthenticated transport`,
+    );
+  }
+
+  const limits = {
+    maxBytes: options.maxBytes ?? DEFAULT_MAX_BYTES,
+    timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  };
+  const base = options.baseUrl.replace(/\/+$/, "");
+  const [body, signature] = await Promise.all([
+    options.fetcher.get(`${base}/definitions.json`, limits),
+    options.fetcher.get(`${base}/definitions.json.sig`, limits),
+  ]);
+
+  let remoteReason: string;
+  if (body.status === "ok" && signature.status === "ok") {
+    const result = await accept({ bytes: body.bytes, signature: signature.bytes }, options);
+    if ("bundle" in result) return { bundle: result.bundle, source: "remote" };
+    remoteReason = result.reason;
+  } else {
+    const failed = body.status === "ok" ? signature : body;
+    remoteReason =
+      failed.status === "not-found"
+        ? "the definitions feed returned nothing"
+        : `the definitions feed could not be reached (${failed.status === "failed" ? failed.reason : "unknown"})`;
+  }
+
+  // The cache is re-verified, not trusted: it lives in a file any process
+  // running as this user can rewrite.
+  if (options.cached !== undefined) {
+    const result = await accept(options.cached, options);
+    if ("bundle" in result) {
+      return {
+        bundle: result.bundle,
+        source: "cache",
+        reason: `${remoteReason}; using the last verified definitions instead`,
+      };
+    }
+    return snapshot(
+      `${remoteReason}, and the cached definitions are unusable (${result.reason}); using the definitions that shipped with this release`,
+    );
+  }
+
+  return snapshot(`${remoteReason}; using the definitions that shipped with this release`);
+}

--- a/packages/core/src/definitions/providers-node.ts
+++ b/packages/core/src/definitions/providers-node.ts
@@ -1,0 +1,90 @@
+import { verify as verifyEd } from "node:crypto";
+import type { FetchResult, Fetcher, SignatureVerifier } from "./providers.js";
+
+/**
+ * Node-backed definitions providers for the CLI.
+ *
+ * Exported ONLY from the `node` entry point. `node:crypto` imported from a
+ * module the desktop's route graph can reach is exactly what broke four
+ * packaged routes before; the webview cannot resolve node builtins, and a
+ * bare `import "crypto"` in a chunk is unresolvable at load.
+ */
+
+/** Ed25519 public keys are 32 raw bytes; SPKI-wrap them for node's verifier. */
+const SPKI_ED25519_PREFIX = Uint8Array.from([
+  0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00,
+]);
+
+export class NodeSignatureVerifier implements SignatureVerifier {
+  async verifyEd25519(
+    message: Uint8Array,
+    signature: Uint8Array,
+    publicKey: Uint8Array,
+  ): Promise<boolean> {
+    try {
+      const { createPublicKey } = await import("node:crypto");
+      const der = new Uint8Array(SPKI_ED25519_PREFIX.length + publicKey.length);
+      der.set(SPKI_ED25519_PREFIX);
+      der.set(publicKey, SPKI_ED25519_PREFIX.length);
+      const key = createPublicKey({ key: Buffer.from(der), format: "der", type: "spki" });
+      return verifyEd(null, message, key, signature);
+    } catch {
+      // A malformed key or signature is indistinguishable from a bad one by
+      // design: a caller deciding whether to trust bytes must not branch on
+      // which kind of wrong they are, and must not handle an exception here.
+      return false;
+    }
+  }
+}
+
+export class NodeFetcher implements Fetcher {
+  async get(
+    url: string,
+    options: { maxBytes: number; timeoutMs: number },
+  ): Promise<FetchResult> {
+    if (!url.startsWith("https://")) {
+      return { status: "failed", reason: "refusing to fetch definitions over a non-https URL" };
+    }
+    const origin = new URL(url).origin;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), options.timeoutMs);
+    try {
+      // `redirect: "manual"` rather than following: a redirect that leaves the
+      // original origin would let a compromised CDN point verification at
+      // another host, and the signature check alone would not notice, since
+      // the attacker would be serving a bundle they also signed for.
+      const response = await fetch(url, { signal: controller.signal, redirect: "manual" });
+      if (response.status >= 300 && response.status < 400) {
+        const location = response.headers.get("location");
+        const target = location === null ? null : new URL(location, url);
+        return target !== null && target.origin === origin
+          ? this.get(target.toString(), options)
+          : { status: "failed", reason: "the definitions feed redirected off its own origin" };
+      }
+      if (response.status === 404) return { status: "not-found" };
+      if (!response.ok) {
+        return { status: "failed", reason: `the feed answered ${response.status}` };
+      }
+      const declared = Number(response.headers.get("content-length") ?? "0");
+      if (declared > options.maxBytes) {
+        return { status: "failed", reason: "the definitions payload is larger than this build accepts" };
+      }
+      const bytes = new Uint8Array(await response.arrayBuffer());
+      // Checked again after reading: content-length is a claim, not a limit.
+      if (bytes.byteLength > options.maxBytes) {
+        return { status: "failed", reason: "the definitions payload is larger than this build accepts" };
+      }
+      return { status: "ok", bytes };
+    } catch (error) {
+      const reason =
+        error instanceof Error && error.name === "AbortError"
+          ? `the feed did not answer within ${Math.round(options.timeoutMs / 1000)}s`
+          : error instanceof Error
+            ? error.message
+            : String(error);
+      return { status: "failed", reason };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/packages/core/src/definitions/providers-node.ts
+++ b/packages/core/src/definitions/providers-node.ts
@@ -1,4 +1,4 @@
-import { verify as verifyEd } from "node:crypto";
+import { createPublicKey, verify as verifyEd } from "node:crypto";
 import type { FetchResult, Fetcher, SignatureVerifier } from "./providers.js";
 
 /**
@@ -15,14 +15,23 @@ const SPKI_ED25519_PREFIX = Uint8Array.from([
   0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00,
 ]);
 
+/** Raw Ed25519 public key length, hardcoded into the DER lengths above. */
+const ED25519_PUBLIC_KEY_BYTES = 32;
+
 export class NodeSignatureVerifier implements SignatureVerifier {
   async verifyEd25519(
     message: Uint8Array,
     signature: Uint8Array,
     publicKey: Uint8Array,
   ): Promise<boolean> {
+    // The DER lengths in the prefix are fixed for 32 bytes, and OpenSSL
+    // ignores trailing data after the SEQUENCE — so a 33-byte or 4 KiB key
+    // was silently TRUNCATED to its first 32 and accepted, making infinitely
+    // many distinct key values the same key. Short keys already failed on
+    // their own; long ones did not. The contract says a malformed key returns
+    // false, so check the length rather than relying on the parser to.
+    if (publicKey.length !== ED25519_PUBLIC_KEY_BYTES) return false;
     try {
-      const { createPublicKey } = await import("node:crypto");
       const der = new Uint8Array(SPKI_ED25519_PREFIX.length + publicKey.length);
       der.set(SPKI_ED25519_PREFIX);
       der.set(publicKey, SPKI_ED25519_PREFIX.length);
@@ -40,10 +49,13 @@ export class NodeSignatureVerifier implements SignatureVerifier {
 /**
  * How many same-origin redirects to follow before giving up.
  *
- * The origin pin makes a self-referential `302 Location: <self>` the ONLY
- * redirect this will follow, which is exactly the shape of an infinite loop —
- * one CDN misconfiguration, no attacker required. Recursion without a bound
- * spun 100k hops in 156ms, allocating a timer and an AbortController per hop.
+ * The origin pin bounds redirects to the ORIGIN, not to a single URL: any
+ * same-origin target is followed, including relative and port-normalised
+ * ones, so a CDN can legitimately hop `/definitions.json` → `/latest/` →
+ * `/cdn/v9/definitions.json`. A self-referential `302 Location: <self>` is
+ * therefore only the tightest case of a loop the pin permits — one CDN
+ * misconfiguration, no attacker required. Recursion without a bound spun
+ * 100k hops in 156ms, allocating a timer and an AbortController per hop.
  */
 const MAX_REDIRECTS = 5;
 
@@ -132,40 +144,54 @@ export class NodeFetcher implements Fetcher {
   }
 }
 
+/** Initial read buffer; grows geometrically, never past `maxBytes`. */
+const INITIAL_READ_BYTES = 64 * 1024;
+
 /**
  * Read a response body, STOPPING at the cap rather than buffering and then
  * complaining. `arrayBuffer()` reads it all first: a 1.5 GiB response against
  * a 2 MiB cap put 1.5 GiB resident before the check ran, and a response with
  * no content-length skipped the earlier check entirely.
+ *
+ * Bytes are copied into ONE growing buffer rather than collected in a chunk
+ * array, because a cap on total bytes is not a cap on memory. Retaining each
+ * chunk let a server drip its response one byte at a time and pay `maxBytes`
+ * for orders of magnitude more allocation: 4 MiB of payload across two
+ * concurrent fetches reached 2.2 GiB resident, well inside the 10s timeout.
+ * Per-chunk overhead is what costs, so the fix is to stop keeping chunks.
  */
 async function readCapped(response: Response, maxBytes: number): Promise<FetchResult> {
   const body = response.body;
   if (body === null) return { status: "ok", bytes: new Uint8Array(0) };
   const reader = body.getReader();
-  const chunks: Uint8Array[] = [];
+  const tooLarge: FetchResult = {
+    status: "failed",
+    reason: "the definitions payload is larger than this build accepts",
+  };
+  let buffer = new Uint8Array(Math.min(maxBytes, INITIAL_READ_BYTES));
   let total = 0;
   try {
     for (;;) {
       const { done, value } = await reader.read();
       if (done) break;
-      total += value.byteLength;
-      if (total > maxBytes) {
+      // Checked BEFORE the copy, so an oversized chunk is never resident.
+      if (total + value.byteLength > maxBytes) {
         await reader.cancel();
-        return {
-          status: "failed",
-          reason: "the definitions payload is larger than this build accepts",
-        };
+        return tooLarge;
       }
-      chunks.push(value);
+      if (total + value.byteLength > buffer.length) {
+        const grown = new Uint8Array(
+          Math.min(maxBytes, Math.max(buffer.length * 2, total + value.byteLength)),
+        );
+        grown.set(buffer.subarray(0, total));
+        buffer = grown;
+      }
+      buffer.set(value, total);
+      total += value.byteLength;
     }
   } finally {
     reader.releaseLock();
   }
-  const bytes = new Uint8Array(total);
-  let offset = 0;
-  for (const chunk of chunks) {
-    bytes.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return { status: "ok", bytes };
+  // Copy out so the returned array does not retain the grown buffer's slack.
+  return { status: "ok", bytes: buffer.slice(0, total) };
 }

--- a/packages/core/src/definitions/providers-node.ts
+++ b/packages/core/src/definitions/providers-node.ts
@@ -37,54 +37,135 @@ export class NodeSignatureVerifier implements SignatureVerifier {
   }
 }
 
+/**
+ * How many same-origin redirects to follow before giving up.
+ *
+ * The origin pin makes a self-referential `302 Location: <self>` the ONLY
+ * redirect this will follow, which is exactly the shape of an infinite loop —
+ * one CDN misconfiguration, no attacker required. Recursion without a bound
+ * spun 100k hops in 156ms, allocating a timer and an AbortController per hop.
+ */
+const MAX_REDIRECTS = 5;
+
+/** A duration a person can read: "800ms", "10s". `Math.round(ms/1000)` said
+ * "within 0s" for any sub-second timeout. */
+function humanDuration(ms: number): string {
+  return ms < 1000 ? `${ms}ms` : `${Math.round(ms / 1000)}s`;
+}
+
 export class NodeFetcher implements Fetcher {
   async get(
     url: string,
     options: { maxBytes: number; timeoutMs: number },
   ): Promise<FetchResult> {
-    if (!url.startsWith("https://")) {
-      return { status: "failed", reason: "refusing to fetch definitions over a non-https URL" };
-    }
-    const origin = new URL(url).origin;
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), options.timeoutMs);
+    // One deadline for the WHOLE call, redirects included. A per-hop timeout
+    // bounds no redirect chain: each hop resets it, so N hops take N times as
+    // long as the caller asked to wait.
+    return this.fetchWithin(url, options, Date.now() + options.timeoutMs, MAX_REDIRECTS);
+  }
+
+  private async fetchWithin(
+    url: string,
+    options: { maxBytes: number; timeoutMs: number },
+    deadline: number,
+    redirectsLeft: number,
+  ): Promise<FetchResult> {
+    // Everything that can throw lives inside the try. `new URL()` on a
+    // malformed feed URL used to sit above it, so a typo took the process
+    // down instead of degrading to the snapshot.
     try {
-      // `redirect: "manual"` rather than following: a redirect that leaves the
-      // original origin would let a compromised CDN point verification at
-      // another host, and the signature check alone would not notice, since
-      // the attacker would be serving a bundle they also signed for.
-      const response = await fetch(url, { signal: controller.signal, redirect: "manual" });
-      if (response.status >= 300 && response.status < 400) {
-        const location = response.headers.get("location");
-        const target = location === null ? null : new URL(location, url);
-        return target !== null && target.origin === origin
-          ? this.get(target.toString(), options)
-          : { status: "failed", reason: "the definitions feed redirected off its own origin" };
+      if (!url.startsWith("https://")) {
+        return { status: "failed", reason: "refusing to fetch definitions over a non-https URL" };
       }
-      if (response.status === 404) return { status: "not-found" };
-      if (!response.ok) {
-        return { status: "failed", reason: `the feed answered ${response.status}` };
+      const origin = new URL(url).origin;
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        return {
+          status: "failed",
+          reason: `the feed did not answer within ${humanDuration(options.timeoutMs)}`,
+        };
       }
-      const declared = Number(response.headers.get("content-length") ?? "0");
-      if (declared > options.maxBytes) {
-        return { status: "failed", reason: "the definitions payload is larger than this build accepts" };
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), remaining);
+      try {
+        const response = await fetch(url, { signal: controller.signal, redirect: "manual" });
+        if (response.status >= 300 && response.status < 400) {
+          if (redirectsLeft <= 0) {
+            return { status: "failed", reason: "the definitions feed redirected too many times" };
+          }
+          const location = response.headers.get("location");
+          if (location === null) {
+            return { status: "failed", reason: "the definitions feed redirected without a target" };
+          }
+          const target = new URL(location, url);
+          // Origin includes the scheme, so this also blocks an https→http
+          // downgrade on an otherwise same-host redirect.
+          if (target.origin !== origin) {
+            return { status: "failed", reason: "the definitions feed redirected off its own origin" };
+          }
+          return this.fetchWithin(target.toString(), options, deadline, redirectsLeft - 1);
+        }
+        if (response.status === 404) return { status: "not-found" };
+        if (!response.ok) {
+          return { status: "failed", reason: `the feed answered ${response.status}` };
+        }
+        const declared = Number(response.headers.get("content-length") ?? "0");
+        if (Number.isFinite(declared) && declared > options.maxBytes) {
+          return {
+            status: "failed",
+            reason: "the definitions payload is larger than this build accepts",
+          };
+        }
+        return await readCapped(response, options.maxBytes);
+      } finally {
+        clearTimeout(timer);
       }
-      const bytes = new Uint8Array(await response.arrayBuffer());
-      // Checked again after reading: content-length is a claim, not a limit.
-      if (bytes.byteLength > options.maxBytes) {
-        return { status: "failed", reason: "the definitions payload is larger than this build accepts" };
-      }
-      return { status: "ok", bytes };
     } catch (error) {
       const reason =
         error instanceof Error && error.name === "AbortError"
-          ? `the feed did not answer within ${Math.round(options.timeoutMs / 1000)}s`
+          ? `the feed did not answer within ${humanDuration(options.timeoutMs)}`
           : error instanceof Error
             ? error.message
             : String(error);
       return { status: "failed", reason };
-    } finally {
-      clearTimeout(timer);
     }
   }
+}
+
+/**
+ * Read a response body, STOPPING at the cap rather than buffering and then
+ * complaining. `arrayBuffer()` reads it all first: a 1.5 GiB response against
+ * a 2 MiB cap put 1.5 GiB resident before the check ran, and a response with
+ * no content-length skipped the earlier check entirely.
+ */
+async function readCapped(response: Response, maxBytes: number): Promise<FetchResult> {
+  const body = response.body;
+  if (body === null) return { status: "ok", bytes: new Uint8Array(0) };
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel();
+        return {
+          status: "failed",
+          reason: "the definitions payload is larger than this build accepts",
+        };
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return { status: "ok", bytes };
 }

--- a/packages/core/src/definitions/providers.ts
+++ b/packages/core/src/definitions/providers.ts
@@ -1,0 +1,45 @@
+/**
+ * Injected effects the definitions feed needs (design.md §7, ADR 0004).
+ *
+ * Core imports no driver for either. The CLI backs them with `fetch` and
+ * `node:crypto`; the desktop must NOT use `node:crypto` — a bare import of it
+ * in a core module already shipped four broken routes in a packaged build,
+ * because the webview cannot resolve node builtins. That incident is why
+ * these are interfaces rather than functions.
+ */
+
+/** The bytes of one fetched artifact, or a stated reason there are none. */
+export type FetchResult =
+  | { status: "ok"; bytes: Uint8Array }
+  | { status: "not-found" }
+  | { status: "failed"; reason: string };
+
+export interface Fetcher {
+  /**
+   * Retrieve one URL. Implementations MUST:
+   * - refuse a non-https URL;
+   * - refuse a redirect that leaves the original origin, since following one
+   *   would let a compromised CDN point verification at another host;
+   * - stop reading past `maxBytes` rather than buffering a hostile response;
+   * - apply a timeout, and report it as `failed` rather than hanging.
+   *
+   * Never throws: offline is an ordinary answer this feed must degrade on.
+   */
+  get(url: string, options: { maxBytes: number; timeoutMs: number }): Promise<FetchResult>;
+}
+
+export interface SignatureVerifier {
+  /**
+   * Verify a detached Ed25519 signature over `message`.
+   *
+   * Returns false for a bad signature AND for a malformed key or signature —
+   * a caller must not be able to tell those apart, and must not have to
+   * handle an exception on a path whose whole purpose is deciding whether to
+   * trust bytes.
+   */
+  verifyEd25519(
+    message: Uint8Array,
+    signature: Uint8Array,
+    publicKey: Uint8Array,
+  ): Promise<boolean>;
+}

--- a/packages/core/src/fs-provider.ts
+++ b/packages/core/src/fs-provider.ts
@@ -1,5 +1,9 @@
 /**
- * Filesystem abstraction all core IO goes through.
+ * Filesystem abstraction all core FILESYSTEM access goes through.
+ *
+ * One of several injected effects, not the only one: process execution goes
+ * through `ProcessRunner`, network and signature verification through the
+ * providers in `definitions/`. Core imports no driver for any of them.
  *
  * Surface observation (observe/) assumes `exists` and `isDirectory` are
  * non-throwing boolean probes — a provider that throws from them is out of

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -440,6 +440,28 @@ export { SURFACES, PRIORITY_SURFACES, getSurface } from "./surfaces/registry.js"
 export type { DefinitionsBundle } from "./definitions/bundle.js";
 export { BUNDLE_FORMAT_VERSION, BundleError, toBundle, fromBundle } from "./definitions/bundle.js";
 
+// ── Definitions feed (AC-25/AC-26, ADR 0004) ─────────────────
+//
+// Remote, signature-verified surface definitions with a release-bundled
+// snapshot as fallback. Verification precedes parsing, a valid signature is
+// not sufficient (anti-rollback), and every fallback states its reason. The
+// Fetcher and SignatureVerifier are injected — core imports no crypto or
+// network driver, which is why a bare node:crypto import once broke four
+// packaged desktop routes.
+export type {
+  Fetcher,
+  FetchResult,
+  SignatureVerifier,
+} from "./definitions/providers.js";
+export type {
+  DefinitionsSource,
+  FeedOptions,
+  LoadedDefinitions,
+  PublisherKey,
+  SignedArtifact,
+} from "./definitions/feed.js";
+export { loadDefinitions } from "./definitions/feed.js";
+
 // ── Whole-harness portability (Protocol v2) ──────────────────
 export type {
   HarnessScope,

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -1,2 +1,3 @@
 export { NodeFsProvider } from "./fs-node.js";
 export { NodeProcessRunner } from "./process-node.js";
+export { NodeSignatureVerifier, NodeFetcher } from "./definitions/providers-node.js";

--- a/packages/core/src/process-runner.ts
+++ b/packages/core/src/process-runner.ts
@@ -1,6 +1,7 @@
 /**
- * Process execution abstraction (design.md §4, D3) — the second injected
- * effect beside `FsProvider`. Core never imports `node:child_process`; the
+ * Process execution abstraction (design.md §4, D3) — one of core's injected
+ * effects, alongside `FsProvider` and the definitions feed's `Fetcher` and
+ * `SignatureVerifier`. Core never imports `node:child_process`; the
  * CLI backs this with a real spawn and the desktop with a Rust command, the
  * same split the filesystem already uses.
  *

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -6,4 +6,10 @@ export default defineConfig({
   dts: true,
   clean: true,
   sourcemap: true,
+  // tsup 8 strips the `node:` prefix by default, which is how `node:sqlite`
+  // became a bare `sqlite` specifier and broke every CLI command with
+  // ERR_MODULE_NOT_FOUND. `node:crypto` survives the rewrite in Node, so the
+  // same bug here would stay invisible until a bundler that does not alias
+  // bare builtins loads it. Keep the prefix the source wrote.
+  removeNodeProtocol: false,
 });

--- a/specs/cross-harness-config-management/spec.md
+++ b/specs/cross-harness-config-management/spec.md
@@ -82,7 +82,7 @@ Format: EARS (`WHEN … THE SYSTEM SHALL …`). Grouped by requirement area; eve
 
 ### Remote definitions (ADR 0004)
 
-- [ ] AC-25: WHEN the app or CLI starts with network access THE SYSTEM SHALL fetch versioned, signature-verified surface definitions (paths, formats, capability matrix, recommendation rules) from harnesskit.ai; WHEN offline or verification fails THE SYSTEM SHALL fall back to the release-bundled snapshot and say so.
+- [ ] AC-25: WHEN the app or CLI starts with network access THE SYSTEM SHALL fetch versioned, signature-verified surface definitions (paths, formats, capability matrix, recommendation rules) from harnesskit.ai; WHEN offline or verification fails THE SYSTEM SHALL fall back to the release-bundled snapshot and say so. *(In progress 2026-09-08, M4: the verification core landed — verify-before-parse, anti-rollback against a machine-history floor, cross-signed key rotation per D7, and snapshot fallback with a stated reason. NOT yet wired: nothing calls `loadDefinitions`, so no remote data reaches the registry and AC-26's end-to-end path is unproven. Also open: `definitions_cache` persistence, a desktop verifier (which cannot use `node:crypto`), CI bundle publishing, and hosting. Known residual: no freshness bound, so withholding updates pins a client on the newest bundle it has seen — design.md §7 does not require a maximum age.)*
 - [ ] AC-26: WHEN a definition update changes a surface's config path THE SYSTEM SHALL use the new path on next inventory without an app update.
 
 ### CLI


### PR DESCRIPTION
M4's verification core. **Nothing calls `loadDefinitions` yet** — no remote data reaches the registry on this branch. Wiring it in is the commit where remote definitions actually become trusted, and it gets its own PR rather than sharing a review with 750 lines of crypto plumbing.

## Why this is signed rather than merely versioned

ADR 0004, verbatim: *"this data tells the tool where to write on users' machines, so it is an attack surface."* A bundle names config-store paths and installer binaries. Accepting an unverified one hands an attacker the user-scope write allowlist **and** the argv of every installer the PluginBroker runs.

## Three rules, and the order of the first two is the design

**1. Verify the bytes, then parse.** The signature covers exactly the bytes fetched. Parsing first would run a JSON parser and every validator in `bundle.ts` across attacker-controlled input *before anything was checked* — that is a decoder to attack instead of a signature to forge.

**2. A valid signature is not sufficient.** A bundle number below the highest this machine has accepted is refused. The floor comes from machine history, **not** from the cache — a cache an attacker can delete must not also reset it. A floor that is present but unreadable now **refuses the bundle** rather than proceeding unprotected.

**3. Fall back, and say so.** Offline, forged, rolled back and corrupt all degrade to the release-bundled snapshot with a stated reason (AC-25) — never silently, never to nothing.

The cache is **re-verified on load** rather than trusted. It is a file any process running as this user can rewrite, so "we verified it when we stored it" says nothing about what is there now.

## Injected effects, not imports

`Fetcher` and `SignatureVerifier` are interfaces; core imports no crypto or network driver. A bare `node:crypto` import in a core module already shipped **four broken routes in a packaged build**, because the webview cannot resolve node builtins and the failure does not reproduce in dev mode. Guarded on the **built artifact** now, not just the source: `dist/index.js` must contain no `node:` specifier, and `dist/node.js` must keep the prefix.

## Trust anchor: compiled-in keys only

Keys are fixed at build time. `notAfter` retires one; only a new binary introduces one. **Key rotation is not implemented**, and design.md D7 (cross-signed transition statements) is deliberately withdrawn — see below.

Both `notAfter` and the injected clock must carry a UTC offset. `Date.parse` resolves the offset-less ISO form in the *host's* timezone, which kept a revoked key honoured 26 hours longer in Honolulu than in Tokyo and made the same bundle verify on one machine and not its neighbour.

## What three review passes changed

One holistic pass, then security and correctness lenses. **21 demonstrated defects**, three of them inside the commit that fixed the previous round's findings. The significant ones:

**D7 rotation withdrawn.** It was added last round as a review fix and produced three HIGH findings of its own: replaying the publisher's own (necessarily public) statement resurrected a key revoked via `notAfter` and re-added it with no expiry; revoking the outgoing key destroyed the incoming one with it, so rotation could not survive the event it exists for; and the statement was JSON-parsed before any signature check, breaking this module's own rule 1. Both failures trace to revocation semantics design.md §7 does not pin down — expiry and compromise are different things and cannot share one `notAfter` field. That is a design decision, not a patch to land in a review round.

**A false security claim, corrected.** Cross-signing was documented as stopping a *stolen* outgoing key. It does not — a thief generates their own second keypair and counter-signs with it. It is proof-of-possession. The test named for that property never tested it.

**Anti-rollback now fails closed.** The previous guard was a no-op on the NaN case it was written for (`n < NaN` is already false) and a regression on two reachable ones, turning `"30"` and `30.5` from refused into accepted. Its test asserted the rollback was ACCEPTED, under a describe block titled *"anti-rollback cannot be disabled by a bad floor"*.

Also fixed: `loadDefinitions` threw when an injected provider rejected (the planned desktop verifier is a Tauri `invoke`, which rejects on `Err`); `maxBytes: NaN` read an unbounded body and `timeoutMs` past 2^31 collapsed `setTimeout` to ~1ms, both now refused rather than defaulted; `readCapped` grew one buffer instead of retaining chunks, cutting a drip-fed 2 MiB body from 70-84 MiB to 1.9-20.4 MiB; an over-length public key was silently truncated to 32 bytes and accepted, because OpenSSL ignores trailing data; tsup's `removeNodeProtocol` default emitted a bare `crypto` specifier, the same rewrite that made `node:sqlite` break every CLI command; and CodeQL's polynomial-ReDoS finding on `/\/+$/`, which took 3.0s on 80k slashes against 0.1ms at 1M for a scan.

## Verification

Tests use **real generated Ed25519 keypairs and the real verifier** — a stub would prove nothing about the only property that matters. 53 tests across the feed, transport and dist guards.

Four tests were repaired because mutation showed they asserted verdicts their own mutants still produced — the UTF-8, https-downgrade and content-length cases each now pin their branch by reason. The abort timer had **no defender at all**: replacing `controller.abort()` with a no-op left all 818 tests green.

Eleven mutations verified to fail:

| mutation | result |
|---|---|
| floor: unreadable no longer fails closed | 1 failed |
| clock: UTC offset no longer required | 2 failed |
| notAfter boundary exclusive → inclusive | 1 failed |
| limits: unusable maxBytes/timeoutMs allowed | 1 failed |
| fetcher rejection no longer caught | 1 failed |
| verifier rejection no longer caught | 1 failed |
| verifier: over-length key accepted | 1 failed |
| abort timer disarmed | 1 failed |
| content-length isFinite guard removed | 1 failed |
| body cap checked after the copy | 2 failed |
| parse before verify | 1 failed |

core **828** · CLI 135 · desktop 483 · Rust 82 · clippy clean.

## Deliberately not in this PR

- Nothing loads a bundle into `getSurface` (AC-26's end-to-end path)
- No `definitions_cache` persistence
- No desktop verifier — that needs a Rust-backed implementation, since `node:crypto` is exactly what it cannot use
- No CI bundle publishing or hosting
- **No key rotation** (design.md D7), withdrawn above — it needs revocation semantics settled first, and a freshness bound, since freezing a client also freezes the arrival of the `notAfter` that retires a compromised key

🤖 Generated with [Claude Code](https://claude.com/claude-code)
