### PR TITLE
docs(website): drop the retired Agents page from the architecture docs

### DIFF
--- a/website/components/architecture-diagram.tsx
+++ b/website/components/architecture-diagram.tsx
@@ -13,13 +13,15 @@ const BORDER_MID = 'rgba(255,255,255,0.14)';
 const MUTED = '#8b919e';
 const SUBTLE = '#4a5060';
 
-// Groups sourced from NAV_SECTIONS + DEMOTED_SECTIONS in AppLayout.tsx.
-// The app has a single sidebar group today ("WORKSPACE"); Agents and Security
-// have real routes but no sidebar entry (Agents is demoted per DESIGN.md §5;
-// Security is reached via Preferences).
+// Groups sourced from NAV_SECTIONS in AppLayout.tsx, plus the Settings button
+// pinned in the sidebar footer (rendered separately from NAV_SECTIONS, so it
+// isn't in the command palette). Security has a real route but no sidebar
+// entry at all — reached only via Preferences. The Agents page was removed
+// in the Phase 0 UX consolidation (unreachable, fed a Comparator form that
+// couldn't submit) — see docs/apps/agents.md.
 const desktopGroups = [
-  { label: 'WORKSPACE',      items: ['Fleet', 'Configure', 'Drift', 'Comparator', 'Observatory', 'Marketplace'] },
-  { label: 'ALSO REACHABLE', items: ['Agents', 'Security'] },
+  { label: 'WORKSPACE',      items: ['Machine', 'Fleet', 'Configure', 'Drift', 'Comparator', 'Observatory', 'Marketplace', 'Settings'] },
+  { label: 'ALSO REACHABLE', items: ['Security'] },
 ];
 
 // Commands sourced from apps/cli/src/index.ts

--- a/website/content/docs/apps/agents.md
+++ b/website/content/docs/apps/agents.md
@@ -4,50 +4,7 @@ title: Agents
 
 # Agents
 
-The Agents page is a detection panel for AI coding agents installed on your machine.
-It scans your `PATH` and known install locations for supported CLI agents and shows
-their installation status, version, and protocol.
-
-## Detected Agents
-
-The page auto-detects the following agents:
-
-| Agent | Binary |
-|-------|--------|
-| Claude Code | `claude` |
-| OpenAI Codex | `codex` |
-| GitHub Copilot CLI | `gh copilot` |
-| Cursor | `cursor-agent` |
-| OpenCode | `opencode` |
-| Goose | `goose` |
-| Gemini CLI | `gemini` |
-| Aider | `aider` |
-| Amazon Q Developer | `q` |
-| Warp | `warp-agent` |
-| Open Interpreter | `interpreter` |
-| Cline | `cline` |
-| Forge | `forge` |
-| Qwen Code | `qwen-coder` |
-
-Each card shows the agent name, binary path, description, protocol (stdio or http),
-and install status. If a version is detected, it is shown on the installed badge.
-
-## Protocol Badges
-
-Each agent is tagged with its communication protocol:
-
-- **stdio** — communicates over standard input/output; the harness spawns the process
-  and reads its stream
-- **http** — communicates over a local HTTP server; the harness connects to a
-  running process
-
-## Add to Comparator
-
-Installed agents can be added to the Comparator from this page. Click
-**Add to Comparator** on any installed agent card to stage it for the next evaluation
-run. The button is disabled for agents that are not installed.
-
-## Install Links
-
-For agents that are not installed, each card shows a **How to install** link that
-opens the agent's official documentation in your browser.
+The Agents page has been retired. It detected installed AI coding agents and
+staged them for [Comparator](/docs/apps/comparator), but the page had become
+unreachable from the sidebar and fed a Comparator form that could not submit,
+so it was removed rather than fixed.


### PR DESCRIPTION
## Summary
The desktop Agents page was removed on main in #377 (UX consolidation Phase 0, commit eb1da37) — it was unreachable from the sidebar and fed a Comparator form that couldn't submit. Two website artefacts had drifted from that change.

- `website/components/architecture-diagram.tsx` — sync `desktopGroups` with the current `NAV_SECTIONS` in `AppLayout.tsx` (Machine, Fleet, Configure, Drift, Comparator, Observatory, Marketplace, plus the Settings sidebar-footer button). Agents dropped from "ALSO REACHABLE", leaving only Security.
- `website/content/docs/apps/agents.md` — replaced the feature doc with a short retired notice pointing to Comparator, rather than deleting the page (keeps the existing URL and nav entry resolving).

## Verification
- Built the website locally (with the generated marketplace/capability-matrix artifacts) and confirmed in-browser: the diagram renders all 9 chips without overflowing the Desktop App box, and the retired Agents page renders with a working link to Comparator.
- Grepped the rest of the docs for stale references to the old page — none found.
- `tsc --noEmit` clean on the diagram file.
- Ran the doc-reviewer skill against both files: 0 errors, 0 warnings, 0 suggestions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)